### PR TITLE
Allow CI/CD to fail for external PRs without required permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,4 @@ jobs:
           header: code-coverage
           recreate: true
           path: code-coverage-results.md
+        continue-on-error: true

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,7 +40,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html/
       - name: Deploy if PR
-        id: deploy_if_pr
         uses: peaceiris/actions-gh-pages@v4
         if: github.ref != 'refs/heads/main'
         with:
@@ -50,7 +49,7 @@ jobs:
         continue-on-error: true
       - name: Add comment if PR
         uses: marocchino/sticky-pull-request-comment@v2
-        if: steps.deploy_if_pr.conclusion == 'success'
+        if: github.event_name == 'pull_request'
         with:
           header: documentation-preview
           recreate: true
@@ -60,3 +59,4 @@ jobs:
             ✨ https://tqec.github.io/tqec/pull/${{github.event.number}}/ ✨
 
             Changes may take a few minutes to propagate.
+        continue-on-error: true

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,15 +40,17 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html/
       - name: Deploy if PR
+        id: deploy_if_pr
         uses: peaceiris/actions-gh-pages@v4
         if: github.ref != 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html/
           destination_dir: ./pull/${{github.event.number}}/
+        continue-on-error: true
       - name: Add comment if PR
         uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
+        if: steps.deploy_if_pr.conclusion == 'success'
         with:
           header: documentation-preview
           recreate: true


### PR DESCRIPTION
### Overview

There are currently two actions in the CI that require write permission to the repository in order to work correctly: 

- `Add Coverage PR Comment`: Adds code coverage report to PR.
- `Deploy if PR`: Adds documentation generation to PR.

The issue has been reported in #401 .

### Solution

Changing the permissions for external PRs could be a security issue, therefore silent failure was chosen as the preferred method.

This PR adds [ `continue-on-error` ](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) to allow for step failure, and makes the step `Add comment if PR` dependent on success of `Deploy if PR`. 