### PR TITLE
SketchUp import failure: delete spaces

### DIFF
--- a/src/tqec/interop/collada/read_write.py
+++ b/src/tqec/interop/collada/read_write.py
@@ -283,8 +283,8 @@ class _BlockLibraryKey:
     def __str__(self) -> str:
         string = f"{self.kind}"
         if self.pop_faces_at_directions:
-            string += " without "
-            string += " ".join(str(d) for d in self.pop_faces_at_directions)
+            string += "-without-"
+            string += "-".join(str(d) for d in self.pop_faces_at_directions)
         return string
 
 


### PR DESCRIPTION
Fix SketchUp import failure by adjusting face popping logic: delete spaces. Before, the import of the DAE file failed because SketchUp does not support spaces in node's ID. Just delete the spaces in the string returned by def __str__ and it's done (@inmzhang gave me the solution, actually :)