### PR TITLE
Removing warning when instantiating QubitSpatialCubeTemplate with k=1

### DIFF
--- a/src/tqec/compile/specs/library/generators/spatial_test.py
+++ b/src/tqec/compile/specs/library/generators/spatial_test.py
@@ -6,7 +6,7 @@ import pytest
 from tqec.compile.specs.enums import SpatialArms
 from tqec.plaquette.rpng import RPNGDescription
 from tqec.utils.enums import Basis
-from tqec.utils.exceptions import TQECException, TQECWarning
+from tqec.utils.exceptions import TQECException
 
 from ._testing import (
     get_spatial_cube_arm_rpng_template,
@@ -37,9 +37,7 @@ def test_4_way_spatial_junction() -> None:
         [_EMPT, _EMPT, _EMPT, _EMPT, _EMPT, _3SBR],
     ]
 
-    expected_warning_message = "^Instantiating QubitSpatialCubeTemplate with k=1\\..*"
-    with pytest.warns(TQECWarning, match=expected_warning_message):
-        instantiation = description.instantiate(k=1)
+    instantiation = description.instantiate(k=1)
     assert instantiation == [
         [_3STL, _EMPT, _EMPT, _EMPT],
         [_EMPT, _ZVHE, _XXXX, _EMPT],
@@ -69,9 +67,7 @@ def test_3_way_UP_RIGHT_DOWN_spatial_junction() -> None:
         [_EMPT, _EMPT, _EMPT, _EMPT, _EMPT, _3SBR],
     ]
 
-    expected_warning_message = "^Instantiating QubitSpatialCubeTemplate with k=1\\..*"
-    with pytest.warns(TQECWarning, match=expected_warning_message):
-        instantiation = description.instantiate(k=1)
+    instantiation = description.instantiate(k=1)
     assert instantiation == [
         [__Z_Z, _EMPT, _EMPT, _EMPT],
         [_EMPT, _ZVHE, _XXXX, _EMPT],
@@ -101,9 +97,7 @@ def test_3_way_LEFT_UP_RIGHT_spatial_junction() -> None:
         [_EMPT, _ZZ__, _EMPT, _ZZ__, _EMPT, _ZZ__],
     ]
 
-    expected_warning_message = "^Instantiating QubitSpatialCubeTemplate with k=1\\..*"
-    with pytest.warns(TQECWarning, match=expected_warning_message):
-        instantiation = description.instantiate(k=1)
+    instantiation = description.instantiate(k=1)
     assert instantiation == [
         [_3STL, _EMPT, _EMPT, _EMPT],
         [_EMPT, _ZVHE, _XXXX, _EMPT],
@@ -142,9 +136,7 @@ def test_2_way_L_shape_spatial_junction() -> None:
         [_EMPT, _EMPT, _EMPT, _EMPT, _EMPT, _3SBR],
     ]
 
-    expected_warning_message = "^Instantiating QubitSpatialCubeTemplate with k=1\\..*"
-    with pytest.warns(TQECWarning, match=expected_warning_message):
-        instantiation = description.instantiate(k=1)
+    instantiation = description.instantiate(k=1)
     assert instantiation == [
         [_EMPT, _EMPT, T__ZZ, _EMPT],
         [_EMPT, _3STL, _XXXX, _EMPT],

--- a/src/tqec/templates/qubit.py
+++ b/src/tqec/templates/qubit.py
@@ -1,6 +1,5 @@
 """Defines templates representing logical qubits and its constituent parts."""
 
-import warnings
 from typing import Sequence
 
 import numpy
@@ -9,7 +8,7 @@ from typing_extensions import override
 
 from tqec.templates.base import BorderIndices, RectangularTemplate
 from tqec.templates.enums import TemplateBorder
-from tqec.utils.exceptions import TQECException, TQECWarning
+from tqec.utils.exceptions import TQECException
 from tqec.utils.scale import LinearFunction, PlaquetteScalable2D
 
 
@@ -111,15 +110,6 @@ class QubitSpatialCubeTemplate(RectangularTemplate):
     ) -> npt.NDArray[numpy.int_]:
         if plaquette_indices is None:
             plaquette_indices = list(range(1, self.expected_plaquettes_number + 1))
-
-        if k == 1:
-            warnings.warn(
-                "Instantiating QubitSpatialCubeTemplate with k=1. The "
-                "instantiation array returned will not have any plaquette with "
-                "an index in [13, 17], which might break other parts of the "
-                "library.",
-                TQECWarning,
-            )
 
         shape = self.shape(k)
         ret = numpy.zeros(shape.to_numpy_shape(), dtype=numpy.int_)

--- a/src/tqec/templates/qubit_test.py
+++ b/src/tqec/templates/qubit_test.py
@@ -8,7 +8,7 @@ from tqec.templates.qubit import (
     QubitTemplate,
     QubitVerticalBorders,
 )
-from tqec.utils.exceptions import TQECException, TQECWarning
+from tqec.utils.exceptions import TQECException
 from tqec.utils.scale import LinearFunction, PlaquetteScalable2D
 
 
@@ -180,17 +180,15 @@ def test_vertical_borders_template_borders_indices() -> None:
 def test_qubit_spatial_cube_template_instantiation() -> None:
     template = QubitSpatialCubeTemplate()
 
-    expected_warning_message = "^Instantiating QubitSpatialCubeTemplate with k=1\\..*"
-    with pytest.warns(TQECWarning, match=expected_warning_message):
-        numpy.testing.assert_array_equal(
-            template.instantiate(1),
-            [
-                [1, 9, 10, 2],
-                [11, 5, 6, 18],
-                [12, 7, 8, 19],
-                [3, 20, 21, 4],
-            ],
-        )
+    numpy.testing.assert_array_equal(
+        template.instantiate(1),
+        [
+            [1, 9, 10, 2],
+            [11, 5, 6, 18],
+            [12, 7, 8, 19],
+            [3, 20, 21, 4],
+        ],
+    )
     numpy.testing.assert_array_equal(
         template.instantiate(2),
         [


### PR DESCRIPTION
This PR removes a warning that was not up-to-date when instantiating `QubitSpatialCubeTemplate`.