### PR TITLE
Fix docs build errors and update contributing guide

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,6 +10,7 @@ BUILDDIR      = _build
 
 # Put it first so that "make" without argument is like "make help".
 help:
+	rm _autosummary/*
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .PHONY: help Makefile

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,6 @@ BUILDDIR      = _build
 
 # Put it first so that "make" without argument is like "make help".
 help:
-	rm _autosummary/*
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .PHONY: help Makefile

--- a/docs/contributor_guide.rst
+++ b/docs/contributor_guide.rst
@@ -17,7 +17,7 @@ to install a few more packages than the regular installation. It is also
 recommended to use an editable installation.
 
 Currently, ``tqec`` is compatible with Python 3.10, 3.11 and 3.12. Some dependencies limit the project's
-compatibility with Python 3.12.
+compatibility with Python 3.13.
 
 .. code-block:: bash
 

--- a/docs/contributor_guide.rst
+++ b/docs/contributor_guide.rst
@@ -16,6 +16,9 @@ If you want to help maintaining and improving the ``tqec`` package, you will nee
 to install a few more packages than the regular installation. It is also
 recommended to use an editable installation.
 
+Currently, ``tqec`` is compatible with Python 3.10, 3.11 and 3.12. Some dependencies limit the project's
+compatibility with Python 3.12.
+
 .. code-block:: bash
 
     # Clone the repository to have local files to work on
@@ -25,6 +28,10 @@ recommended to use an editable installation.
     # Go in the tqec directory and enable pre-commit
     cd tqec
     pre-commit install
+
+.. warning::
+    You will have to install ``pandoc`` separately as the instructions above only install a ``pandoc`` wrapper.
+    See https://stackoverflow.com/a/71585691 for more info.
 
 If you encounter any issue during the installation, please refer to :ref:`installation` for more information.
 

--- a/docs/user_guide/terminology.rst
+++ b/docs/user_guide/terminology.rst
@@ -97,7 +97,7 @@ The circuits that implement these spatial cubes are more complex than the circui
 the hook errors from decreasing the circuit-level code distance.
 
 :py:class:`~tqec.computation.YHalfCube`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A green cube representing inplace Y-basis logical initialization or measurement as proposed in `this paper <https://quantum-journal.org/papers/q-2024-04-08-1310/>`_.
 The cube's function, whether for initialization or measurement, is determined by its connection to other cubes, either upwards or downwards.


### PR DESCRIPTION
Fixes #496

I did not need to add `rm _autosummary/*` to the makefile because switching to a Python 3.12 environment fixed the duplicate target issues.