### PR TITLE
clarified sketch-up os dependency

### DIFF
--- a/docs/user_guide/build_computations.ipynb
+++ b/docs/user_guide/build_computations.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "[SketchUp](https://www.sketchup.com/app) is a 3D modeling tool widely used in QEC community to build the spacetime diagram for logical computations. Its user-friendly interface allows you to easily create and manipulate the computation blocks. \n",
     "\n",
-    "Once you make a Trimble account, you may freely use the web version of SketchUp to import a `.skp` file and create a diagram. However, unless you are on a Windows machine, you must either activate a paid license or free trial to export a SketchUp `.skp` as a COLLADA `.dae` file format. On Windows, it suffices to use the [freeware version SketchUp8](https://google-sketchup.en.lo4d.com/download). \n",
+    "Once you make a Trimble account, you may freely use the web version of SketchUp to import a `.skp` file and create a scene. However, unless you are on a Windows machine, you must either activate a paid license or free trial to export a SketchUp `.skp` as a COLLADA `.dae` file format. On Windows, it suffices to use the [freeware version SketchUp8](https://google-sketchup.en.lo4d.com/download). \n",
     "\n",
     "Users that are not on Windows may fully use `tqec` via the programmatic construction below. Please notify a developer if you are aware of a way to export a SketchUp scene to a `.dae` file on Mac OSX or Linux.\n",
     "\n",

--- a/docs/user_guide/build_computations.ipynb
+++ b/docs/user_guide/build_computations.ipynb
@@ -20,15 +20,18 @@
    "source": [
     "## Use SketchUp\n",
     "\n",
-    "[SketchUp](https://www.sketchup.com/app) is a 3D modeling tool widely used in QEC community to build the spacetime diagram for logical computations. Its user-friendly interface allows you to easily create and manipulate the computation blocks.\n",
+    "[SketchUp](https://www.sketchup.com/app) is a 3D modeling tool widely used in QEC community to build the spacetime diagram for logical computations. Its user-friendly interface allows you to easily create and manipulate the computation blocks. \n",
+    "\n",
+    "Once you make a Trimble account, you may freely use the web version of SketchUp to import a `.skp` file and create a diagram. However, unless you are on a Windows machine, you must either activate a paid license or free trial to export a SketchUp `.skp` as a COLLADA `.dae` file format. On Windows, it suffices to use the [freeware version SketchUp8](https://google-sketchup.en.lo4d.com/download). \n",
+    "\n",
+    "Users that are not on Windows may fully use `tqec` via the programmatic construction below. Please notify a developer if you are aware of a way to export a SketchUp scene to a `.dae` file on Mac OSX or Linux.\n",
     "\n",
     "The workflow using SketchUp to build computations is as follows:\n",
     "\n",
-    "1. Download the [freeware version SketchUp8](https://google-sketchup.en.lo4d.com/download). Unfortunately, it's the only free version that supports exporting to `.dae` file format. \n",
-    "2. Open the [template file](https://github.com/tqec/tqec/blob/main/assets/template.skp) in SketchUp.\n",
-    "3. Use the building blocks provided in the template file to build your computation. After you finish building, remove the template blocks from the scene.\n",
-    "4. Save and export the model to `.dae` file format.\n",
-    "5. Import the computation into `tqec` using the `tqec.read_block_graph_from_dae_file` function."
+    "1. Open the [template file](https://github.com/tqec/tqec/blob/main/assets/template.skp) in SketchUp.\n",
+    "2. Use the building blocks provided in the template file to build your computation. After you finish building, remove the template blocks from the scene.\n",
+    "3. Save and export the model to `.dae` file format.\n",
+    "4. Import the computation into `tqec` using the `tqec.read_block_graph_from_dae_file` function."
    ]
   },
   {

--- a/docs/user_guide/build_computations.ipynb
+++ b/docs/user_guide/build_computations.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "[SketchUp](https://www.sketchup.com/app) is a 3D modeling tool widely used in QEC community to build the spacetime diagram for logical computations. Its user-friendly interface allows you to easily create and manipulate the computation blocks. \n",
     "\n",
-    "Once you make a Trimble account, you may freely use the web version of SketchUp to import a `.skp` file and create a scene. However, unless you are on a Windows machine, you must either activate a paid license or free trial to export a SketchUp `.skp` as a COLLADA `.dae` file format. On Windows, it suffices to use the [freeware version SketchUp8](https://google-sketchup.en.lo4d.com/download). \n",
+    "Once you make a Trimble account, you may freely use the web version of SketchUp to import a `.skp` file and create a scene. However, unless you are on a Windows machine, you must either activate a paid license or free trial to export a SketchUp `.skp` file as a COLLADA `.dae` file. On Windows, it suffices to use the [freeware version SketchUp8](https://google-sketchup.en.lo4d.com/download). \n",
     "\n",
     "Users that are not on Windows may fully use `tqec` via the programmatic construction below. Please notify a developer if you are aware of a way to export a SketchUp scene to a `.dae` file on Mac OSX or Linux.\n",
     "\n",


### PR DESCRIPTION
The documentation should explicitly say that SketchUp usage is OS dependent, to avoid confusing first time users. I clarify this portion of the docs in this short PR. 