### PR TITLE
Implement a few post-processing functions for `stim.Circuit`

### DIFF
--- a/src/tqec/circuit/moment.py
+++ b/src/tqec/circuit/moment.py
@@ -10,6 +10,7 @@ instead of using ``cirq`` data-structures.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any, Callable, Iterable, Iterator, cast
 
 import stim
@@ -173,6 +174,17 @@ class Moment:
             )
         self._circuit += other._circuit
         return self
+
+    def __add__(self, other: Moment) -> Moment:
+        """Add instructions of ``self`` and ``other`` in a new instance."""
+        both_sides_used_qubits = self._used_qubits.intersection(other._used_qubits)
+        if both_sides_used_qubits:
+            raise TQECException(
+                "Trying to add an overlapping quantum circuit to a Moment instance."
+            )
+        cpy = deepcopy(self)
+        cpy += other
+        return cpy
 
     @staticmethod
     def _get_used_qubit_indices(

--- a/src/tqec/post_processing/merge.py
+++ b/src/tqec/post_processing/merge.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import stim
+
+from tqec.circuit.moment import Moment
+from tqec.post_processing.remove import _remove_empty_moments_inline
+from tqec.post_processing.utils.moment import (
+    RepeatedMoments,
+    collect_moments,
+    iter_stim_circuit_by_moments,
+    merge_moments,
+)
+
+
+def merge_adjacent_moments(circuit: stim.Circuit) -> stim.Circuit:
+    """Merge adjacent moments that can be merged.
+
+    This function merges moments from the provided ``circuit`` that can be
+    merged together. It performs merging in the increasing time direction. It
+    may re-organise the neighbourhood of ``REPEAT`` blocks in some cases, but
+    the returned circuit should always be strictly equivalent to the provided
+    one.
+
+    Args:
+        circuit: a circuit containing moments that may be mergeable.
+
+    Returns:
+        a new quantum circuit that contains strictly the same instructions as
+        the provided ``circuit`` but that might re-order some of these operations
+        to reduce the number of moments.
+    """
+    merged_moments: list[Moment | RepeatedMoments] = list(
+        iter_stim_circuit_by_moments(circuit, collected_before_use=True)
+    )
+    _remove_empty_moments_inline(merged_moments)
+    _merge_internal_adjacent_moments_inline(merged_moments)
+    _merge_repeat_block_boundaries_inline(merged_moments)
+    return collect_moments(merged_moments)
+
+
+def _can_be_merged(lhs: Moment, rhs: Moment) -> bool:
+    return not lhs.qubits_indices.intersection(rhs.qubits_indices)
+
+
+def _merge_internal_adjacent_moments_inline(
+    moments: list[Moment | RepeatedMoments],
+) -> None:
+    """Merges adjacent moments without considering REPEAT block boundaries."""
+    i: int = 1
+    while i < len(moments):
+        # Invariant of the loop: moments[i - 1] is not a REPEAT block.
+        previous_moment, current_moment = moments[i - 1], moments[i]
+        assert not isinstance(previous_moment, RepeatedMoments)
+
+        if isinstance(current_moment, RepeatedMoments):
+            # Just recurse in the REPEAT block but do not perform any specific
+            # computation for its boundaries.
+            _merge_internal_adjacent_moments_inline(current_moment.moments)
+            # We do not have to look at the moment just after the REPEAT block
+            # because it will not be merged with the REPEAT block, so just skip
+            # it (that also allows to respect the loop invariant).
+            i += 2
+            continue
+
+        # Try to merge moments[i] into moments[i - 1]
+        # If they can be merged, merge them. Else, just increase i and go to the
+        # next moment.
+        if _can_be_merged(previous_moment, current_moment):
+            moments[i - 1] = merge_moments(previous_moment, current_moment)
+            moments.pop(i)
+        else:
+            i += 1
+
+
+def _merge_repeat_block_boundaries_inline(
+    moments: list[Moment | RepeatedMoments],
+) -> None:
+    i: int = 0
+    while i < len(moments):
+        current_moment = moments[i]
+        if not isinstance(current_moment, RepeatedMoments):
+            i += 1
+            continue
+        # First recursively merge the potentially nested REPEAT blocks boundaries.
+        _merge_repeat_block_boundaries_inline(current_moment.moments)
+        # Then merge the boundaries of the current REPEAT block if possible.
+        start, *bulk, end = current_moment.moments
+        if isinstance(start, RepeatedMoments) or isinstance(end, RepeatedMoments):
+            # Not handled yet, just ignore.
+            i += 1
+            continue
+        if not _can_be_merged(start, end) or current_moment.repetitions < 2:
+            # Either START and END cannot be merged or merging them would lead to
+            # an invalid REPEAT block (repetitions == 0), so do nothing.
+            i += 1
+            continue
+        # Here, we know that start and start can be merged. We replace:
+        #
+        # REPEAT N {
+        #     START
+        #     BULK
+        #     END
+        # }
+        #
+        # by
+        #
+        # START
+        # BULK
+        # REPEAT N - 1 {
+        #     END + START
+        #     BULK
+        # }
+        # END
+        # Note: modifying moments in-place.
+        moments.pop(i)
+        moments.insert(i, start)
+        for b in range(len(bulk)):
+            moments.insert(i + 1 + b, bulk[i])
+        moments.insert(
+            i + 1 + len(bulk),
+            RepeatedMoments(
+                current_moment.repetitions - 1, [merge_moments(end, start), *bulk]
+            ),
+        )
+        moments.insert(i + 2 + len(bulk), end)
+        # We can update i to the index of the REPEAT block, just in case more
+        # merging can be done.
+        i += 2

--- a/src/tqec/post_processing/merge.py
+++ b/src/tqec/post_processing/merge.py
@@ -139,5 +139,5 @@ def _merge_repeat_block_boundaries_inline(
         modification_performed = True
         # We can update i to the index of the REPEAT block, just in case more
         # merging can be done.
-        i += 2
+        i += len(bulk) + 1
     return modification_performed

--- a/src/tqec/post_processing/merge.py
+++ b/src/tqec/post_processing/merge.py
@@ -130,16 +130,12 @@ def _merge_repeat_block_boundaries_inline(
         # END
         # Note: modifying moments in-place.
         moments.pop(i)
-        moments.insert(i, start)
-        for b in range(len(bulk)):
-            moments.insert(i + 1 + b, bulk[i])
-        moments.insert(
-            i + 1 + len(bulk),
-            RepeatedMoments(
-                current_moment.repetitions - 1, [merge_moments(end, start), *bulk]
-            ),
+        new_repeat_block = RepeatedMoments(
+            current_moment.repetitions - 1, [merge_moments(end, start), *bulk]
         )
-        moments.insert(i + 2 + len(bulk), end)
+        inserted_moments = [start, *bulk, new_repeat_block, end]
+        for m in range(len(inserted_moments)):
+            moments.insert(i + m, inserted_moments[m])
         modification_performed = True
         # We can update i to the index of the REPEAT block, just in case more
         # merging can be done.

--- a/src/tqec/post_processing/merge.py
+++ b/src/tqec/post_processing/merge.py
@@ -138,6 +138,8 @@ def _merge_repeat_block_boundaries_inline(
             moments.insert(i + m, inserted_moments[m])
         modification_performed = True
         # We can update i to the index of the REPEAT block, just in case more
-        # merging can be done.
+        # merging can be done. Note that even if BULK contains REPEAT blocks,
+        # they have been addressed in the beginning of this loop iteration, hence
+        # we do not need to iterate again on BULK.
         i += len(bulk) + 1
     return modification_performed

--- a/src/tqec/post_processing/merge_test.py
+++ b/src/tqec/post_processing/merge_test.py
@@ -1,0 +1,56 @@
+import stim
+
+from tqec.post_processing.merge import merge_adjacent_moments
+
+
+def test_empty() -> None:
+    assert merge_adjacent_moments(stim.Circuit()) == stim.Circuit()
+
+
+def test_no_merge_possible() -> None:
+    assert merge_adjacent_moments(stim.Circuit("H 0")) == stim.Circuit("H 0")
+    assert merge_adjacent_moments(stim.Circuit("H 0\nTICK\nH 0")) == stim.Circuit(
+        "H 0\nTICK\nH 0"
+    )
+    assert merge_adjacent_moments(
+        stim.Circuit("H 0\nTICK\nCX 0 1\nTICK\nH 1")
+    ) == stim.Circuit("H 0\nTICK\nCX 0 1\nTICK\nH 1")
+
+
+def test_merge_possible() -> None:
+    assert merge_adjacent_moments(stim.Circuit("H 0\nTICK\nH 1")) == stim.Circuit(
+        "H 0 1"
+    )
+    assert merge_adjacent_moments(
+        stim.Circuit("CX 0 1\nTICK\nH 3\nTICK\nCX 2 4")
+    ) == stim.Circuit("CX 0 1 2 4\nH 3")
+
+
+def test_merge_repeat_simple() -> None:
+    assert merge_adjacent_moments(
+        stim.Circuit(
+            """\
+REPEAT 3 {
+    TICK
+    H 0
+    TICK
+    CX 0 1
+    TICK
+    H 1
+}"""
+        )
+    ) == stim.Circuit(
+        """\
+H 0
+TICK
+CX 0 1
+REPEAT 2 {
+    TICK
+    H 0 1
+    TICK
+    CX 0 1
+}
+TICK
+H 1
+"""
+    )

--- a/src/tqec/post_processing/remove.py
+++ b/src/tqec/post_processing/remove.py
@@ -1,0 +1,77 @@
+import stim
+
+
+def remove_empty_moments(
+    circuit: stim.Circuit,
+    remove_leading_tick: bool = True,
+    remove_trailing_tick: bool = True,
+) -> stim.Circuit:
+    """Remove empty moments in a circuit.
+
+    This function removes empty moments (delimited by ``TICK`` instructions) in
+    the provided circuit, returning a copy of the circuit without the empty
+    moments.
+
+    Note:
+        This function follows ``stim`` convention on ``REPEAT`` blocks to:
+
+        1. not include any ``TICK`` instruction just before the ``REPEAT`` block,
+        2. include a ``TICK`` instruction at the beginning of the repeated block,
+        3. not include a ``TICK`` instruction at the end of the repeated block.
+
+        The instruction following a ``REPEAT`` block with ``stim gen`` is often
+        not a ``TICK`` because only the last measurements on data-qubits are left
+        to perform and so they do not overlap with the last measurements within
+        the repeated block. For this reason, this function do not enforce
+        anything about the instruction following a ``REPEAT`` block:
+
+        - if it is not a ``TICK`` in the original circuit, no ``TICK`` is
+          inserted,
+        - if there are one or more consecutive ``TICK`` instructions, only one
+          will be left (removing empty moments).
+
+    Args:
+        circuit: circuit to remove empty moments from.
+        remove_leading_tick: whether to remove the first instruction of
+            ``circuit`` if it is a ``TICK`` instruction. Note that this parameter
+            is not recursively forwarded to repeated blocks, see the note.
+        remove_trailing_tick: whether to remove the last instruction of
+            ``circuit`` if it is a ``TICK`` instruction. Note that this parameter
+            is not recursively forwarded to repeated blocks, see the note.
+
+    Returns:
+        A quantum circuit without any empty moment and with ``REPEAT`` blocks
+        adhering to the conventions detailed in the note above.
+    """
+    ret = stim.Circuit()
+    # Start with a virtual TICK if the user wants to remove empty moments at the
+    # beginning of the provided circuit. Else, any other instruction that is not
+    # a TICK would work and avoid the removal of the first instruction if it is
+    # a TICK.
+    previous_instruction = (
+        stim.CircuitInstruction("TICK")
+        if remove_leading_tick
+        else stim.CircuitInstruction("SHIFT_COORDS", [], [0])
+    )
+    for inst in circuit:
+        # If we have two (or more) consecutive TICK instructions, do not append
+        # any except the first one.
+        if inst.name == previous_instruction.name == "TICK":
+            continue
+        # If we have a REPEAT block, be careful about the conventions.
+        if isinstance(inst, stim.CircuitRepeatBlock):
+            # Check convention 1 about the instruction before the REPEAT instruction
+            if ret[-1].name == "TICK":
+                ret = ret[:-1]
+            # Check conventions 2 and 3 about the repeated block.
+            repeated_block = stim.Circuit("TICK") + remove_empty_moments(
+                inst.body_copy(), remove_leading_tick=True, remove_trailing_tick=True
+            )
+            ret.append(stim.CircuitRepeatBlock(inst.repeat_count, repeated_block))
+        else:
+            ret.append(inst)
+        previous_instruction = inst
+    # If the last instruction is a TICK, that's an empty moment, remove it.
+    if previous_instruction.name == "TICK" and remove_trailing_tick:
+        return ret[:-1]
+    return ret

--- a/src/tqec/post_processing/remove.py
+++ b/src/tqec/post_processing/remove.py
@@ -1,5 +1,8 @@
 import stim
 
+from tqec.circuit.moment import Moment
+from tqec.post_processing.utils.moment import RepeatedMoments
+
 
 def remove_empty_moments(
     circuit: stim.Circuit,
@@ -75,3 +78,20 @@ def remove_empty_moments(
     if previous_instruction.name == "TICK" and remove_trailing_tick:
         return ret[:-1]
     return ret
+
+
+def _remove_empty_moments_inline(moments: list[Moment | RepeatedMoments]) -> None:
+    i = 0
+    while i < len(moments):
+        moment = moments[i]
+        if isinstance(moment, Moment):
+            if moment.is_empty:
+                moments.pop(i)
+            else:
+                i += 1
+        else:
+            _remove_empty_moments_inline(moment.moments)
+            if len(moment.moments) == 0:
+                moments.pop(i)
+            else:
+                i += 1

--- a/src/tqec/post_processing/remove_test.py
+++ b/src/tqec/post_processing/remove_test.py
@@ -1,0 +1,45 @@
+import stim
+
+from tqec.post_processing.remove import remove_empty_moments
+
+
+def test_trivial() -> None:
+    assert remove_empty_moments(stim.Circuit()) == stim.Circuit()
+    assert remove_empty_moments(stim.Circuit("TICK")) == stim.Circuit()
+    assert remove_empty_moments(stim.Circuit("TICK\nTICK")) == stim.Circuit()
+    assert (
+        remove_empty_moments(stim.Circuit("\n".join("TICK" for _ in range(890))))
+        == stim.Circuit()
+    )
+
+
+def test_single_gate() -> None:
+    assert remove_empty_moments(stim.Circuit("TICK\nH 0\nTICK")) == stim.Circuit("H 0")
+    assert remove_empty_moments(stim.Circuit("TICK\nCX 0 1\nTICK")) == stim.Circuit(
+        "CX 0 1"
+    )
+
+
+def test_remove_leading_trailing_tick() -> None:
+    c = stim.Circuit("TICK\nH 0\nTICK")
+    assert remove_empty_moments(c, remove_leading_tick=False) == stim.Circuit(
+        "TICK\nH 0"
+    )
+    assert remove_empty_moments(c, remove_trailing_tick=False) == stim.Circuit(
+        "H 0\nTICK"
+    )
+    assert remove_empty_moments(
+        c, remove_trailing_tick=False, remove_leading_tick=False
+    ) == stim.Circuit("TICK\nH 0\nTICK")
+
+
+def test_within_circuit() -> None:
+    assert remove_empty_moments(
+        stim.Circuit("TICK\nH 0\nTICK\nTICK\nH 1")
+    ) == stim.Circuit("H 0\nTICK\nH 1")
+
+
+def test_repeat_block_conventions() -> None:
+    assert remove_empty_moments(
+        stim.Circuit("H 0\nTICK\nREPEAT 5 {\nH 0\nTICK\n}\nTICK\nH 0")
+    ) == stim.Circuit("H 0\nREPEAT 5 {\nTICK\nH 0\n}\nTICK\nH 0")

--- a/src/tqec/post_processing/utils/moment.py
+++ b/src/tqec/post_processing/utils/moment.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterator
+
+import stim
+
+from tqec.circuit.moment import Moment
+from tqec.circuit.schedule.manipulation import merge_instructions
+
+
+@dataclass
+class RepeatedMoments:
+    repetitions: int
+    moments: list[Moment | RepeatedMoments]
+
+
+def iter_stim_circuit_by_moments(
+    circuit: stim.Circuit, collected_before_use: bool = True
+) -> Iterator[Moment | RepeatedMoments]:
+    copy_func: Callable[[stim.Circuit], stim.Circuit] = (
+        (lambda c: c.copy()) if collected_before_use else (lambda c: c)
+    )
+    cur_moment = stim.Circuit()
+    for inst in circuit:
+        if isinstance(inst, stim.CircuitRepeatBlock):
+            yield Moment(copy_func(cur_moment))
+            cur_moment.clear()
+            yield RepeatedMoments(
+                inst.repeat_count,
+                list(
+                    iter_stim_circuit_by_moments(
+                        inst.body_copy(), collected_before_use=True
+                    )
+                ),
+            )
+        elif inst.name == "TICK":
+            yield Moment(copy_func(cur_moment))
+            cur_moment.clear()
+        else:
+            cur_moment.append(inst)
+    # No need to copy the last moment
+    yield Moment(cur_moment)
+
+
+def collect_moments(moments: list[Moment | RepeatedMoments]) -> stim.Circuit:
+    if not moments:
+        return stim.Circuit()
+
+    ret = stim.Circuit()
+    if isinstance(moments[0], Moment):
+        ret += moments[0].circuit
+    else:
+        repeated_block = stim.Circuit("TICK") + collect_moments(moments[0].moments)
+        ret.append(stim.CircuitRepeatBlock(moments[0].repetitions, repeated_block))
+
+    for i in range(1, len(moments)):
+        moment = moments[i]
+        if isinstance(moment, Moment):
+            ret.append(stim.CircuitInstruction("TICK"))
+            ret += moment.circuit
+        else:
+            repeated_block = stim.Circuit("TICK") + collect_moments(moment.moments)
+            ret.append(stim.CircuitRepeatBlock(moment.repetitions, repeated_block))
+    return ret
+
+
+def merge_moments(lhs: Moment, rhs: Moment) -> Moment:
+    instructions = merge_instructions(list(lhs.instructions) + list(rhs.instructions))
+    circuit = stim.Circuit()
+    for inst in instructions:
+        circuit.append(
+            inst.name,
+            sum(
+                sorted(
+                    inst.target_groups(),
+                    key=lambda group: tuple(t.value for t in group),
+                ),
+                start=[],
+            ),
+            inst.gate_args_copy(),
+        )
+    return Moment(circuit)


### PR DESCRIPTION
This PR implements two post-processing functions for `stim.Circuit`:

- `remove_empty_moments`
- `merge_adjacent_moments`

The implementation of `merge_adjacent_moments` should fix #462.