### PR TITLE
fixed basis has no .value error in _from_cube_kind function in pipe.py

### DIFF
--- a/src/tqec/computation/pipe.py
+++ b/src/tqec/computation/pipe.py
@@ -138,7 +138,7 @@ class PipeKind:
             bases = [basis.flipped() for basis in cube_kind.as_tuple()]
         else:
             bases = list(cube_kind.as_tuple())
-        bases_str = [basis.value for basis in bases]
+        bases_str = [str(basis) for basis in bases]
         bases_str[direction.value] = "O"
         if has_hadamard:
             bases_str.append("H")


### PR DESCRIPTION
in python 3.12.6, when trying to create Pipe object using Pipe.from_cubes, providing two cube object will currently throw the following error : "AttributeError: 'str' object has no attribute 'value'"
this PR fix that.

here is a code snippet to reproduce the bug : 

```py
from tqec import Cube, ZXCube, YCube
from tqec import Pipe
from tqec import BlockGraph
from tqec import Position3D
class PipeData:
    def __init__(self, start_cube, end_cube):
        self.start_cube = start_cube
        self.end_cube = end_cube
class CubeData:
    def __init__(self, position, color):
        self.position = position
        self.color = color
pipes = [PipeData(cubes[0], cubes[1])]
cubes = [
    CubeData((0, 0, 0), 'green'),
    CubeData((1, 0, 0), 'red'),
    CubeData((0, 1, 0), 'yellow')
]
block_graph = BlockGraph()

for cube in cubes:
    position = Position3D(*cube.position)
    if cube.color == 'green':
        kind = ZXCube('Z', 'Z', 'X')
    elif cube.color == 'red':
        kind = ZXCube('X', 'X', 'Z')
    else:
        kind = YCube() 
    block_graph.add_cube(position, kind)

for pipe in pipes:
    start_pos = Position3D(*pipe.start_cube.position)
    end_pos = Position3D(*pipe.end_cube.position)
    start_cube = block_graph[start_pos]
    end_cube = block_graph[end_pos]

    pipe_kind = Pipe.from_cubes(start_cube, end_cube)
    block_graph.add_pipe(start_pos, end_pos, pipe_kind)
```