### PR TITLE
Get cubes by label

### DIFF
--- a/src/tqec/computation/block_graph.py
+++ b/src/tqec/computation/block_graph.py
@@ -729,6 +729,18 @@ class BlockGraph:
             new_graph.add_pipe(pipe.u.position, pipe.v.position, pipe.kind)
         return new_graph
 
+    def get_cubes_by_label(self, label: str) -> list[Cube]:
+        """
+        Find cubes with the specified label in the BlockGraph.
+
+        Args:
+            label: The label of the cubes.
+
+        Returns:
+            The cube instances that have the specified label.
+        """
+        return [cube for cube in self.cubes if cube.label == label]
+
 
 def block_kind_from_str(string: str) -> BlockKind:
     """Parse a block kind from a string."""


### PR DESCRIPTION
Look for a cube using its label #517

get_cubes_by_label(label): With a given str, the label, returns the 3D integer position, and the CubeKind (ZXCube | Port | YHalfCube)

I checked using this:
```
    result = block_graph.get_cubes_by_label("P3")

    if result:
        position, kind = result
        print(f"Cube found at {position} with kind {kind}")
    else:
        print("No cube found with that label")
```
Result:
```
python cubes_label_test.py
Cube found at (-1,0,3) with kind PORT
```