### PR TITLE
Fix shadowed faces to match pipe color

### DIFF
--- a/src/tqec/computation/block_graph.py
+++ b/src/tqec/computation/block_graph.py
@@ -641,7 +641,7 @@ class BlockGraph:
                 pos_map[pipe.v.position],
                 cast(PipeKind, rotated_kind),
             )
-        return rotated
+        return rotated.fix_shadowed_faces()
 
     def fix_shadowed_faces(self) -> BlockGraph:
         """Fix the basis of those shadowed faces of the cubes in the graph.

--- a/src/tqec/computation/block_graph.py
+++ b/src/tqec/computation/block_graph.py
@@ -676,11 +676,6 @@ class BlockGraph:
             pipes_by_direction: dict[Direction3D, list[Pipe]] = {}
             for pipe in self.pipes_at(cube.position):
                 pipes_by_direction.setdefault(pipe.direction, []).append(pipe)
-            shadowed_directions = {
-                d for d, ps in pipes_by_direction.items() if len(ps) == 2
-            }
-            if not shadowed_directions:
-                continue
             # No need to handle the case `len(pipes_by_direction) == 0` as there
             # is no pipes connected to the cube.
             # No need to handle the case `len(pipes_by_direction) == 3` as it's
@@ -688,8 +683,14 @@ class BlockGraph:
             # Spatial pass-through, ensure that the cube is not a spatial cube
             if len(pipes_by_direction) in [0, 3]:
                 continue
+            shadowed_directions = {
+                d for d, ps in pipes_by_direction.items() if len(ps) == 2
+            }
+            if not shadowed_directions:
+                continue
             new_kind = cube.kind
             for shadowed_direction in shadowed_directions:
+                # Spatial pass-through, ensure that the cube is not a spatial cube
                 if (
                     len(pipes_by_direction) == 1
                     and shadowed_direction != Direction3D.Z

--- a/src/tqec/computation/block_graph.py
+++ b/src/tqec/computation/block_graph.py
@@ -676,6 +676,8 @@ class BlockGraph:
             # Regularize the cube in a spatial pass-through
             if len(pipes_by_direction) == 1:
                 direction = next(iter(pipes_by_direction))
+                if len(pipes_by_direction[direction]) != 2:
+                    continue
                 if direction == Direction3D.Z or not cube.is_spatial:
                     continue
                 kind = cube.kind

--- a/src/tqec/computation/cube.py
+++ b/src/tqec/computation/cube.py
@@ -110,6 +110,25 @@ class ZXCube:
         """
         return self.as_tuple()[direction.value]
 
+    def with_basis_along(self, direction: Direction3D, basis: Basis) -> ZXCube:
+        """Set the basis of the walls along the given direction axis and return
+        a new instance.
+
+        Args:
+            direction: The direction of the axis along which the basis is set.
+            basis: The basis to set along the given direction axis.
+
+        Returns:
+            The new :py:class:`~tqec.computation.cube.ZXCube` instance with the basis
+            set along the given direction axis.
+        """
+        return ZXCube(
+            *[
+                basis if i == direction.value else b
+                for i, b in enumerate(self.as_tuple())
+            ]
+        )
+
 
 class Port:
     """Cube kind representing the open ports in the block graph.

--- a/src/tqec/interop/collada/read_write.py
+++ b/src/tqec/interop/collada/read_write.py
@@ -222,7 +222,7 @@ def read_block_graph_from_dae_file(
     graph_fixed = graph.fix_shadowed_faces()
     if graph_fixed != graph:
         warnings.warn(
-            "There are some shadowed faces have been fixed. "
+            "Some shadowed faces have been fixed. "
             "Check `BlockGraph.fix_shadowed_faces` for more details.",
             TQECWarning,
         )

--- a/src/tqec/interop/collada/read_write_test.py
+++ b/src/tqec/interop/collada/read_write_test.py
@@ -57,7 +57,7 @@ def rotated_cnot(observable_basis: Basis | None = None) -> BlockGraph:
 
 @pytest.mark.parametrize("pipe_length", [0.5, 1.0, 2.0, 10.0])
 def test_logical_cnot_collada_write_read(pipe_length: float) -> None:
-    block_graph = cnot(Basis.Z)
+    block_graph = cnot(Basis.X)
 
     # Set `delete=False` to be compatible with Windows
     # https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile

--- a/src/tqec/interop/collada/read_write_test.py
+++ b/src/tqec/interop/collada/read_write_test.py
@@ -30,12 +30,12 @@ def rotated_cnot(observable_basis: Basis | None = None) -> BlockGraph:
     nodes = [
         (Position3D(0, 0, 1), "P", "In_Control"),
         (Position3D(0, 1, 1), "ZXX", ""),
-        (Position3D(0, 2, 1), "ZZX", ""),
+        (Position3D(0, 2, 1), "ZXX", ""),
         (Position3D(0, 3, 1), "P", "Out_Control"),
         (Position3D(0, 1, 0), "ZXX", ""),
         (Position3D(0, 2, 0), "ZZX", ""),
         (Position3D(1, 0, 0), "P", "In_Target"),
-        (Position3D(1, 1, 0), "ZZX", ""),
+        (Position3D(1, 1, 0), "ZXX", ""),
         (Position3D(1, 2, 0), "ZZX", ""),
         (Position3D(1, 3, 0), "P", "Out_Target"),
     ]
@@ -57,7 +57,7 @@ def rotated_cnot(observable_basis: Basis | None = None) -> BlockGraph:
 
 @pytest.mark.parametrize("pipe_length", [0.5, 1.0, 2.0, 10.0])
 def test_logical_cnot_collada_write_read(pipe_length: float) -> None:
-    block_graph = cnot(Basis.X)
+    block_graph = cnot(Basis.Z)
 
     # Set `delete=False` to be compatible with Windows
     # https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile
@@ -70,8 +70,7 @@ def test_logical_cnot_collada_write_read(pipe_length: float) -> None:
     os.remove(temp_file.name)
 
 
-@pytest.mark.parametrize("pipe_length", [0.5, 1.0, 2.0, 10.0])
-def test_rotated_cnot_collada_write_read(pipe_length: float) -> None:
+def test_rotated_cnot_collada_write_read() -> None:
     block_graph = rotated_cnot(Basis.Z)
 
     ROTATED_CNOT_DAE = Path(__file__).parent / "test_files/rotated_cnot.dae"


### PR DESCRIPTION
Fixes https://github.com/tqec/tqec/pull/510#issuecomment-272544649.

In the following `.dae` file, the highlighted cube is incorrectly defined as `ZZX` instead of `ZXZ`. Although it appears correct because its front and back faces are shadowed by connected pipes, this discrepancy can affect cube kinds and the compilation pipeline.

![image](https://github.com/user-attachments/assets/c50ce3cf-622a-4fe2-93b2-975bba4549e3)

This PR introduces a new method, `fix_shadowed_faces`, in `BlockGraph` to detect and correct such shadowed faces by adjusting their basis to match the pipe color. For example, the cube above will be properly corrected to `ZXZ`. The fix procedure has also been integrated into `BlockGraph.from_dae_file`, allowing users to make such fixable mistakes in SketchUp without affecting the final compilation.