### PR TITLE
Fix duplicate correlation surfaces

### DIFF
--- a/src/tqec/computation/correlation.py
+++ b/src/tqec/computation/correlation.py
@@ -39,7 +39,7 @@ class CorrelationSurface:
     represented as a mapping from the the input/output labels to the logical operator type there.
 
     Attributes:
-        nodes: A set of ``ZXNode`` representing the logical operators appeared in the correlation surface.
+        nodes: A set of ``ZXNode`` representing the logical operators appearing in the correlation surface.
             For example, if either a logical X operator or Z operator has appeared at this node position in
             the span, then the node is of X or Z kind. If both X and Z logical operators have appeared at
             this node position in the span, then the node is of Y kind.
@@ -201,19 +201,24 @@ def _find_correlation_surfaces_from_leaf(
             _find_spans_with_flood_fill(zx_graph, {ZXNode(leaf.position, leaf.kind.with_zx_flipped())}, set()) or []
         )
         return _construct_compatible_correlation_surfaces(zx_graph, spans)
+
     x_spans = (
         _find_spans_with_flood_fill(zx_graph, {ZXNode(leaf.position, ZXKind.X)}, set())
         or []
     )
+
     z_spans = (
         _find_spans_with_flood_fill(zx_graph, {ZXNode(leaf.position, ZXKind.Z)}, set())
         or []
     )
+
     # For the port node, try to construct both the x and z type correlation surfaces.
     if leaf.is_port:
         return _construct_compatible_correlation_surfaces(zx_graph, x_spans + z_spans)
+
     # For the Y type node, the correlation surface must be the product of the x and z type.
     assert leaf.is_y_node
+
     return _construct_compatible_correlation_surfaces(
         zx_graph, [sx | sz for sx, sz in itertools.product(x_spans, z_spans)]
     )
@@ -337,6 +342,7 @@ def _find_spans_with_flood_fill(
         spans = _find_spans_with_flood_fill(zx_graph, product_frontier, product_span)
         if spans is not None:
             final_spans.extend(spans)
+
     return final_spans or None
 
 

--- a/src/tqec/computation/correlation.py
+++ b/src/tqec/computation/correlation.py
@@ -198,7 +198,7 @@ def _find_correlation_surfaces_from_leaf(
     # Z/X type node can only support the correlation surface with the opposite type.
     if leaf.is_zx_node:
         spans = (
-            _find_spans_with_flood_fill(zx_graph, {leaf.with_zx_flipped()}, set()) or []
+            _find_spans_with_flood_fill(zx_graph, {ZXNode(leaf.position, leaf.kind.with_zx_flipped())}, set()) or []
         )
         return _construct_compatible_correlation_surfaces(zx_graph, spans)
     x_spans = (

--- a/src/tqec/computation/correlation.py
+++ b/src/tqec/computation/correlation.py
@@ -4,8 +4,8 @@ the functions to find the correlation surfaces in the ZX graph."""
 from __future__ import annotations
 
 import itertools
+from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Iterable
 
 from tqec.computation.zx_graph import ZXEdge, ZXGraph, ZXKind, ZXNode
 from tqec.exceptions import TQECException

--- a/src/tqec/computation/correlation.py
+++ b/src/tqec/computation/correlation.py
@@ -198,7 +198,10 @@ def _find_correlation_surfaces_from_leaf(
     # Z/X type node can only support the correlation surface with the opposite type.
     if leaf.is_zx_node:
         spans = (
-            _find_spans_with_flood_fill(zx_graph, {ZXNode(leaf.position, leaf.kind.with_zx_flipped())}, set()) or []
+            _find_spans_with_flood_fill(
+                zx_graph, {ZXNode(leaf.position, leaf.kind.with_zx_flipped())}, set()
+            )
+            or []
         )
         return _construct_compatible_correlation_surfaces(zx_graph, spans)
 

--- a/src/tqec/computation/correlation_test.py
+++ b/src/tqec/computation/correlation_test.py
@@ -15,6 +15,7 @@ def test_correlation_single_xz_node() -> None:
     assert surface.external_stabilizer == {}
     assert surface.observables_at_nodes == {Position3D(0, 0, 0): ZXKind.Z}
 
+
 @pytest.mark.parametrize("label_u", [None, "foo"])
 @pytest.mark.parametrize("kind", [ZXKind.X, ZXKind.Z])
 def test_correlation_two_xz_nodes(kind: ZXKind, label_u: str | None) -> None:
@@ -36,6 +37,7 @@ def test_correlation_two_xz_nodes(kind: ZXKind, label_u: str | None) -> None:
             ),
         )
     ]
+
 
 def test_correlation_two_xz_nodes_impossible() -> None:
     g = ZXGraph()


### PR DESCRIPTION
Resolves https://github.com/tqec/tqec/issues/441.

I added a test which is sensitive to this bug. Thereby I also refactored the (test) code a little bit. 

I solved the bug by initializing the frontier with a fresh instantiation of the leaf without the label. This solution fits best with the rest of the code because this is actually done too when adding new nodes to the frontier. It also makes sense in regard of the fact that the span just reuses `ZXNode` in a way where a label has actually no meaning.