### PR TITLE
Correct space time volume definition

### DIFF
--- a/src/tqec/computation/block_graph.py
+++ b/src/tqec/computation/block_graph.py
@@ -110,8 +110,18 @@ class BlockGraph:
         """Get the positions occupied by the cubes in the graph."""
         return list(self._graph.nodes)
 
-    def spacetime_volume(self) -> tuple[int, int, int]:
-        """Return the spacetime volume of the computation.
+    @property
+    def spacetime_volume(self) -> int:
+        """Return the spacetime volume of the computation, i.e. the number of
+        non-port cubes in the graph.
+
+        Returns:
+            The spacetime volume of the computation.
+        """
+        return self.num_cubes - self.num_ports
+
+    def bounding_box_size(self) -> tuple[int, int, int]:
+        """Return the size of the bounding box of the computation structure.
 
         Returns:
             A tuple of three integers representing the width along the X, Y, and Z

--- a/src/tqec/computation/block_graph.py
+++ b/src/tqec/computation/block_graph.py
@@ -89,6 +89,11 @@ class BlockGraph:
         return len([node for node in self.cubes if node.is_port])
 
     @property
+    def num_half_y_cubes(self) -> int:
+        """Number of half Y cubes in the graph."""
+        return len([node for node in self.cubes if node.is_y_cube])
+
+    @property
     def ordered_ports(self) -> list[str]:
         """Get the labels of the ports in the alphabetical order."""
         return sorted(self._ports.keys())
@@ -111,14 +116,18 @@ class BlockGraph:
         return list(self._graph.nodes)
 
     @property
-    def spacetime_volume(self) -> int:
-        """Return the spacetime volume of the computation, i.e. the number of
-        non-port cubes in the graph.
+    def spacetime_volume(self) -> float:
+        """Return the spacetime volume of the computation.
+
+        A port cube and the pipes have no spacetime volume. A half Y cube has a
+        spacetime volume of 0.5. Other cubes have a spacetime volume of 1. The
+        spacetime volume of the block graph is the sum of the spacetime volumes
+        of all the cubes in the graph.
 
         Returns:
             The spacetime volume of the computation.
         """
-        return self.num_cubes - self.num_ports
+        return self.num_cubes - self.num_ports - self.num_half_y_cubes * 0.5
 
     def bounding_box_size(self) -> tuple[int, int, int]:
         """Return the size of the bounding box of the computation structure.

--- a/src/tqec/computation/block_graph_test.py
+++ b/src/tqec/computation/block_graph_test.py
@@ -12,12 +12,14 @@ def test_block_graph_construction() -> None:
     g = BlockGraph()
     assert len(g.cubes) == 0
     assert len(g.pipes) == 0
+    assert g.spacetime_volume == 0
 
 
 def test_block_graph_add_cube() -> None:
     g = BlockGraph()
     v = g.add_cube(Position3D(0, 0, 0), "ZXZ")
     assert g.num_cubes == 1
+    assert g.spacetime_volume == 1
     assert g[v].kind == ZXCube.from_str("ZXZ")
     assert v in g
 
@@ -27,6 +29,7 @@ def test_block_graph_add_cube() -> None:
     v = g.add_cube(Position3D(1, 0, 0), "PORT", "P")
     assert g.num_cubes == 2
     assert g.num_ports == 1
+    assert g.spacetime_volume == 1
     assert g[v].is_port
 
     with pytest.raises(TQECException, match=".* port with the same label .*"):

--- a/src/tqec/gallery/cnot_test.py
+++ b/src/tqec/gallery/cnot_test.py
@@ -10,6 +10,7 @@ def test_cnot_open() -> None:
     g = cnot()
     assert g.num_ports == 4
     assert g.num_cubes == 10
+    assert g.spacetime_volume == 6
     assert g.num_pipes == 9
     assert len(g.leaf_cubes) == 4
     assert {*g.ports.keys()} == {
@@ -18,7 +19,7 @@ def test_cnot_open() -> None:
         "In_Target",
         "Out_Target",
     }
-    assert g.spacetime_volume() == (2, 2, 4)
+    assert g.bounding_box_size() == (2, 2, 4)
 
 
 def test_cnot_open_zx() -> None:

--- a/src/tqec/gallery/cz_test.py
+++ b/src/tqec/gallery/cz_test.py
@@ -11,6 +11,7 @@ def test_cz_open() -> None:
     g = cz()
     assert g.num_ports == 4
     assert g.num_cubes == 6
+    assert g.spacetime_volume == 2
     assert g.num_pipes == 5
     assert len(g.leaf_cubes) == 4
     assert {*g.ports.keys()} == {
@@ -19,7 +20,7 @@ def test_cz_open() -> None:
         "In_2",
         "Out_2",
     }
-    assert g.spacetime_volume() == (2, 3, 3)
+    assert g.bounding_box_size() == (2, 3, 3)
 
 
 def test_cz_open_zx() -> None:

--- a/src/tqec/gallery/move_rotation_test.py
+++ b/src/tqec/gallery/move_rotation_test.py
@@ -9,13 +9,14 @@ def test_move_rotation_open() -> None:
     g = move_rotation()
     assert g.num_ports == 2
     assert g.num_cubes == 5
+    assert g.spacetime_volume == 3
     assert g.num_pipes == 4
     assert len(g.leaf_cubes) == 2
     assert {*g.ports.keys()} == {
         "In",
         "Out",
     }
-    assert g.spacetime_volume() == (2, 2, 3)
+    assert g.bounding_box_size() == (2, 2, 3)
 
 
 def test_move_rotation_open_zx() -> None:

--- a/src/tqec/gallery/three_cnots_test.py
+++ b/src/tqec/gallery/three_cnots_test.py
@@ -9,6 +9,7 @@ def test_three_cnots_OPEN() -> None:
     g = three_cnots()
     assert g.num_ports == 6
     assert g.num_cubes == 12
+    assert g.spacetime_volume == 6
     assert g.num_pipes == 12
     assert len(g.leaf_cubes) == 6
     assert {*g.ports.keys()} == {
@@ -19,7 +20,7 @@ def test_three_cnots_OPEN() -> None:
         "In_c",
         "Out_c",
     }
-    assert g.spacetime_volume() == (4, 3, 4)
+    assert g.bounding_box_size() == (4, 3, 4)
 
 
 def test_three_cnots_open_zx() -> None:


### PR DESCRIPTION
The definition of "spacetime volume" used throughout Austin's lectures is "the number of non-port cubes the computation has". 

Previously, it was defined as "the size of the bounding box of the block graph":

https://github.com/tqec/tqec/blob/06420e1b53f227c2f1b6bcb18524f1e41a3c7d03/src/tqec/computation/block_graph.py#L113-L119

This PR renames it as `bounding_box_size` and add the method `spacetime_volume` with the correct definition.