### PR TITLE
Implement Plaquette for spatial junctions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,9 @@ uv.lock
 
 # tqec specific
 benchmarks/data/
+
+# vim
+*.swp
+
+# temporary files
+temp/

--- a/src/tqec/compile/specs/library/generators/spatial.py
+++ b/src/tqec/compile/specs/library/generators/spatial.py
@@ -17,15 +17,22 @@ The spatial pipes connected to the spatial cubes are called **arms**.
 
 from typing import Final
 
+
+from tqec.utils.enums import Basis
+
+
+from tqec.circuit.qubit import GridQubit
 from tqec.compile.specs.enums import SpatialArms
 from tqec.compile.specs.library.generators.utils import default_plaquette_mapper
+from tqec.plaquette.plaquette import Plaquettes
+from tqec.plaquette.library import empty_plaquette
+from tqec.plaquette.qubit import PlaquetteQubits
 from tqec.plaquette.rpng import RPNGDescription
 from tqec.templates.qubit import (
     QubitHorizontalBorders,
     QubitSpatialCubeTemplate,
     QubitVerticalBorders,
 )
-from tqec.utils.enums import Basis
 from tqec.utils.exceptions import TQECException
 from tqec.utils.frozendefaultdict import FrozenDefaultDict
 
@@ -492,6 +499,25 @@ def _get_down_spatial_cube_arm_rpng_descriptions(
 get_spatial_cube_qubit_plaquettes: Final = default_plaquette_mapper(
     get_spatial_cube_qubit_rpng_descriptions
 )
-get_spatial_cube_arm_plaquettes: Final = default_plaquette_mapper(
-    get_spatial_cube_arm_rpng_descriptions
-)
+# get_spatial_cube_arm_plaquettes: Final = default_plaquette_mapper(
+#     get_spatial_cube_arm_rpng_descriptions
+# )
+
+
+def get_spatial_cube_arm_plaquettes(
+    spatial_boundary_basis: Basis,
+    arms: SpatialArms,
+    reset: Basis | None = None,
+    measurement: Basis | None = None,
+) -> Plaquettes:
+    ep = empty_plaquette(
+        PlaquetteQubits(
+            data_qubits=[GridQubit(0, 0)], syndrome_qubits=[GridQubit(0, 0)]
+        )
+    )
+    collection = FrozenDefaultDict(
+        {
+            0: ep,
+        }
+    )
+    return Plaquettes(collection)

--- a/src/tqec/compile/specs/library/generators/spatial.py
+++ b/src/tqec/compile/specs/library/generators/spatial.py
@@ -499,9 +499,22 @@ def _get_down_spatial_cube_arm_rpng_descriptions(
 get_spatial_cube_qubit_plaquettes: Final = default_plaquette_mapper(
     get_spatial_cube_qubit_rpng_descriptions
 )
-# get_spatial_cube_arm_plaquettes: Final = default_plaquette_mapper(
-#     get_spatial_cube_arm_rpng_descriptions
-# )
+
+
+def _get_up_spatial_cube_arm_plaquettes():
+    pass
+
+
+def _get_down_spatial_cube_arm_plaquettes():
+    pass
+
+
+def _get_left_spatial_cube_arm_plaquettes():
+    pass
+
+
+def _get_right_spatial_cube_arm_plaquettes():
+    pass
 
 
 def get_spatial_cube_arm_plaquettes(

--- a/src/tqec/plaquette/library/spatial.py
+++ b/src/tqec/plaquette/library/spatial.py
@@ -1,4 +1,4 @@
-"""Define the standard CSS-type surface code plaquettes."""
+"""Define the plaquettes for implementing arms for spatial cubes."""
 
 from __future__ import annotations
 
@@ -18,14 +18,32 @@ from tqec.utils.enums import Basis
 def make_spatial_cube_arm_plaquette(
     basis: Basis,
     plaquette_kind: Literal["UP", "DOWN"],
+    reset: Basis | None = None,
+    measurement: Basis | None = None,
     is_reverse: bool = False,
     is_corner_trimmed: bool = False,
 ) -> Plaquette:
     """Make a plaquette for spatial cube arms.
 
+    The below text represents the qubits in a stretched stabilizer ::
+
+        a ----- b
+        |       |
+        |   c   |
+        |       |
+        d ------
+        |       |
+        |   e   |
+        |       |
+        f ----- g
+
+    This is split into two plaquettes, with "UP" being (a, b, c, d) and "DOWN" being (d, e, f, g).
+
     Args:
         basis: the basis of the plaquette.
         plaquette_kind: the kind of the plaquette.
+        reset: the logical basis for data initialization.
+        measurement: the logical basis for data measurement.
         is_reverse: whether the plaquette has controlled-A reversed.
         is_corner_trimmed: whether the plaquette has corner trimmed, for "UP" plaquette
             the left top corner is trimmed, for "DOWN" plaquette the right bottom corner is trimmed.
@@ -33,8 +51,20 @@ def make_spatial_cube_arm_plaquette(
     Returns:
         A plaquette for spatial cube arms.
 
-    References:
-        - Surface code quantum computation by Fowler et al. Fig. 13.
+    Notes:
+        This method could generate 8 different plaquettes.
+        UP-plaquettes:
+        1. Qubits (a, b, c, d)
+        2. Qubits (a, b, c, d) with controlled-A gates reversed
+        DOWN-plaquettes:
+        3. Qubits (d, e, f, g)
+        4. Qubits (d, e, f, g) with controlled-A gates reversed
+        Trimmed UP-plaquettes:
+        5. Qubits (b, c, d)
+        6. Qubits (b, c, d) with controlled-A gates reversed
+        Trimmed DOWN-plaquettes:
+        7. Qubits (d, e, f)
+        8. Qubits (d, e, f) with controlled-A gates reversed
     """
     builder = _SpatialCubeArmPlaquetteBuilder(
         basis,
@@ -42,6 +72,10 @@ def make_spatial_cube_arm_plaquette(
         is_reverse=is_reverse,
         is_corner_trimmed=is_corner_trimmed,
     )
+    if reset is not None:
+        builder.add_data_init_or_meas(reset, False)
+    if measurement is not None:
+        builder.add_data_init_or_meas(measurement, True)
     return builder.build()
 
 
@@ -57,7 +91,7 @@ class _SpatialCubeArmPlaquetteBuilder:
         is_corner_trimmed: bool = False,
     ) -> None:
         self._basis = basis
-        self._plaquette_kind = plaquette_kind
+        self._plaquette_kind: Literal["UP", "DOWN"] = plaquette_kind
         self._is_reverse = is_reverse
         self._is_corner_trimmed = is_corner_trimmed
         self._trimmed_qubit: int | None = None
@@ -76,6 +110,16 @@ class _SpatialCubeArmPlaquetteBuilder:
             | {i + 1: q for i, q in enumerate(self._qubits.data_qubits)}
         )
 
+        self._data_init: Basis | None = None
+        self._data_meas: Basis | None = None
+
+    def _get_data_qubits_for_init_or_meas(self) -> list[int]:
+        match self._plaquette_kind:
+            case "UP":
+                return [2] if self._is_corner_trimmed else [1, 2]
+            case "DOWN":
+                return [3] if self._is_corner_trimmed else [3, 4]
+
     def _get_plaquette_name(self) -> str:
         parts = [
             _SpatialCubeArmPlaquetteBuilder.BASE_NAME,
@@ -86,6 +130,10 @@ class _SpatialCubeArmPlaquetteBuilder:
             parts.append("REVERSE")
         if self._is_corner_trimmed:
             parts.append("CORNER_TRIMMED")
+        if self._data_init is not None:
+            parts.append(f"datainit({self._data_init.name})")
+        if self._data_meas is not None:
+            parts.append(f"datameas({self._data_meas.name})")
         return "_".join(parts)
 
     def build(self) -> Plaquette:
@@ -136,3 +184,15 @@ class _SpatialCubeArmPlaquetteBuilder:
         circuit.append("TICK")
         circuit.append("MX", [0], [])
         return list(iter_stim_circuit_without_repeat_by_moments(circuit))
+
+    def add_data_init_or_meas(self, basis: Basis, is_measurement: bool) -> None:
+        if is_measurement:
+            moment_index = -1
+            self._data_meas = basis
+        else:
+            moment_index = 0
+            self._data_init = basis
+        op = "M" if is_measurement else "R"
+        self._moments[moment_index].append(
+            f"{op}{basis.value}", self._get_data_qubits_for_init_or_meas(), []
+        )

--- a/src/tqec/plaquette/library/spatial.py
+++ b/src/tqec/plaquette/library/spatial.py
@@ -11,7 +11,7 @@ from tqec.circuit.moment import Moment, iter_stim_circuit_without_repeat_by_mome
 from tqec.circuit.qubit_map import QubitMap
 from tqec.circuit.schedule.circuit import ScheduledCircuit
 from tqec.plaquette.plaquette import Plaquette
-from tqec.plaquette.qubit import DownTrianglePlaquetteQubits, UpTrianglePlaquetteQubits
+from tqec.plaquette.qubit import SquarePlaquetteQubits
 from tqec.utils.enums import Basis
 
 
@@ -50,12 +50,11 @@ class _SpatialCubeArmPlaquetteBuilder:
         self._plaquette_kind = plaquette_kind
         self._is_reverse = is_reverse
 
+        self._qubits = SquarePlaquetteQubits()
         match self._plaquette_kind:
             case "UP":
-                self._qubits = UpTrianglePlaquetteQubits()
                 self._moments = self._build_memory_moments_up()
             case "DOWN":
-                self._qubits = DownTrianglePlaquetteQubits()
                 self._moments = self._build_memory_moments_down()
 
         self._qubit_map = QubitMap(
@@ -105,7 +104,7 @@ class _SpatialCubeArmPlaquetteBuilder:
         circuit.append("TICK")
         circuit.append("CX", [1, 0], [])
         circuit.append("TICK")
-        targ_order = [3, 2] if self._is_reverse else [2, 3]
+        targ_order = [4, 3] if self._is_reverse else [3, 4]
         circuit.append(f"C{self._basis.name}", [0, targ_order[0]], [])
         circuit.append("TICK")
         circuit.append("TICK")

--- a/src/tqec/plaquette/library/spatial.py
+++ b/src/tqec/plaquette/library/spatial.py
@@ -1,0 +1,110 @@
+"""Define the standard CSS-type surface code plaquettes."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import stim
+
+
+from tqec.circuit.moment import Moment, iter_stim_circuit_without_repeat_by_moments
+from tqec.circuit.qubit_map import QubitMap
+from tqec.circuit.schedule.circuit import ScheduledCircuit
+from tqec.plaquette.plaquette import Plaquette
+from tqec.plaquette.qubit import DownTrianglePlaquetteQubits, UpTrianglePlaquetteQubits
+from tqec.utils.enums import Basis
+
+
+def make_spatial_cube_arm_plaquette(
+    basis: Basis,
+    plaquette_kind: Literal["UP", "DOWN"],
+    is_reverse: bool = False,
+) -> Plaquette:
+    """Make a plaquette for spatial cube arms.
+
+    Args:
+        basis: the basis of the plaquette.
+        plaquette_kind: the kind of the plaquette.
+        is_reverse: whether the plaquette has controlled-A reversed.
+
+    Returns:
+        A plaquette for spatial cube arms.
+    """
+    builder = _SpatialCubeArmPlaquetteBuilder(
+        basis, plaquette_kind, is_reverse=is_reverse
+    )
+    return builder.build()
+
+
+class _SpatialCubeArmPlaquetteBuilder:
+    MERGEABLE_INSTRUCTIONS = frozenset(("M", "MZ", "MX", "R", "RZ", "RX"))
+    BASE_NAME = "SPATIAL_CUBE_ARM"
+
+    def __init__(
+        self,
+        basis: Basis,
+        plaquette_kind: Literal["UP", "DOWN"],
+        is_reverse: bool = False,
+    ) -> None:
+        self._basis = basis
+        self._plaquette_kind = plaquette_kind
+
+        match self._plaquette_kind:
+            case "UP":
+                self._qubits = UpTrianglePlaquetteQubits()
+                self._moments = self._build_memory_moments_up(is_reverse=is_reverse)
+            case "DOWN":
+                self._qubits = DownTrianglePlaquetteQubits()
+                self._moments = self._build_memory_moments_down(is_reverse=is_reverse)
+
+        self._qubit_map = QubitMap(
+            {0: self._qubits.syndrome_qubits[0]}
+            | {i + 1: q for i, q in enumerate(self._qubits.data_qubits)}
+        )
+
+    def _get_plaquette_name(self) -> str:
+        parts = [
+            _SpatialCubeArmPlaquetteBuilder.BASE_NAME,
+            self._basis.name,
+            self._plaquette_kind,
+        ]
+        return "_".join(parts)
+
+    def build(self) -> Plaquette:
+        return Plaquette(
+            self._get_plaquette_name(),
+            self._qubits,
+            ScheduledCircuit(self._moments, schedule=0, qubit_map=self._qubit_map),
+            mergeable_instructions=self.MERGEABLE_INSTRUCTIONS,
+        )
+
+    def _build_memory_moments_up(self, is_reverse: bool = False) -> list[Moment]:
+        circuit = stim.Circuit()
+        circuit.append("RX", [0], [])
+        circuit.append("RZ", [3], [])
+        circuit.append("TICK")
+        circuit.append("CX", [0, 3], [])
+        circuit.append("TICK")
+        targ_order = [2, 1] if is_reverse else [1, 2]
+        for dq in targ_order:
+            circuit.append(f"C{self._basis.name}", [0, dq], [])
+            circuit.append("TICK")
+        circuit.append("CX", [3, 0], [])
+        return list(iter_stim_circuit_without_repeat_by_moments(circuit))
+
+    def _build_memory_moments_down(self, is_reverse: bool = False) -> list[Moment]:
+        circuit = stim.Circuit()
+        circuit.append("RZ", [1], [])
+        circuit.append("TICK")
+        circuit.append("RZ", [0], [])
+        circuit.append("TICK")
+        circuit.append("CX", [1, 0], [])
+        circuit.append("TICK")
+        targ_order = [3, 2] if is_reverse else [2, 3]
+        for dq in targ_order:
+            circuit.append(f"C{self._basis.name}", [0, dq], [])
+            circuit.append("TICK")
+        circuit.append("CX", [0, 1], [])
+        circuit.append("TICK")
+        circuit.append("MX", [0], [])
+        return list(iter_stim_circuit_without_repeat_by_moments(circuit))

--- a/src/tqec/plaquette/library/spatial_test.py
+++ b/src/tqec/plaquette/library/spatial_test.py
@@ -2,15 +2,12 @@ import stim
 
 from tqec.utils.enums import Basis
 from tqec.plaquette.library.spatial import make_spatial_cube_arm_plaquette
-from tqec.plaquette.qubit import (
-    UpTrianglePlaquetteQubits,
-    DownTrianglePlaquetteQubits,
-)
+from tqec.plaquette.qubit import SquarePlaquetteQubits
 
 
 def test_spatial_cube_arm_plaquette() -> None:
     plaquette = make_spatial_cube_arm_plaquette(Basis.X, "UP", is_reverse=False)
-    assert plaquette.qubits == UpTrianglePlaquetteQubits()
+    assert plaquette.qubits == SquarePlaquetteQubits()
     assert plaquette.name == "SPATIAL_CUBE_ARM_X_UP"
     circuit = plaquette.circuit.get_circuit()
     assert circuit == stim.Circuit(
@@ -19,6 +16,7 @@ QUBIT_COORDS(0, 0) 0
 QUBIT_COORDS(-1, -1) 1
 QUBIT_COORDS(1, -1) 2
 QUBIT_COORDS(-1, 1) 3
+QUBIT_COORDS(1, 1) 4
 RX 0
 RZ 3
 TICK
@@ -33,7 +31,7 @@ CX 3 0
 """
     )
     plaquette = make_spatial_cube_arm_plaquette(Basis.X, "UP", is_reverse=True)
-    assert plaquette.qubits == UpTrianglePlaquetteQubits()
+    assert plaquette.qubits == SquarePlaquetteQubits()
     assert plaquette.name == "SPATIAL_CUBE_ARM_X_UP_REVERSE"
     circuit = plaquette.circuit.get_circuit()
     assert circuit == stim.Circuit(
@@ -42,6 +40,7 @@ QUBIT_COORDS(0, 0) 0
 QUBIT_COORDS(-1, -1) 1
 QUBIT_COORDS(1, -1) 2
 QUBIT_COORDS(-1, 1) 3
+QUBIT_COORDS(1, 1) 4
 RX 0
 RZ 3
 TICK
@@ -56,25 +55,26 @@ CX 3 0
 """
     )
     plaquette = make_spatial_cube_arm_plaquette(Basis.X, "DOWN", is_reverse=False)
-    assert plaquette.qubits == DownTrianglePlaquetteQubits()
+    assert plaquette.qubits == SquarePlaquetteQubits()
     assert plaquette.name == "SPATIAL_CUBE_ARM_X_DOWN"
     circuit = plaquette.circuit.get_circuit()
     assert circuit == stim.Circuit(
         """
 QUBIT_COORDS(0, 0) 0
 QUBIT_COORDS(-1, -1) 1
-QUBIT_COORDS(-1, 1) 2
-QUBIT_COORDS(1, 1) 3
+QUBIT_COORDS(1, -1) 2
+QUBIT_COORDS(-1, 1) 3
+QUBIT_COORDS(1, 1) 4
 RZ 1
 TICK
 RZ 0
 TICK
 CX 1 0
 TICK
-CX 0 2
-TICK
-TICK
 CX 0 3
+TICK
+TICK
+CX 0 4
 TICK
 CX 0 1
 TICK
@@ -82,25 +82,26 @@ MX 0
 """
     )
     plaquette = make_spatial_cube_arm_plaquette(Basis.X, "DOWN", is_reverse=True)
-    assert plaquette.qubits == DownTrianglePlaquetteQubits()
+    assert plaquette.qubits == SquarePlaquetteQubits()
     assert plaquette.name == "SPATIAL_CUBE_ARM_X_DOWN_REVERSE"
     circuit = plaquette.circuit.get_circuit()
     assert circuit == stim.Circuit(
         """
 QUBIT_COORDS(0, 0) 0
 QUBIT_COORDS(-1, -1) 1
-QUBIT_COORDS(-1, 1) 2
-QUBIT_COORDS(1, 1) 3
+QUBIT_COORDS(1, -1) 2
+QUBIT_COORDS(-1, 1) 3
+QUBIT_COORDS(1, 1) 4
 RZ 1
 TICK
 RZ 0
 TICK
 CX 1 0
 TICK
+CX 0 4
+TICK
+TICK
 CX 0 3
-TICK
-TICK
-CX 0 2
 TICK
 CX 0 1
 TICK
@@ -108,7 +109,7 @@ MX 0
 """
     )
     plaquette = make_spatial_cube_arm_plaquette(Basis.Z, "UP", is_reverse=False)
-    assert plaquette.qubits == UpTrianglePlaquetteQubits()
+    assert plaquette.qubits == SquarePlaquetteQubits()
     assert plaquette.name == "SPATIAL_CUBE_ARM_Z_UP"
     circuit = plaquette.circuit.get_circuit()
     assert circuit == stim.Circuit(
@@ -117,6 +118,7 @@ QUBIT_COORDS(0, 0) 0
 QUBIT_COORDS(-1, -1) 1
 QUBIT_COORDS(1, -1) 2
 QUBIT_COORDS(-1, 1) 3
+QUBIT_COORDS(1, 1) 4
 RX 0
 RZ 3
 TICK
@@ -131,7 +133,7 @@ CX 3 0
 """
     )
     plaquette = make_spatial_cube_arm_plaquette(Basis.Z, "UP", is_reverse=True)
-    assert plaquette.qubits == UpTrianglePlaquetteQubits()
+    assert plaquette.qubits == SquarePlaquetteQubits()
     assert plaquette.name == "SPATIAL_CUBE_ARM_Z_UP_REVERSE"
     circuit = plaquette.circuit.get_circuit()
     assert circuit == stim.Circuit(
@@ -140,6 +142,7 @@ QUBIT_COORDS(0, 0) 0
 QUBIT_COORDS(-1, -1) 1
 QUBIT_COORDS(1, -1) 2
 QUBIT_COORDS(-1, 1) 3
+QUBIT_COORDS(1, 1) 4
 RX 0
 RZ 3
 TICK
@@ -154,25 +157,26 @@ CX 3 0
 """
     )
     plaquette = make_spatial_cube_arm_plaquette(Basis.Z, "DOWN", is_reverse=False)
-    assert plaquette.qubits == DownTrianglePlaquetteQubits()
+    assert plaquette.qubits == SquarePlaquetteQubits()
     assert plaquette.name == "SPATIAL_CUBE_ARM_Z_DOWN"
     circuit = plaquette.circuit.get_circuit()
     assert circuit == stim.Circuit(
         """
 QUBIT_COORDS(0, 0) 0
 QUBIT_COORDS(-1, -1) 1
-QUBIT_COORDS(-1, 1) 2
-QUBIT_COORDS(1, 1) 3
+QUBIT_COORDS(1, -1) 2
+QUBIT_COORDS(-1, 1) 3
+QUBIT_COORDS(1, 1) 4
 RZ 1
 TICK
 RZ 0
 TICK
 CX 1 0
 TICK
-CZ 0 2
-TICK
-TICK
 CZ 0 3
+TICK
+TICK
+CZ 0 4
 TICK
 CX 0 1
 TICK
@@ -180,25 +184,26 @@ MX 0
 """
     )
     plaquette = make_spatial_cube_arm_plaquette(Basis.Z, "DOWN", is_reverse=True)
-    assert plaquette.qubits == DownTrianglePlaquetteQubits()
+    assert plaquette.qubits == SquarePlaquetteQubits()
     assert plaquette.name == "SPATIAL_CUBE_ARM_Z_DOWN_REVERSE"
     circuit = plaquette.circuit.get_circuit()
     assert circuit == stim.Circuit(
         """
 QUBIT_COORDS(0, 0) 0
 QUBIT_COORDS(-1, -1) 1
-QUBIT_COORDS(-1, 1) 2
-QUBIT_COORDS(1, 1) 3
+QUBIT_COORDS(1, -1) 2
+QUBIT_COORDS(-1, 1) 3
+QUBIT_COORDS(1, 1) 4
 RZ 1
 TICK
 RZ 0
 TICK
 CX 1 0
 TICK
+CZ 0 4
+TICK
+TICK
 CZ 0 3
-TICK
-TICK
-CZ 0 2
 TICK
 CX 0 1
 TICK

--- a/src/tqec/plaquette/library/spatial_test.py
+++ b/src/tqec/plaquette/library/spatial_test.py
@@ -1,0 +1,7 @@
+from tqec.plaquette.library.spatial import _SpatialCubeArmPlaquetteBuilder
+from tqec.utils.enums import Basis
+
+
+def test_make_spatial_cube_arm_plaquette():
+    builder = _SpatialCubeArmPlaquetteBuilder(Basis.Z, "UP")
+    assert builder._get_plaquette_name() == "SPATIAL_CUBE_ARM_Z_UP"

--- a/src/tqec/plaquette/library/spatial_test.py
+++ b/src/tqec/plaquette/library/spatial_test.py
@@ -210,3 +210,29 @@ TICK
 MX 0
 """
     )
+    plaquette = make_spatial_cube_arm_plaquette(
+        Basis.X, "UP", is_reverse=False, is_corner_trimmed=True
+    )
+    assert plaquette.qubits == SquarePlaquetteQubits()
+    assert plaquette.name == "SPATIAL_CUBE_ARM_X_UP_CORNER_TRIMMED"
+    circuit = plaquette.circuit.get_circuit()
+    assert circuit == stim.Circuit(
+        """
+QUBIT_COORDS(0, 0) 0
+QUBIT_COORDS(-1, -1) 1
+QUBIT_COORDS(1, -1) 2
+QUBIT_COORDS(-1, 1) 3
+QUBIT_COORDS(1, 1) 4
+RX 0
+RZ 3
+TICK
+CX 0 3
+TICK
+TICK
+TICK
+TICK
+CX 0 2
+TICK
+CX 3 0
+"""
+    )

--- a/src/tqec/plaquette/library/spatial_test.py
+++ b/src/tqec/plaquette/library/spatial_test.py
@@ -1,7 +1,207 @@
-from tqec.plaquette.library.spatial import _SpatialCubeArmPlaquetteBuilder
+import stim
+
 from tqec.utils.enums import Basis
+from tqec.plaquette.library.spatial import make_spatial_cube_arm_plaquette
+from tqec.plaquette.qubit import (
+    UpTrianglePlaquetteQubits,
+    DownTrianglePlaquetteQubits,
+)
 
 
-def test_make_spatial_cube_arm_plaquette():
-    builder = _SpatialCubeArmPlaquetteBuilder(Basis.Z, "UP")
-    assert builder._get_plaquette_name() == "SPATIAL_CUBE_ARM_Z_UP"
+def test_spatial_cube_arm_plaquette() -> None:
+    plaquette = make_spatial_cube_arm_plaquette(Basis.X, "UP", is_reverse=False)
+    assert plaquette.qubits == UpTrianglePlaquetteQubits()
+    assert plaquette.name == "SPATIAL_CUBE_ARM_X_UP"
+    circuit = plaquette.circuit.get_circuit()
+    assert circuit == stim.Circuit(
+        """
+QUBIT_COORDS(0, 0) 0
+QUBIT_COORDS(-1, -1) 1
+QUBIT_COORDS(1, -1) 2
+QUBIT_COORDS(-1, 1) 3
+RX 0
+RZ 3
+TICK
+CX 0 3
+TICK
+CX 0 1
+TICK
+TICK
+CX 0 2
+TICK
+CX 3 0
+"""
+    )
+    plaquette = make_spatial_cube_arm_plaquette(Basis.X, "UP", is_reverse=True)
+    assert plaquette.qubits == UpTrianglePlaquetteQubits()
+    assert plaquette.name == "SPATIAL_CUBE_ARM_X_UP_REVERSE"
+    circuit = plaquette.circuit.get_circuit()
+    assert circuit == stim.Circuit(
+        """
+QUBIT_COORDS(0, 0) 0
+QUBIT_COORDS(-1, -1) 1
+QUBIT_COORDS(1, -1) 2
+QUBIT_COORDS(-1, 1) 3
+RX 0
+RZ 3
+TICK
+CX 0 3
+TICK
+CX 0 2
+TICK
+TICK
+CX 0 1
+TICK
+CX 3 0
+"""
+    )
+    plaquette = make_spatial_cube_arm_plaquette(Basis.X, "DOWN", is_reverse=False)
+    assert plaquette.qubits == DownTrianglePlaquetteQubits()
+    assert plaquette.name == "SPATIAL_CUBE_ARM_X_DOWN"
+    circuit = plaquette.circuit.get_circuit()
+    assert circuit == stim.Circuit(
+        """
+QUBIT_COORDS(0, 0) 0
+QUBIT_COORDS(-1, -1) 1
+QUBIT_COORDS(-1, 1) 2
+QUBIT_COORDS(1, 1) 3
+RZ 1
+TICK
+RZ 0
+TICK
+CX 1 0
+TICK
+CX 0 2
+TICK
+TICK
+CX 0 3
+TICK
+CX 0 1
+TICK
+MX 0
+"""
+    )
+    plaquette = make_spatial_cube_arm_plaquette(Basis.X, "DOWN", is_reverse=True)
+    assert plaquette.qubits == DownTrianglePlaquetteQubits()
+    assert plaquette.name == "SPATIAL_CUBE_ARM_X_DOWN_REVERSE"
+    circuit = plaquette.circuit.get_circuit()
+    assert circuit == stim.Circuit(
+        """
+QUBIT_COORDS(0, 0) 0
+QUBIT_COORDS(-1, -1) 1
+QUBIT_COORDS(-1, 1) 2
+QUBIT_COORDS(1, 1) 3
+RZ 1
+TICK
+RZ 0
+TICK
+CX 1 0
+TICK
+CX 0 3
+TICK
+TICK
+CX 0 2
+TICK
+CX 0 1
+TICK
+MX 0
+"""
+    )
+    plaquette = make_spatial_cube_arm_plaquette(Basis.Z, "UP", is_reverse=False)
+    assert plaquette.qubits == UpTrianglePlaquetteQubits()
+    assert plaquette.name == "SPATIAL_CUBE_ARM_Z_UP"
+    circuit = plaquette.circuit.get_circuit()
+    assert circuit == stim.Circuit(
+        """
+QUBIT_COORDS(0, 0) 0
+QUBIT_COORDS(-1, -1) 1
+QUBIT_COORDS(1, -1) 2
+QUBIT_COORDS(-1, 1) 3
+RX 0
+RZ 3
+TICK
+CX 0 3
+TICK
+CZ 0 1
+TICK
+TICK
+CZ 0 2
+TICK
+CX 3 0
+"""
+    )
+    plaquette = make_spatial_cube_arm_plaquette(Basis.Z, "UP", is_reverse=True)
+    assert plaquette.qubits == UpTrianglePlaquetteQubits()
+    assert plaquette.name == "SPATIAL_CUBE_ARM_Z_UP_REVERSE"
+    circuit = plaquette.circuit.get_circuit()
+    assert circuit == stim.Circuit(
+        """
+QUBIT_COORDS(0, 0) 0
+QUBIT_COORDS(-1, -1) 1
+QUBIT_COORDS(1, -1) 2
+QUBIT_COORDS(-1, 1) 3
+RX 0
+RZ 3
+TICK
+CX 0 3
+TICK
+CZ 0 2
+TICK
+TICK
+CZ 0 1
+TICK
+CX 3 0
+"""
+    )
+    plaquette = make_spatial_cube_arm_plaquette(Basis.Z, "DOWN", is_reverse=False)
+    assert plaquette.qubits == DownTrianglePlaquetteQubits()
+    assert plaquette.name == "SPATIAL_CUBE_ARM_Z_DOWN"
+    circuit = plaquette.circuit.get_circuit()
+    assert circuit == stim.Circuit(
+        """
+QUBIT_COORDS(0, 0) 0
+QUBIT_COORDS(-1, -1) 1
+QUBIT_COORDS(-1, 1) 2
+QUBIT_COORDS(1, 1) 3
+RZ 1
+TICK
+RZ 0
+TICK
+CX 1 0
+TICK
+CZ 0 2
+TICK
+TICK
+CZ 0 3
+TICK
+CX 0 1
+TICK
+MX 0
+"""
+    )
+    plaquette = make_spatial_cube_arm_plaquette(Basis.Z, "DOWN", is_reverse=True)
+    assert plaquette.qubits == DownTrianglePlaquetteQubits()
+    assert plaquette.name == "SPATIAL_CUBE_ARM_Z_DOWN_REVERSE"
+    circuit = plaquette.circuit.get_circuit()
+    assert circuit == stim.Circuit(
+        """
+QUBIT_COORDS(0, 0) 0
+QUBIT_COORDS(-1, -1) 1
+QUBIT_COORDS(-1, 1) 2
+QUBIT_COORDS(1, 1) 3
+RZ 1
+TICK
+RZ 0
+TICK
+CX 1 0
+TICK
+CZ 0 3
+TICK
+TICK
+CZ 0 2
+TICK
+CX 0 1
+TICK
+MX 0
+"""
+    )

--- a/src/tqec/plaquette/library/spatial_test.py
+++ b/src/tqec/plaquette/library/spatial_test.py
@@ -236,3 +236,30 @@ TICK
 CX 3 0
 """
     )
+    plaquette = make_spatial_cube_arm_plaquette(
+        Basis.X, "UP", reset=Basis.Z, is_reverse=False, is_corner_trimmed=True
+    )
+    assert plaquette.qubits == SquarePlaquetteQubits()
+    assert plaquette.name == "SPATIAL_CUBE_ARM_X_UP_CORNER_TRIMMED_datainit(Z)"
+    circuit = plaquette.circuit.get_circuit()
+    assert circuit == stim.Circuit(
+        """
+QUBIT_COORDS(0, 0) 0
+QUBIT_COORDS(-1, -1) 1
+QUBIT_COORDS(1, -1) 2
+QUBIT_COORDS(-1, 1) 3
+QUBIT_COORDS(1, 1) 4
+RX 0
+RZ 3
+RZ 2
+TICK
+CX 0 3
+TICK
+TICK
+TICK
+TICK
+CX 0 2
+TICK
+CX 3 0
+"""
+    )

--- a/src/tqec/plaquette/qubit.py
+++ b/src/tqec/plaquette/qubit.py
@@ -116,3 +116,21 @@ class SquarePlaquetteQubits(PlaquetteQubits):
             [GridQubit(-1, -1), GridQubit(1, -1), GridQubit(-1, 1), GridQubit(1, 1)],
             [GridQubit(0, 0)],
         )
+
+
+class UpTrianglePlaquetteQubits(PlaquetteQubits):
+    def __init__(self) -> None:
+        super().__init__(
+            # Order is important here! Top-left, top-right, bottom-left.
+            [GridQubit(-1, -1), GridQubit(1, -1), GridQubit(-1, 1)],
+            [GridQubit(0, 0)],
+        )
+
+
+class DownTrianglePlaquetteQubits(PlaquetteQubits):
+    def __init__(self) -> None:
+        super().__init__(
+            # Order is important here! Top-left, bottom-left, bottom-right.
+            [GridQubit(-1, -1), GridQubit(-1, 1), GridQubit(1, 1)],
+            [GridQubit(0, 0)],
+        )

--- a/src/tqec/plaquette/qubit.py
+++ b/src/tqec/plaquette/qubit.py
@@ -116,21 +116,3 @@ class SquarePlaquetteQubits(PlaquetteQubits):
             [GridQubit(-1, -1), GridQubit(1, -1), GridQubit(-1, 1), GridQubit(1, 1)],
             [GridQubit(0, 0)],
         )
-
-
-class UpTrianglePlaquetteQubits(PlaquetteQubits):
-    def __init__(self) -> None:
-        super().__init__(
-            # Order is important here! Top-left, top-right, bottom-left.
-            [GridQubit(-1, -1), GridQubit(1, -1), GridQubit(-1, 1)],
-            [GridQubit(0, 0)],
-        )
-
-
-class DownTrianglePlaquetteQubits(PlaquetteQubits):
-    def __init__(self) -> None:
-        super().__init__(
-            # Order is important here! Top-left, bottom-left, bottom-right.
-            [GridQubit(-1, -1), GridQubit(-1, 1), GridQubit(1, 1)],
-            [GridQubit(0, 0)],
-        )


### PR DESCRIPTION
Hi team, I wonder if it is proper  to close this issue: https://github.com/tqec/tqec/issues/461 using two PRs. In this PR, I prefer to first make sure that the circuit implementations of corresponding plaquettes are completely correct. 

Then I'll open another PR to implement `get_spatial_cube_arm_plaquettes`, i.e., map these plaquettes to corresponding templates, which will call the method named `make_spatial_cube_arm_plaquette` in the plaquettes library to create `Plaquette` instances.

- [ ] Implement `get_spatial_cube_arm_plaquettes` 

In this PR, I made some assumptions as below that need to be confirmed to be correct, please review them carefully

- The mapping between qubits and the two non-rectangle plaquettes.
   <img src="https://github.com/user-attachments/assets/a8a83f75-ff0c-4cd1-aaf8-75cddeb76db3" width="300" alt="">

- The data qubits to apply optional initialization and measurement (because we always need to apply RZ to `d`?)
  - For plaquettes (a,b,c,d), these data qubits are (a,b)
  - For plaquettes (d,e,f,g), these data qubits are (f,g)


- Plaquettes (a,b,c,d) have 6 moments, while plaquettes (d,e,f,g) have 8 moments, as shown below 
  <img src="https://github.com/user-attachments/assets/dd236deb-a2e0-442b-b5b2-0187ff2d0617" width="300" alt="">
- As such, optional measurements to data qubits are appended at `moments[5]` for plaquettes (a,b,c,d), and at `moments[7]` for plaquettes (d,e,f,g)


BTW I updated `.gitignore` but this may be just personalized to myself, I'll revert this change if necessary

