### PR TITLE
Implement `rotate` method on block graph

### DIFF
--- a/src/tqec/computation/block_graph_test.py
+++ b/src/tqec/computation/block_graph_test.py
@@ -3,6 +3,7 @@ import pytest
 from tqec.computation.block_graph import BlockGraph
 from tqec.computation.cube import ZXCube
 from tqec.computation.pipe import PipeKind
+from tqec.utils.enums import Basis
 from tqec.utils.exceptions import TQECException
 from tqec.utils.position import Direction3D, Position3D
 
@@ -206,3 +207,17 @@ def test_graph_rotation() -> None:
     rg = g.rotate(Direction3D.Z)
     assert Position3D(-1, 0, 0) in rg
     assert str(rg.cubes[0].kind) == "Y"
+
+
+@pytest.mark.parametrize("obs_basis", [Basis.Z, Basis.X, None])
+def test_cnot_graph_rotation(obs_basis: Basis | None) -> None:
+    from tqec.interop.collada.read_write_test import rotated_cnot
+    from tqec.gallery.cnot import cnot
+
+    g = cnot(obs_basis)
+    rg = g.rotate(Direction3D.X, False)
+
+    rg_from_scratch = rotated_cnot(obs_basis)
+
+    # We need to shift the rotated graph in Z direction to match the two
+    assert rg.shift_by(dz=2) == rg_from_scratch

--- a/src/tqec/computation/block_graph_test.py
+++ b/src/tqec/computation/block_graph_test.py
@@ -198,3 +198,11 @@ def test_graph_rotation() -> None:
     assert str(rg[Position3D(-1, 1, 0)].kind) == "XZZ"
     assert str(rg.pipes[0].kind) == "XOZ"
     assert rg.rotate(Direction3D.Z, num_90_degree_rotation=3) == g
+
+    g = BlockGraph()
+    g.add_cube(Position3D(0, 0, 0), "Y")
+    with pytest.raises(TQECException):
+        g.rotate(Direction3D.X)
+    rg = g.rotate(Direction3D.Z)
+    assert Position3D(-1, 0, 0) in rg
+    assert str(rg.cubes[0].kind) == "Y"

--- a/src/tqec/computation/block_graph_test.py
+++ b/src/tqec/computation/block_graph_test.py
@@ -4,7 +4,7 @@ from tqec.computation.block_graph import BlockGraph
 from tqec.computation.cube import ZXCube
 from tqec.computation.pipe import PipeKind
 from tqec.utils.exceptions import TQECException
-from tqec.utils.position import Position3D
+from tqec.utils.position import Direction3D, Position3D
 
 
 def test_block_graph_construction() -> None:
@@ -186,3 +186,15 @@ def test_single_connected() -> None:
 
     g.add_pipe(n1, n2)
     assert g.is_single_connected()
+
+
+def test_graph_rotation() -> None:
+    g = BlockGraph()
+    n1 = g.add_cube(Position3D(0, 0, 0), "ZXZ")
+    n2 = g.add_cube(Position3D(1, 0, 0), "ZXZ")
+    g.add_pipe(n1, n2)
+    rg = g.rotate(Direction3D.Z)
+    assert str(rg[Position3D(-1, 0, 0)].kind) == "XZZ"
+    assert str(rg[Position3D(-1, 1, 0)].kind) == "XZZ"
+    assert str(rg.pipes[0].kind) == "XOZ"
+    assert rg.rotate(Direction3D.Z, num_90_degree_rotation=3) == g

--- a/src/tqec/gallery/cz.py
+++ b/src/tqec/gallery/cz.py
@@ -13,7 +13,7 @@ def cz(support_flows: str | list[str] | None = None) -> BlockGraph:
 
     By default, the Hadamard edge in the CZ gate will be horizontal. If you
     want to use vertical Hadamard edges, you can rotate the graph by 90 degrees
-    by calling `~tqec.computation.block_graph.BlockGraph.rotate`.
+    by calling :py:meth:`~tqec.computation.block_graph.BlockGraph.rotate`.
 
     Args:
         support_flows: The stabilizer flow supported by the logical CZ gate. It

--- a/src/tqec/interop/collada/read_write_test.py
+++ b/src/tqec/interop/collada/read_write_test.py
@@ -28,16 +28,16 @@ def rotated_cnot(observable_basis: Basis | None = None) -> BlockGraph:
     g = BlockGraph()
 
     nodes = [
-        (Position3D(0, 0, 1), "ZZX", ""),
+        (Position3D(0, 0, 1), "P", "In_Control"),
         (Position3D(0, 1, 1), "ZXX", ""),
         (Position3D(0, 2, 1), "ZZX", ""),
-        (Position3D(0, 3, 1), "ZZX", ""),
+        (Position3D(0, 3, 1), "P", "Out_Control"),
         (Position3D(0, 1, 0), "ZXX", ""),
         (Position3D(0, 2, 0), "ZZX", ""),
-        (Position3D(1, 0, 0), "ZZX", ""),
+        (Position3D(1, 0, 0), "P", "In_Target"),
         (Position3D(1, 1, 0), "ZZX", ""),
         (Position3D(1, 2, 0), "ZZX", ""),
-        (Position3D(1, 3, 0), "ZZX", ""),
+        (Position3D(1, 3, 0), "P", "Out_Target"),
     ]
 
     for pos, kind, label in nodes:
@@ -49,7 +49,7 @@ def rotated_cnot(observable_basis: Basis | None = None) -> BlockGraph:
         g.add_pipe(nodes[p0][0], nodes[p1][0])
 
     if observable_basis == Basis.Z:
