### PR TITLE
Autofix: Check `main` branch protection rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,22 @@ jobs:
           header: code-coverage
           recreate: true
           path: code-coverage-results.md
+  check-branch-protection:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch protection
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/{owner}/{repo}/branches/{branch}/protection
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          branch: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify branch protection
+        run: |
+          if [ ${{ steps.check-branch-protection.outputs.status }} != 200 ]; then
+            echo "Branch protection rules are not set up correctly for the main branch."
+            exit 1
+          fi
+


### PR DESCRIPTION
Updated the .github/workflows/ci.yml file to include a job that checks for branch protection rules on the main branch. This will help prevent accidental direct pushes to main. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    