### PR TITLE
Ensuring `simulation` and `CompiledGraph` appear in API docs

### DIFF
--- a/src/tqec/__init__.py
+++ b/src/tqec/__init__.py
@@ -4,6 +4,7 @@ from .circuit import ScheduledCircuit as ScheduledCircuit
 from .circuit import ScheduleException as ScheduleException
 from .circuit import generate_circuit as generate_circuit
 from .circuit import merge_scheduled_circuits as merge_scheduled_circuits
+from .compile import CompiledGraph as CompiledGraph
 from .compile import compile_block_graph as compile_block_graph
 from .computation import BlockGraph as BlockGraph
 from .computation import BlockKind as BlockKind

--- a/src/tqec/compile/__init__.py
+++ b/src/tqec/compile/__init__.py
@@ -9,6 +9,7 @@ on available hardware.
 """
 
 from .block import CompiledBlock as CompiledBlock
+from .compile import CompiledGraph as CompiledGraph
 from .compile import compile_block_graph as compile_block_graph
 from .specs import BlockBuilder as BlockBuilder
 from .specs import CubeSpec as CubeSpec

--- a/src/tqec/simulation/__init__.py
+++ b/src/tqec/simulation/__init__.py
@@ -2,8 +2,4 @@
 
 from .plotting import add_inset_axes3d as add_inset_axes3d
 from .plotting import plot_observable_as_inset as plot_observable_as_inset
-from .generation import (
-    generate_stim_circuits_with_detectors as generate_stim_circuits_with_detectors,
-)
-from .generation import generate_sinter_tasks as generate_sinter_tasks
 from .simulation import start_simulation_using_sinter as start_simulation_using_sinter

--- a/src/tqec/simulation/__init__.py
+++ b/src/tqec/simulation/__init__.py
@@ -1,5 +1,4 @@
 """Defines several helper methods to facilitate QEC circuit simulation."""
 
-from .plotting import add_inset_axes3d as add_inset_axes3d
 from .plotting import plot_observable_as_inset as plot_observable_as_inset
 from .simulation import start_simulation_using_sinter as start_simulation_using_sinter

--- a/src/tqec/simulation/__init__.py
+++ b/src/tqec/simulation/__init__.py
@@ -1,4 +1,9 @@
 """Defines several helper methods to facilitate QEC circuit simulation."""
 
+from .plotting import add_inset_axes3d as add_inset_axes3d
 from .plotting import plot_observable_as_inset as plot_observable_as_inset
+from .generation import (
+    generate_stim_circuits_with_detectors as generate_stim_circuits_with_detectors,
+)
+from .generation import generate_sinter_tasks as generate_sinter_tasks
 from .simulation import start_simulation_using_sinter as start_simulation_using_sinter


### PR DESCRIPTION
Small PR to address issue #418. I was exploring #364 and noticed some functions in the `simulation` module were not in the API documentation either, so I update the init file similarly. 