-        g.fill_ports(ZXCube.from_str("ZXZ"))
+        g.fill_ports(ZXCube.from_str("ZZX"))
     elif observable_basis == Basis.X:
         g.fill_ports(ZXCube.from_str("ZXX"))
     return g
@@ -72,25 +72,12 @@ def test_logical_cnot_collada_write_read(pipe_length: float) -> None:
 
 @pytest.mark.parametrize("pipe_length", [0.5, 1.0, 2.0, 10.0])
 def test_rotated_cnot_collada_write_read(pipe_length: float) -> None:
-    block_graph = rotated_cnot(Basis.X)
-    cubes_in_blockgraph = [cube for cube in block_graph.cubes]
-    pipes_in_blockgraph = [
-        (pipe.u.position, pipe.v.position, pipe.kind) for pipe in block_graph.pipes
-    ]
+    block_graph = rotated_cnot(Basis.Z)
 
     ROTATED_CNOT_DAE = Path(__file__).parent / "test_files/rotated_cnot.dae"
     block_graph_from_file = BlockGraph.from_dae_file(ROTATED_CNOT_DAE)
 
-    cubes_from_dae = [cube for cube in block_graph_from_file.cubes]
-    pipes_from_dae = [
-        (pipe.u.position, pipe.v.position, pipe.kind)
-        for pipe in block_graph_from_file.pipes
-    ]
-
-    match_cubes = [(cube in cubes_in_blockgraph) for cube in cubes_from_dae]
-    match_pipes = [(pipe in pipes_in_blockgraph) for pipe in pipes_from_dae]
-
-    assert all([match_cubes, match_pipes])
+    assert block_graph_from_file == block_graph
 
 
 @pytest.mark.parametrize("pipe_length", [0.5, 1.0, 2.0, 10.0])

--- a/src/tqec/utils/rotations.py
+++ b/src/tqec/utils/rotations.py
@@ -42,11 +42,13 @@ from tqec.utils.position import Direction3D, Position3D
 from tqec.utils.scale import round_or_fail
 
 
-def calc_rotation_angles(M: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:
+def calc_rotation_angles(
+    rotation_matrix: npt.NDArray[np.float32],
+) -> npt.NDArray[np.float32]:
     """Calculates the rotation angles of the three row vectors of matrix (M) from the original X/Y/Z axis (given by an identity matrix)).
 
     Args:
-        M: rotation matrix for node, extracted from `.dae` file.
+        rotation_matrix: rotation matrix for node, extracted from `.dae` file.
 
     Returns:
         rotations: the rotation angle for each of the three vectors in M (see notes: !)
@@ -62,7 +64,7 @@ def calc_rotation_angles(M: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:
     # ! I think that, technically, this should be done per column (aka column-major)
     # ! but this function is only to confirm rotation validity rather than to transform objects
     # ! per row (aka. row-major) is fine for this
-    for i, row in enumerate(M):
+    for i, row in enumerate(rotation_matrix):
         cos_theta = np.dot(ID[i], row) / (np.linalg.norm(ID[i]) * np.linalg.norm(row))
         angle_rad = np.arccos(np.clip(cos_theta, -1.0, 1.0))
         angle_deg = np.degrees(angle_rad)
@@ -75,7 +77,7 @@ def get_axes_directions(rotation_matrix: npt.NDArray[np.float32]) -> dict[str, i
     """Gets up/down multipliers for each row of a rotation matrix.
 
     Args:
-        rotate_matrix: rotation matrix for node.
+        rotation_matrix: rotation matrix for node.
 
     Returns:
         axes_directions: up/down multipliers for each axis
@@ -99,7 +101,7 @@ def rotate_block_kind_by_matrix(
         - rotate_matrix is rotated: block_kind rotated accordingly
 
     Args:
-        rotate_matrix: rotation matrix for node.
+        rotation_matrix: rotation matrix for node.
         block_kind: original kind.
 
     Returns:
@@ -181,7 +183,7 @@ def rotate_position_by_matrix(
 
     Args:
         position: cube position to rotate.
-        rotate_matrix: rotation matrix.
+        rotation_matrix: rotation matrix.
 
     Returns:
         The rotated position.

--- a/src/tqec/utils/rotations.py
+++ b/src/tqec/utils/rotations.py
@@ -105,6 +105,8 @@ def rotate_block_kind_by_matrix(
     Returns:
         rotated_kind: rotated kind for the node.
     """
+    if str(block_kind) == "PORT":
+        return block_kind
 
     # Placeholder for results
     rotated_name = ""
@@ -116,7 +118,6 @@ def rotate_block_kind_by_matrix(
 
     # Loop:
     # - applies transformation encoded in rotate_matrix to vectorised kind
-    # - builds dict with plus/minus direction for each axis
     for _, row in enumerate(rotation_matrix):
         entry = ""
         for j, element in enumerate(row):
@@ -131,7 +132,8 @@ def rotate_block_kind_by_matrix(
         not rotated_name.endswith("!") or axes_directions["Z"] < 0
     ):
         raise TQECException(
-            f"There is an invalid rotation for {rotated_name.replace('!', '').replace('-', '')} block."
+            f"There is an invalid rotation for {rotated_name.replace('!', '').replace('-', '')} block.",
+            "Cultivation and Y blocks should only allow rotation around Z axis.",
         )
     # Clean kind names for special names
     # State cultivation


### PR DESCRIPTION
With #468, we can now import a `.dae` file with rotation transformations as a `BlockGraph`. This PR introduces direct rotation functionality to the `BlockGraph` data structure, allowing us to rotate by multiples of 90 degrees using `block_graph.rotate`. 