### PR TITLE
Single simulation run for multiple observable statistics

### DIFF
--- a/src/tqec/simulation/__init__.py
+++ b/src/tqec/simulation/__init__.py
@@ -2,3 +2,5 @@
 
 from .plotting import plot_observable_as_inset as plot_observable_as_inset
 from .simulation import start_simulation_using_sinter as start_simulation_using_sinter
+from .split import split_stats_for_observables as split_stats_for_observables
+from .split import heuristic_custom_error_key as heuristic_custom_error_key

--- a/src/tqec/simulation/simulation.py
+++ b/src/tqec/simulation/simulation.py
@@ -125,9 +125,7 @@ def start_simulation_using_sinter(
     if observables is None:
         observables = block_graph.find_correlation_surfaces()
     custom_error_count_key: str | None = None
-    if not split_observable_stats or len(observables) <= 1:
-        custom_error_count_key = None
-    else:
+    if split_observable_stats and len(observables) > 1:
         custom_error_count_key = heuristic_custom_error_key(observables)
 
     compiled_graph = compile_block_graph(

--- a/src/tqec/simulation/simulation.py
+++ b/src/tqec/simulation/simulation.py
@@ -155,6 +155,6 @@ def start_simulation_using_sinter(
         count_observable_error_combos=True,
         custom_error_count_key=custom_error_count_key,
     )
-    if split_stats_for_observables:
+    if split_observable_stats:
         return split_stats_for_observables(stats, len(observables))
     return [stats]

--- a/src/tqec/simulation/simulation.py
+++ b/src/tqec/simulation/simulation.py
@@ -115,9 +115,12 @@ def start_simulation_using_sinter(
             post-processed to get individual statistics for each observable in
             `observables`. If False, the results are returned as they are
             collected.
+
     Returns:
-        one simulation result (of type `list[sinter.TaskStats]`) per provided
-        observable in `observables`.
+        A list of lists of `sinter.TaskStats`. If `split_observable_stats` is
+        True, the outer list has one element per provided observable in `observables`.
+        If `split_observable_stats` is False, the outer list has only one element,
+        containing the raw statistics collected.
     """
     if observables is None:
         observables = block_graph.find_correlation_surfaces()

--- a/src/tqec/simulation/split.py
+++ b/src/tqec/simulation/split.py
@@ -133,6 +133,5 @@ def heuristic_custom_error_key(observables: list[CorrelationSurface]) -> str:
             obs_comb.append("E" if fragment in obs.span else "_")
         key = "obs_mistake_mask=" + "".join(obs_comb)
         obs_comb_to_prob[key] = obs_comb_to_prob.get(key, 0) + 1
-    # order the observable combinations by probability
-    ordered_combs = sorted(obs_comb_to_prob.keys(), key=lambda x: obs_comb_to_prob[x])
-    return ordered_combs[-1]
+    # return the most frequent observable combination
+    return max(obs_comb_to_prob.keys(), key=lambda x: obs_comb_to_prob[x])

--- a/src/tqec/simulation/split.py
+++ b/src/tqec/simulation/split.py
@@ -1,42 +1,42 @@
 """Split the statistics for multiple observables."""
 
 import collections
+from functools import reduce
 from typing import Mapping
 
 import sinter
 
+from tqec.computation.correlation import CorrelationSurface, ZXEdge
 
-def split_counts_for_observables(counts: Mapping[str, int]) -> list[int]:
+
+def split_counts_for_observables(
+    counts: Mapping[str, int], num_observables: int
+) -> list[int]:
     """Split the error counts for each individual observable when
     specifying ``count_observable_error_combos=True`` for ``sinter``.
 
     Args:
         counts: The error counts for different observable error combinations.
+        num_observables: The number of observables.
 
     Returns:
         A list of error counts for each individual observable.
     """
-    num_observables: int = 0
-    split_counts: list[int] = []
+    split_counts: list[int] = [0] * num_observables
     for key, count in counts.items():
         if not key.startswith("obs_mistake_mask="):
             continue
         comb = key.split("=")[1]
-        if num_observables == 0:
-            num_observables = len(comb)
-            split_counts = [0] * num_observables
         assert num_observables == len(comb)
         for i in range(num_observables):
             if comb[i] == "E":
                 split_counts[i] += count
-
-    if num_observables == 0:
-        raise ValueError("No observable mistake mask found in the counts.")
     return split_counts
 
 
 def split_stats_for_observables(
     stats: list[sinter.TaskStats],
+    num_observables: int,
 ) -> list[list[sinter.TaskStats]]:
     """Split the statistics for each individual observable when specifying
     ``count_observable_error_combos=True`` for ``sinter``.
@@ -56,11 +56,15 @@ def split_stats_for_observables(
     combined_stats = list(data.data.values())
 
     # For each task, split the stats by observable
-    stats_by_observables: dict[int, list[sinter.TaskStats]] = {}
+    stats_by_observables: list[list[sinter.TaskStats]] = [
+        [] for _ in range(num_observables)
+    ]
     for task_stats in combined_stats:
-        split_counts = split_counts_for_observables(task_stats.custom_counts)
+        split_counts = split_counts_for_observables(
+            task_stats.custom_counts, num_observables
+        )
         for obs_idx, count in enumerate(split_counts):
-            stats_by_observables.setdefault(obs_idx, []).append(
+            stats_by_observables[obs_idx].append(
                 task_stats.with_edits(
                     errors=count,
                     custom_counts=collections.Counter(
@@ -72,4 +76,40 @@ def split_stats_for_observables(
                     ),
                 )
             )
-    return [stats_by_observables[i] for i in range(len(stats_by_observables))]
+    return stats_by_observables
+
+
+def heuristic_custom_error_key(observables: list[CorrelationSurface]) -> str:
+    """Get a heuristic custom error key using for the ``error`` metric in
+    ``sinter``.
+
+    Currently, we determine the most likely observable error combinations by
+    analyzing their correlation surfaces. For each combination, we perform an
+    AND on the corresponding correlation surfaces and calculate the area of the
+    resulting span. We then rank these combinations according to the computed
+    AND-area metric. To derive a reasonable error metric, we select
+    ``ordered_combs[-len(observables)]`` for two reasons: first, errors should
+    be easy to sample so as not to require excessive shots; and second, once an
+    error reaches a preset MAX value, there should be enough statistical data for
+    all individual observables.
+
+    Args:
+        observables: The list of observables.
+
+    Returns:
+        The heuristic custom error key.
+    """
+    key_area: dict[str, int] = {}
+    span_union: set[ZXEdge] = reduce(
+        lambda a, b: a | b,
+        (obs.span for obs in observables),
+        set(),
+    )
+    for edge in span_union:
+        key_list: list[str] = []
+        for obs in observables:
+            key_list.append("E" if edge in obs.span else "_")
+        key = "obs_mistake_mask=" + "".join(key_list)
+        key_area[key] = key_area.get(key, 0) + 1
+    most_frequent_keys = sorted(key_area.items(), key=lambda x: x[1])
+    return most_frequent_keys[-len(observables)][0]

--- a/src/tqec/simulation/split.py
+++ b/src/tqec/simulation/split.py
@@ -47,7 +47,7 @@ def split_stats_for_observables(
     Returns:
         A list of statistics for each individual observable.
     """
-    from sinter._data import ExistingData
+    from sinter._data import ExistingData  # type: ignore
 
     # Combine the stats for each task
     data = ExistingData()

--- a/src/tqec/simulation/split.py
+++ b/src/tqec/simulation/split.py
@@ -1,0 +1,75 @@
+"""Split the statistics for multiple observables."""
+
+import collections
+from typing import Mapping
+
+import sinter
+
+
+def split_counts_for_observables(counts: Mapping[str, int]) -> list[int]:
+    """Split the error counts for each individual observable when
+    specifying ``count_observable_error_combos=True`` for ``sinter``.
+
+    Args:
+        counts: The error counts for different observable error combinations.
+
+    Returns:
+        A list of error counts for each individual observable.
+    """
+    num_observables: int = 0
+    split_counts: list[int] = []
+    for key, count in counts.items():
+        if not key.startswith("obs_mistake_mask="):
+            continue
+        comb = key.split("=")[1]
+        if num_observables == 0:
+            num_observables = len(comb)
+            split_counts = [0] * num_observables
+        assert num_observables == len(comb)
+        for i in range(num_observables):
+            if comb[i] == "E":
+                split_counts[i] += count
+
+    if num_observables == 0:
+        raise ValueError("No observable mistake mask found in the counts.")
+    return split_counts
+
+
+def split_stats_for_observables(
+    stats: list[sinter.TaskStats],
+) -> list[list[sinter.TaskStats]]:
+    """Split the statistics for each individual observable when specifying
+    ``count_observable_error_combos=True`` for ``sinter``.
+
+    Args:
+        stats: The statistics for different observable error combinations.
+
+    Returns:
+        A list of statistics for each individual observable.
+    """
+    from sinter._data import ExistingData
+
+    # Combine the stats for each task
+    data = ExistingData()
+    for s in stats:
+        data.add_sample(s)
+    combined_stats = list(data.data.values())
+
+    # For each task, split the stats by observable
+    stats_by_observables: dict[int, list[sinter.TaskStats]] = {}
+    for task_stats in combined_stats:
+        split_counts = split_counts_for_observables(task_stats.custom_counts)
+        for obs_idx, count in enumerate(split_counts):
+            stats_by_observables.setdefault(obs_idx, []).append(
+                task_stats.with_edits(
+                    errors=count,
+                    custom_counts=collections.Counter(
+                        {
+                            k: v
+                            for k, v in task_stats.custom_counts.items()
+                            if not k.startswith("obs_mistake_mask=")
+                        }
+                    ),
+                )
+            )
+    return [stats_by_observables[i] for i in range(len(stats_by_observables))]


### PR DESCRIPTION
Fixes #364.

The solution is mainly based on [my previous comments](https://github.com/tqec/tqec/issues/364#issuecomment-2574720834).

For the `custom_error_key` used in `sinter`, I use the following heuristic algorithm, copied from the docstring of `heuristic_custom_error_key`.

```txt
    Currently, we determine the most likely observable error combinations by
    analyzing their correlation surfaces. For each combination, we perform an
    AND on the corresponding correlation surfaces and calculate the area of the
    resulting span. We then rank these combinations according to the computed
    AND-area metric. To derive a reasonable error metric, we select
    ``ordered_combs[-len(observables)]`` for two reasons: first, errors should
    be easy to sample so as not to require excessive shots; and second, once an
    error reaches a preset MAX value, there should be enough statistical data for
    all individual observables.
```

The heuristic might need improvement in the future, or not.

For the logical CNOT, I have tested for the Z basis observables and get results:

![css_logical_cnot_result_Z_observable_0](https://github.com/user-attachments/assets/dea3ca01-ca1f-49eb-ac36-2fb09b49c992)
![css_logical_cnot_result_Z_observable_1](https://github.com/user-attachments/assets/e873c69a-25f7-419a-9d30-6b2a156ac5b8)
![css_logical_cnot_result_Z_observable_2](https://github.com/user-attachments/assets/45815825-77ed-4940-86ae-585a6cddcf32)
