### PR TITLE
Allow the option to copy code blocks in the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ extensions = [
     # Include Mermaid diagrams in the documentation
     # https://sphinxcontrib-mermaid-demo.readthedocs.io/en/latest/
     "sphinxcontrib.mermaid",
-    "sphinx_copybutton"
+    "sphinx_copybutton",
     # Adds a copy button to each code block in the documentation
     # https://sphinx-copybutton.readthedocs.io/en/latest/
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,9 @@ extensions = [
     # Include Mermaid diagrams in the documentation
     # https://sphinxcontrib-mermaid-demo.readthedocs.io/en/latest/
     "sphinxcontrib.mermaid",
+    "sphinx_copybutton"
+    # Adds a copy button to each code block in the documentation
+    # https://sphinx-copybutton.readthedocs.io/en/latest/
 ]
 
 templates_path = ["_templates"]

--- a/examples/notebooks/sketchup_model.ipynb
+++ b/examples/notebooks/sketchup_model.ipynb
@@ -1021,7 +1021,7 @@
     "    ax = fig.add_subplot(1, 3, i + 1, projection=\"3d\")\n",
     "    draw_zx_graph_on(zx_graph, ax)\n",
     "    draw_correlation_surface_on(correlation_surfaces[i], ax)\n",
-    "    ax.set_title(f\"Correlation Surface {i+1}\")"
+    "    ax.set_title(f\"Correlation Surface {i + 1}\")"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "tqec[test, doc, bench]",
     "pre-commit",
 ]
-doc = ["sphinx", "myst-parser", "pydata-sphinx-theme", "nbsphinx", "pandoc", "sphinxcontrib-mermaid", "docformatter", "sphinx-autobuild"]
+doc = ["sphinx", "myst-parser", "pydata-sphinx-theme", "nbsphinx", "pandoc", "sphinxcontrib-mermaid", "docformatter", "sphinx-autobuild", "sphinx-copybutton"]
 bench = ["pyinstrument"]
 all = ["tqec[test, dev, doc, bench]"]
 


### PR DESCRIPTION
This PR adds `sphinx_copybutton` as a dependency. Due to this, the code blocks in the documentation can be easily copied (as required).

To see the `copy` option, hover over the top right corner of a code block in the docs.

https://sphinx-copybutton.readthedocs.io/en/latest/