### PR TITLE
fix: close #479

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ Here we generate the circuits for a logical CNOT between two logical qubits to d
 Refer to [quick start](https://tqec.github.io/tqec/user_guide/quick_start.html) in the documentation for more detailed explanation.
 
 ```py
-from tqec import BlockGraph, compile_block_graph
-from tqec.noise_model import NoiseModel
+from tqec import BlockGraph, compile_block_graph, NoiseModel
 
 # 1. Construct the logical computation
 block_graph = BlockGraph.from_dae_file("assets/logical_cnot.dae")

--- a/docs/user_guide/quick_start.rst
+++ b/docs/user_guide/quick_start.rst
@@ -89,7 +89,7 @@ From this compiled computation, the final ``stim.Circuit`` instance can be gener
 
 .. code-block:: python
 
-    from tqec.noise_model import NoiseModel
+    from tqec import NoiseModel
 
     circuit = compiled_computation.generate_stim_circuit(
         k=2,
@@ -125,7 +125,7 @@ The compilation of the block graph is done automatically based on the inputs.
 
     import numpy as np
 
-    from tqec.noise_model import NoiseModel
+    from tqec import NoiseModel
     from tqec.simulation.simulation import start_simulation_using_sinter
 
     # returns a iterator

--- a/src/tqec/compile/specs/base.py
+++ b/src/tqec/compile/specs/base.py
@@ -49,7 +49,7 @@ class CubeSpec:
         pos = cube.position
         spatial_arms = SpatialArms.NONE
         for flag, shift in SpatialArms.get_map_from_arm_to_shift().items():
-            if graph.get_pipe(pos, pos.shift_by(*shift)) is not None:
+            if graph.has_pipe_between(pos, pos.shift_by(*shift)):
                 spatial_arms |= flag
         return CubeSpec(cube.kind, spatial_arms)
 


### PR DESCRIPTION
1. Fix https://github.com/tqec/tqec/issues/479

As suggested by @inmzhang, move rotation structure includes spatial cube and is not supported by the compilation yet.

Now when trying compile `move_rotation`, the output is 

```
Traceback (most recent call last):
  File "/home/zhaoyilun/workspace/github/quantum-computing-resources/learning/qec/tqec_learn/test_move_rotation.py", line 8, in <module>
    compiled_computation = compile_block_graph(block_graph, observables="auto")
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zhaoyilun/workspace/github/forks/tqec/src/tqec/compile/compile.py", line 350, in compile_block_graph
    blocks[cube.position] = block_builder(spec)
                            ^^^^^^^^^^^^^^^^^^^
  File "/home/zhaoyilun/workspace/github/forks/tqec/src/tqec/compile/specs/library/_utils.py", line 29, in default_compiled_block_builder
    raise NotImplementedError("Irregular cubes are not implemented yet.")
NotImplementedError: Irregular cubes are not implemented yet.
```

2. Now `NoiseModel` could be imported directly from `tqec`. The legacy README example raises module not found error