### PR TITLE
Properly handle shadowed faces

### DIFF
--- a/src/tqec/computation/block_graph.py
+++ b/src/tqec/computation/block_graph.py
@@ -676,7 +676,7 @@ class BlockGraph:
                 pos_map[pipe.v.position],
                 cast(PipeKind, rotated_kind),
             )
-        return rotated.fix_shadowed_faces()
+        return rotated
 
     def fix_shadowed_faces(self) -> BlockGraph:
         """Fix the basis of those shadowed faces of the cubes in the graph.

--- a/src/tqec/computation/block_graph_test.py
+++ b/src/tqec/computation/block_graph_test.py
@@ -118,6 +118,18 @@ def test_block_graph_validate_3d_corner() -> None:
         g.validate()
 
 
+def test_block_graph_validate_ignore_shadowed_faces() -> None:
+    g = BlockGraph()
+    n1 = g.add_cube(Position3D(0, 0, 0), "XXZ")
+    n2 = g.add_cube(Position3D(1, 0, 0), "XXZ")
+    n3 = g.add_cube(Position3D(-1, 0, 0), "XXZ")
+    n4 = g.add_cube(Position3D(0, 0, 1), "ZXX")
+    g.add_pipe(n1, n2)
+    g.add_pipe(n1, n3)
+    g.add_pipe(n1, n4, "ZXO")
+    g.validate()
+
+
 def test_graph_shift() -> None:
     g = BlockGraph()
     g.add_cube(Position3D(0, 0, 1), "ZXZ")

--- a/src/tqec/computation/block_graph_test.py
+++ b/src/tqec/computation/block_graph_test.py
@@ -3,6 +3,7 @@ import pytest
 from tqec.computation.block_graph import BlockGraph
 from tqec.computation.cube import ZXCube
 from tqec.computation.pipe import PipeKind
+from tqec.gallery import cnot
 from tqec.utils.enums import Basis
 from tqec.utils.exceptions import TQECException
 from tqec.utils.position import Direction3D, Position3D
@@ -233,3 +234,10 @@ def test_cnot_graph_rotation(obs_basis: Basis | None) -> None:
 
     # We need to shift the rotated graph in Z direction to match the two
     assert rg.shift_by(dz=2) == rg_from_scratch
+
+
+def test_block_graph_fix_shadowed_faces() -> None:
+    rotated_cnot = cnot().rotate(Direction3D.X, False)
+    fixed = rotated_cnot.fix_shadowed_faces()
+    assert fixed[Position3D(0, 2, -1)].kind == ZXCube.from_str("ZXX")
+    assert fixed[Position3D(1, 1, -2)].kind == ZXCube.from_str("ZXX")

--- a/src/tqec/computation/pipe.py
+++ b/src/tqec/computation/pipe.py
@@ -238,30 +238,6 @@ class Pipe:
         """The direction along which the pipe connects the cubes."""
         return self.kind.direction
 
-    def check_compatible_with_cubes(self) -> None:
-        """Check if the pipe is compatible with the cubes it connects.
-
-        For compatibility, each cube (head and tail) must match the pipe's basis
-        along each direction, except for the direction of the pipe, if the cube is
-        of type :py:class:`~tqec.computation.cube.ZXCube`.
-
-        Raises:
-            TQECException: If the pipe is not compatible with the cubes.
-        """
-        for cube in self:
-            if cube.is_port or cube.is_y_cube:
-                continue
-            assert isinstance(cube.kind, ZXCube)
-            for direction in Direction3D.all_directions():
-                if direction == self.direction:
-                    continue
-                cube_basis = cube.kind.get_basis_along(direction)
-                pipe_basis = self.kind.get_basis_along(direction, cube == self.u)
-                if cube_basis != pipe_basis:
-                    raise TQECException(
-                        f"The pipe is not compatible with the cube {cube} along {direction} direction."
-                    )
-
     def at_head(self, position: Position3D) -> bool:
         """Whether the position is at the head (u) of the pipe."""
         if position == self.u.position:
@@ -273,3 +249,6 @@ class Pipe:
     def __iter__(self) -> Generator[Cube]:
         yield self.u
         yield self.v
+
+    def __str__(self) -> str:
+        return f"{self.u}--({self.kind})--{self.v}"

--- a/src/tqec/computation/pipe_test.py
+++ b/src/tqec/computation/pipe_test.py
@@ -3,7 +3,6 @@ import pytest
 from tqec.computation.cube import Cube, ZXCube
 from tqec.computation.pipe import Pipe, PipeKind
 from tqec.utils.enums import Basis
-from tqec.utils.exceptions import TQECException
 from tqec.utils.position import Direction3D, Position3D
 
 
@@ -66,16 +65,4 @@ def test_pipe() -> None:
     )
     assert pipe.direction == Direction3D.X
     assert pipe.u.position < pipe.v.position
-    pipe.check_compatible_with_cubes()
     assert list(iter(pipe)) == [pipe.u, pipe.v]
-
-
-def test_pipe_compatible() -> None:
-    pipe = Pipe(
-        Cube(Position3D(1, 0, 0), ZXCube.from_str("XXZ")),
-        Cube(Position3D(0, 0, 0), ZXCube.from_str("XXZ")),
-        PipeKind.from_str("OZX"),
-    )
-
-    with pytest.raises(TQECException, match="The pipe is not compatible"):
-        pipe.check_compatible_with_cubes()

--- a/src/tqec/interop/collada/read_write.py
+++ b/src/tqec/interop/collada/read_write.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import pathlib
 from dataclasses import dataclass
 from typing import BinaryIO, Iterable, cast
-import warnings
 
 import collada
 import collada.source
@@ -16,7 +15,7 @@ from tqec.computation.block_graph import BlockGraph, BlockKind, block_kind_from_
 from tqec.computation.cube import CubeKind, Port, YHalfCube
 from tqec.computation.pipe import PipeKind
 from tqec.utils.enums import Basis
-from tqec.utils.exceptions import TQECException, TQECWarning
+from tqec.utils.exceptions import TQECException
 from tqec.interop.collada._geometry import (
     BlockGeometries,
     Face,
@@ -219,14 +218,7 @@ def read_block_graph_from_dae_file(
             port_index += 1
         graph.add_pipe(head_pos, tail_pos, pipe_kind)
 
-    graph_fixed = graph.fix_shadowed_faces()
-    if graph_fixed != graph:
-        warnings.warn(
-            "Some shadowed faces have been fixed. "
-            "Check `BlockGraph.fix_shadowed_faces` for more details.",
-            TQECWarning,
-        )
-    return graph_fixed
+    return graph
 
 
 def write_block_graph_to_dae_file(

--- a/src/tqec/interop/collada/read_write_test.py
+++ b/src/tqec/interop/collada/read_write_test.py
@@ -30,12 +30,12 @@ def rotated_cnot(observable_basis: Basis | None = None) -> BlockGraph:
     nodes = [
         (Position3D(0, 0, 1), "P", "In_Control"),
         (Position3D(0, 1, 1), "ZXX", ""),
-        (Position3D(0, 2, 1), "ZXX", ""),
+        (Position3D(0, 2, 1), "ZZX", ""),
         (Position3D(0, 3, 1), "P", "Out_Control"),
         (Position3D(0, 1, 0), "ZXX", ""),
         (Position3D(0, 2, 0), "ZZX", ""),
         (Position3D(1, 0, 0), "P", "In_Target"),
-        (Position3D(1, 1, 0), "ZXX", ""),
+        (Position3D(1, 1, 0), "ZZX", ""),
         (Position3D(1, 2, 0), "ZZX", ""),
         (Position3D(1, 3, 0), "P", "Out_Target"),
     ]

--- a/src/tqec/utils/position.py
+++ b/src/tqec/utils/position.py
@@ -205,6 +205,11 @@ class Direction3D(Enum):
             f"{source:=} and {sink:=}."
         )
 
+    @property
+    def orthogonal_directions(self) -> tuple[Direction3D, Direction3D]:
+        i = self.value
+        return Direction3D((i + 1) % 3), Direction3D((i + 2) % 3)
+
 
 @dataclass(frozen=True)
 class SignedDirection3D:


### PR DESCRIPTION
Fixes #536.

This PR includes the following changes:

- Do not check colors of shadowed faces when validating the block graph
- Do not fix shadowed faces when importing dae file or rotate block graph, leave it to compilation pipeline
- Add `validate` and `fix_shadowed_faces` at the start of compilation pipeline