### PR TITLE
Fix layer approach

### DIFF
--- a/src/tqec/compile/blocks/block.py
+++ b/src/tqec/compile/blocks/block.py
@@ -37,7 +37,10 @@ class Block(SequencedLayers):
     def with_spatial_borders_trimmed(
         self, borders: Iterable[SpatialBlockBorder]
     ) -> Block:
-        return Block(self._layers_with_spatial_borders_trimmed(borders))
+        return Block(
+            self._layers_with_spatial_borders_trimmed(borders),
+            self.trimmed_spatial_borders | frozenset(borders),
+        )
 
     @override
     def with_temporal_borders_replaced(

--- a/src/tqec/compile/blocks/block.py
+++ b/src/tqec/compile/blocks/block.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Final, Iterable, Mapping
 
 from typing_extensions import override
@@ -21,7 +20,6 @@ from tqec.utils.exceptions import TQECException
 from tqec.utils.scale import LinearFunction, PhysicalQubitScalable2D
 
 
-@dataclass
 class Block(SequencedLayers):
     """Encodes the implementation of a block.
 

--- a/src/tqec/compile/blocks/block_test.py
+++ b/src/tqec/compile/blocks/block_test.py
@@ -76,17 +76,12 @@ def logical_qubit_shape_fixture() -> PhysicalQubitScalable2D:
 
 
 def test_creation(
-    plaquette_layer: PlaquetteLayer,
-    raw_circuit_layer: RawCircuitLayer,
-    raw_circuit_fixed_size_layer: RawCircuitLayer,
+    plaquette_layer: PlaquetteLayer, raw_circuit_layer: RawCircuitLayer
 ) -> None:
     # Invalid sequences due to duration < 1
     err_regex = ".*expected to have at least one layer.*"
     with pytest.raises(TQECException, match=err_regex):
         Block([])
-    # Invalid sequence due to different shapes
-    with pytest.raises(TQECException, match="Found at least two different shapes.*"):
-        Block([plaquette_layer, raw_circuit_layer, raw_circuit_fixed_size_layer])
 
     Block([plaquette_layer for _ in range(10)])
     Block(

--- a/src/tqec/compile/blocks/layers/atomic/base.py
+++ b/src/tqec/compile/blocks/layers/atomic/base.py
@@ -43,3 +43,7 @@ class BaseLayer(WithSpatialFootprint, WithTemporalFootprint):
                 "an atomic layer that, by definition, only contain one layer."
             )
         return next(iter(border_replacements.values()))
+
+    @override
+    def get_temporal_layer_on_border(self, border: TemporalBlockBorder) -> BaseLayer:
+        return self

--- a/src/tqec/compile/blocks/layers/atomic/base.py
+++ b/src/tqec/compile/blocks/layers/atomic/base.py
@@ -29,21 +29,10 @@ class BaseLayer(WithSpatialFootprint, WithTemporalFootprint):
         # By definition of a "layer":
         return LinearFunction(0, 1)
 
+    @override
     def with_temporal_borders_replaced(
         self, border_replacements: Mapping[TemporalBlockBorder, BaseLayer | None]
     ) -> BaseLayer | None:
-        """Returns ``self`` with the provided temporal borders replaced.
-
-        Args:
-            borders: a mapping from temporal borders to replace to their
-                replacement. A value of ``None`` as a replacement means that the
-                border is removed.
-
-        Returns:
-            a copy of ``self`` with the provided ``borders`` replaced, or ``None``
-            if replacing the provided ``borders`` from ``self`` result in an
-            empty temporal footprint.
-        """
         if not border_replacements:
             return self
         if len(border_replacements) > 1 and any(

--- a/src/tqec/compile/blocks/layers/atomic/layout.py
+++ b/src/tqec/compile/blocks/layers/atomic/layout.py
@@ -37,23 +37,22 @@ class LayoutLayer(BaseLayer):
         self,
         layers: dict[LayoutPosition2D, BaseLayer],
         element_shape: PhysicalQubitScalable2D,
-        trimmed_spatial_borders: frozenset[SpatialBlockBorder] = frozenset(),
     ) -> None:
         """A layer gluing several other layers together on a 2-dimensional grid.
 
         Args:
-            layers:
+            layers: a mapping from positions on the 2-dimensional space to
+                blocks implementing the circuit that should be present at that
+                position.
+                The mapping is expected to represent a connected computation.
             element_shape: scalable shape (in qubit coordinates) of each entry
                 in the provided ``layers``.
-            trimmed_spatial_borders: all the spatial borders that have been
-                removed from the layer. For this particular class type, this
-                should always be empty.
 
         Raises:
             TQECException: if ``layers`` is empty.
             TQECException: if ``trimmed_spatial_borders`` is not empty.
         """
-        super().__init__(trimmed_spatial_borders)
+        super().__init__(frozenset())
         self._layers = layers
         self._element_shape = element_shape
         self._post_init_check()

--- a/src/tqec/compile/blocks/layers/atomic/layout.py
+++ b/src/tqec/compile/blocks/layers/atomic/layout.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from functools import cached_property
 from typing import Final, Iterable, TypeGuard
 
@@ -33,18 +32,49 @@ def contains_only_plaquette_layers(
     return all(isinstance(layer, PlaquetteLayer) for layer in layers.values())
 
 
-@dataclass(frozen=True)
 class LayoutLayer(BaseLayer):
-    """A layer gluing several other layers together on a 2-dimensional grid."""
+    def __init__(
+        self,
+        layers: dict[LayoutPosition2D, BaseLayer],
+        element_shape: PhysicalQubitScalable2D,
+        trimmed_spatial_borders: frozenset[SpatialBlockBorder] = frozenset(),
+    ) -> None:
+        """A layer gluing several other layers together on a 2-dimensional grid.
 
-    layers: dict[LayoutPosition2D, BaseLayer]
-    element_shape: PhysicalQubitScalable2D
+        Args:
+            layers:
+            element_shape: scalable shape (in qubit coordinates) of each entry
+                in the provided ``layers``.
+            trimmed_spatial_borders: all the spatial borders that have been
+                removed from the layer. For this particular class type, this
+                should always be empty.
 
-    def __post_init__(self) -> None:
+        Raises:
+            TQECException: if ``layers`` is empty.
+            TQECException: if ``trimmed_spatial_borders`` is not empty.
+        """
+        super().__init__(trimmed_spatial_borders)
+        self._layers = layers
+        self._element_shape = element_shape
+        self._post_init_check()
+
+    def _post_init_check(self) -> None:
         if not self.layers:
             raise TQECException(
                 f"An instance of {type(self).__name__} should have at least one layer."
             )
+        if self.trimmed_spatial_borders:
+            raise TQECException(
+                f"{LayoutLayer.__name__} cannot have trimmed spatial borders."
+            )
+
+    @property
+    def layers(self) -> dict[LayoutPosition2D, BaseLayer]:
+        return self._layers
+
+    @property
+    def element_shape(self) -> PhysicalQubitScalable2D:
+        return self._element_shape
 
     @cached_property
     def bounds(self) -> tuple[BlockPosition2D, BlockPosition2D]:

--- a/src/tqec/compile/blocks/layers/atomic/plaquettes.py
+++ b/src/tqec/compile/blocks/layers/atomic/plaquettes.py
@@ -162,7 +162,7 @@ class PlaquetteLayer(BaseLayer):
         return PlaquetteLayer(
             self.template,
             self.plaquettes.without_plaquettes(border_indices),
-            trimmed_spatial_borders=borders,
+            trimmed_spatial_borders=self.trimmed_spatial_borders | borders,
         )
 
     def __eq__(self, value: object) -> bool:

--- a/src/tqec/compile/blocks/layers/atomic/plaquettes.py
+++ b/src/tqec/compile/blocks/layers/atomic/plaquettes.py
@@ -23,25 +23,38 @@ class PlaquetteLayer(BaseLayer):
         self,
         template: RectangularTemplate,
         plaquettes: Plaquettes,
-        spatial_borders_removed: frozenset[SpatialBlockBorder] = frozenset(),
+        trimmed_spatial_borders: frozenset[SpatialBlockBorder] = frozenset(),
     ) -> None:
         """Represents a layer with a template and some plaquettes.
 
         This class implements the layer interface by using a template and some
         plaquettes. This is the preferred way of representing a layer.
 
+        Args:
+            template: template used in conjunction to ``plaquettes`` to
+                represent the quantum circuit implementing the layer.
+            plaquettes: plaquettes used in conjunction to ``template`` to
+                represent the quantum circuit implementing the layer.
+            trimmed_spatial_borders: all the spatial borders that have been
+                removed from the layer.
+
         Raises:
             TQECException: if the provided ``template`` increments do not match
                 with the expected spatial border width.
             TQECException: if the provided ``template`` and
-                ``spatial_borders_removed`` can lead to empty instantiations for
+                ``trimmed_spatial_borders`` can lead to empty instantiations for
                 ``k >= 1``.
         """
-        super().__init__()
+        super().__init__(trimmed_spatial_borders)
+        self._template = template
+        self._plaquettes = plaquettes
+        self._post_init_check()
+
+    def _post_init_check(self) -> None:
         # Shortening variable name for convenience
         EW: Final[int] = EXPECTED_SPATIAL_BORDER_WIDTH
         expected_shifts = Shift2D(EW, EW)
-        if (shifts := template.get_increments()) != expected_shifts:
+        if (shifts := self._template.get_increments()) != expected_shifts:
             raise TQECException(
                 f"Spatial borders are expected to be {EW} qubits large. Got a "
                 f"Template instance with {shifts:=}. Removing a border from "
@@ -50,12 +63,14 @@ class PlaquetteLayer(BaseLayer):
             )
         # We require the template shape to be strictly positive for any value of
         # k > 0.
-        shape = PlaquetteLayer._get_template_shape(template, spatial_borders_removed)
+        shape = PlaquetteLayer._get_template_shape(
+            self._template, self.trimmed_spatial_borders
+        )
         shape1 = shape.to_numpy_shape(1)
         # Check that the shape is valid (i.e., strictly positive) for k == 1.
         if not all(coord > 0 for coord in shape1):
             raise TQECException(
-                "The provided template/spatial_borders_removed combo leads to an "
+                "The provided template/trimmed_spatial_borders combo leads to an "
                 f"invalid template shape ({shape1}) for k == 1. "
                 f"{PlaquetteLayer.__name__} instances do not support empty templates."
             )
@@ -67,10 +82,6 @@ class PlaquetteLayer(BaseLayer):
                 "which will eventually lead to an empty instantiation, which is "
                 f"not supported by {PlaquetteLayer.__name__} instances."
             )
-
-        self._template = template
-        self._plaquettes = plaquettes
-        self._spatial_borders_removed = spatial_borders_removed
 
     @staticmethod
     def _get_number_of_plaquettes(axis: Literal["X", "Y"], increments: int) -> int:
@@ -129,7 +140,7 @@ class PlaquetteLayer(BaseLayer):
     @override
     def scalable_shape(self) -> PhysicalQubitScalable2D:
         tshape = PlaquetteLayer._get_template_shape(
-            self.template, self._spatial_borders_removed
+            self.template, self.trimmed_spatial_borders
         )
         initial_qubit_offset = PhysicalQubitScalable2D(
             LinearFunction(0, 1), LinearFunction(0, 1)
@@ -151,7 +162,7 @@ class PlaquetteLayer(BaseLayer):
         return PlaquetteLayer(
             self.template,
             self.plaquettes.without_plaquettes(border_indices),
-            spatial_borders_removed=borders,
+            trimmed_spatial_borders=borders,
         )
 
     def __eq__(self, value: object) -> bool:
@@ -159,5 +170,4 @@ class PlaquetteLayer(BaseLayer):
             isinstance(value, PlaquetteLayer)
             and self._template == value._template
             and self._plaquettes == value._plaquettes
-            and self._spatial_borders_removed == value._spatial_borders_removed
         )

--- a/src/tqec/compile/blocks/layers/atomic/plaquettes_test.py
+++ b/src/tqec/compile/blocks/layers/atomic/plaquettes_test.py
@@ -23,19 +23,19 @@ def test_creation() -> None:
     PlaquetteLayer(
         large_template,
         plaquettes,
-        spatial_borders_removed=frozenset([SpatialBlockBorder.X_NEGATIVE]),
+        trimmed_spatial_borders=frozenset([SpatialBlockBorder.X_NEGATIVE]),
     )
     PlaquetteLayer(
         large_template,
         plaquettes,
-        spatial_borders_removed=frozenset(SpatialBlockBorder),
+        trimmed_spatial_borders=frozenset(SpatialBlockBorder),
     )
 
     with pytest.raises(TQECException):
         PlaquetteLayer(
             template,
             plaquettes,
-            spatial_borders_removed=frozenset([SpatialBlockBorder.X_NEGATIVE]),
+            trimmed_spatial_borders=frozenset([SpatialBlockBorder.X_NEGATIVE]),
         )
 
 
@@ -52,14 +52,14 @@ def test_scalable_shape() -> None:
     assert PlaquetteLayer(
         large_template,
         plaquettes,
-        spatial_borders_removed=frozenset([SpatialBlockBorder.X_NEGATIVE]),
+        trimmed_spatial_borders=frozenset([SpatialBlockBorder.X_NEGATIVE]),
     ).scalable_shape == PhysicalQubitScalable2D(
         LinearFunction(0, 19), LinearFunction(0, 21)
     )
     assert PlaquetteLayer(
         large_template,
         plaquettes,
-        spatial_borders_removed=frozenset(SpatialBlockBorder),
+        trimmed_spatial_borders=frozenset(SpatialBlockBorder),
     ).scalable_shape == PhysicalQubitScalable2D(
         LinearFunction(0, 17), LinearFunction(0, 17)
     )

--- a/src/tqec/compile/blocks/layers/atomic/raw.py
+++ b/src/tqec/compile/blocks/layers/atomic/raw.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Callable, Iterable
 
 from typing_extensions import override
@@ -11,13 +10,35 @@ from tqec.compile.blocks.layers.atomic.base import BaseLayer
 from tqec.utils.scale import PhysicalQubitScalable2D
 
 
-@dataclass
 class RawCircuitLayer(BaseLayer):
-    """Represents a layer with a spatial footprint that is defined by a raw
-    circuit."""
+    def __init__(
+        self,
+        circuit_factory: Callable[[int], ScheduledCircuit],
+        scalable_raw_shape: PhysicalQubitScalable2D,
+        trimmed_spatial_borders: frozenset[SpatialBlockBorder] = frozenset(),
+    ):
+        """Represents a layer with a spatial footprint that is defined by a raw
+        circuit.
 
-    circuit_factory: Callable[[int], ScheduledCircuit]
-    scalable_raw_shape: PhysicalQubitScalable2D
+        Args:
+            circuit_factory: a function callable returning a quantum circuit for
+                any input ``k >= 1``.
+            scalable_raw_shape: scalable shape of the quantum circuit returned
+                by the provided ``circuit_factory``.
+            trimmed_spatial_borders: all the spatial borders that have been
+                removed from the layer.
+        """
+        super().__init__(trimmed_spatial_borders)
+        self._circuit_factory = circuit_factory
+        self._scalable_raw_shape = scalable_raw_shape
+
+    @property
+    def scalable_raw_shape(self) -> PhysicalQubitScalable2D:
+        return self._scalable_raw_shape
+
+    @property
+    def circuit_factory(self) -> Callable[[int], ScheduledCircuit]:
+        return self._circuit_factory
 
     @property
     @override

--- a/src/tqec/compile/blocks/layers/composed/base.py
+++ b/src/tqec/compile/blocks/layers/composed/base.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Iterable, Mapping
+from typing import TYPE_CHECKING, Iterable
 
-from tqec.compile.blocks.enums import TemporalBlockBorder
 from tqec.compile.blocks.layers.atomic.base import BaseLayer
 from tqec.compile.blocks.layers.spatial import WithSpatialFootprint
 from tqec.compile.blocks.layers.temporal import WithTemporalFootprint
@@ -29,24 +28,6 @@ class BaseComposedLayer(WithSpatialFootprint, WithTemporalFootprint):
         Returns:
             All the base layers represented by the instance. The returned
             iterable should have as many entries as ``self.timesteps(k)``.
-        """
-        pass
-
-    @abstractmethod
-    def with_temporal_borders_replaced(
-        self, border_replacements: Mapping[TemporalBlockBorder, BaseLayer | None]
-    ) -> BaseLayer | BaseComposedLayer | None:
-        """Returns ``self`` with the provided temporal borders replaced.
-
-        Args:
-            borders: a mapping from temporal borders to replace to their
-                replacement. A value of ``None`` as a replacement means that the
-                border is removed.
-
-        Returns:
-            a copy of ``self`` with the provided ``borders`` replaced, or ``None``
-            if replacing the provided ``borders`` from ``self`` result in an
-            empty temporal footprint.
         """
         pass
 

--- a/src/tqec/compile/blocks/layers/composed/repeated.py
+++ b/src/tqec/compile/blocks/layers/composed/repeated.py
@@ -216,3 +216,7 @@ class RepeatedLayer(BaseComposedLayer):
             and self.repetitions == value.repetitions
             and self.internal_layer == value.internal_layer
         )
+
+    @override
+    def get_temporal_layer_on_border(self, border: TemporalBlockBorder) -> BaseLayer:
+        return self.internal_layer.get_temporal_layer_on_border(border)

--- a/src/tqec/compile/blocks/layers/composed/repeated.py
+++ b/src/tqec/compile/blocks/layers/composed/repeated.py
@@ -96,7 +96,9 @@ class RepeatedLayer(BaseComposedLayer):
         self, borders: Iterable[SpatialBlockBorder]
     ) -> RepeatedLayer:
         return RepeatedLayer(
-            self.internal_layer.with_spatial_borders_trimmed(borders), self.repetitions
+            self.internal_layer.with_spatial_borders_trimmed(borders),
+            self.repetitions,
+            self.trimmed_spatial_borders | frozenset(borders),
         )
 
     @staticmethod

--- a/src/tqec/compile/blocks/layers/composed/repeated.py
+++ b/src/tqec/compile/blocks/layers/composed/repeated.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from itertools import chain
 from typing import Iterable, Mapping
 
@@ -14,22 +13,46 @@ from tqec.utils.exceptions import TQECException
 from tqec.utils.scale import LinearFunction, PhysicalQubitScalable2D, round_or_fail
 
 
-@dataclass
 class RepeatedLayer(BaseComposedLayer):
-    """Composed layer implementing repetition.
+    def __init__(
+        self,
+        internal_layer: BaseLayer | BaseComposedLayer,
+        repetitions: LinearFunction,
+        trimmed_spatial_borders: frozenset[SpatialBlockBorder] = frozenset(),
+    ):
+        """Composed layer implementing repetition.
 
-    This composed layer repeats another layer (that can be atomic or composed)
-    multiple times.
+        This composed layer repeats another layer (that can be atomic or composed)
+        multiple times.
 
-    Attributes:
-        internal_layer: repeated layer.
-        repetitions: number of repetitions to perform. Can scale with ``k``.
-    """
+        Args:
+            internal_layer: repeated layer.
+            repetitions: number of repetitions to perform. Can scale with ``k``.
+            trimmed_spatial_borders: all the spatial borders that have been
+                removed from the layer.
 
-    internal_layer: BaseLayer | BaseComposedLayer
-    repetitions: LinearFunction
+        Raises:
+            TQECException: if the total number of timesteps is not a linear
+                function (i.e., ``internal_layer.scalable_timesteps.slope != 0``
+                and ``repetitions.slope != 0``).
+            TQECException: if the total number of timesteps is strictly
+                decreasing.
+        """
 
-    def __post_init__(self) -> None:
+        super().__init__(trimmed_spatial_borders)
+        self._internal_layer = internal_layer
+        self._repetitions = repetitions
+        self._post_init_check()
+
+    @property
+    def internal_layer(self) -> BaseLayer | BaseComposedLayer:
+        return self._internal_layer
+
+    @property
+    def repetitions(self) -> LinearFunction:
+        return self._repetitions
+
+    def _post_init_check(self) -> None:
         # Check that the number of timesteps of self is a linear function.
         if (
             self.internal_layer.scalable_timesteps.slope != 0

--- a/src/tqec/compile/blocks/layers/composed/sequenced.py
+++ b/src/tqec/compile/blocks/layers/composed/sequenced.py
@@ -156,3 +156,7 @@ class SequencedLayers(BaseComposedLayer):
             isinstance(value, SequencedLayers)
             and self.layer_sequence == value.layer_sequence
         )
+
+    @override
+    def get_temporal_layer_on_border(self, border: TemporalBlockBorder) -> BaseLayer:
+        return self._layer_sequence[0].get_temporal_layer_on_border(border)

--- a/src/tqec/compile/blocks/layers/composed/sequenced.py
+++ b/src/tqec/compile/blocks/layers/composed/sequenced.py
@@ -86,7 +86,10 @@ class SequencedLayers(BaseComposedLayer):
     def with_spatial_borders_trimmed(
         self, borders: Iterable[SpatialBlockBorder]
     ) -> SequencedLayers:
-        return SequencedLayers(self._layers_with_spatial_borders_trimmed(borders))
+        return SequencedLayers(
+            self._layers_with_spatial_borders_trimmed(borders),
+            self.trimmed_spatial_borders | frozenset(borders),
+        )
 
     def _layers_with_temporal_borders_replaced(
         self, border_replacements: Mapping[TemporalBlockBorder, BaseLayer | None]

--- a/src/tqec/compile/blocks/layers/composed/sequenced.py
+++ b/src/tqec/compile/blocks/layers/composed/sequenced.py
@@ -162,4 +162,6 @@ class SequencedLayers(BaseComposedLayer):
 
     @override
     def get_temporal_layer_on_border(self, border: TemporalBlockBorder) -> BaseLayer:
-        return self._layer_sequence[0].get_temporal_layer_on_border(border)
+        return self._layer_sequence[
+            0 if border == TemporalBlockBorder.Z_NEGATIVE else -1
+        ].get_temporal_layer_on_border(border)

--- a/src/tqec/compile/blocks/layers/composed/sequenced_test.py
+++ b/src/tqec/compile/blocks/layers/composed/sequenced_test.py
@@ -48,19 +48,12 @@ def raw_circuit_fixed_size_layer_fixture() -> RawCircuitLayer:
 
 
 def test_creation(
-    plaquette_layer: PlaquetteLayer,
-    raw_circuit_layer: RawCircuitLayer,
-    raw_circuit_fixed_size_layer: RawCircuitLayer,
+    plaquette_layer: PlaquetteLayer, raw_circuit_layer: RawCircuitLayer
 ) -> None:
     # Invalid sequences due to duration < 1
     err_regex = ".*expected to have at least one layer.*"
     with pytest.raises(TQECException, match=err_regex):
         SequencedLayers([])
-    # Invalid sequence due to different shapes
-    with pytest.raises(TQECException, match="Found at least two different shapes.*"):
-        SequencedLayers(
-            [plaquette_layer, raw_circuit_layer, raw_circuit_fixed_size_layer]
-        )
 
     SequencedLayers([plaquette_layer for _ in range(10)])
     SequencedLayers(

--- a/src/tqec/compile/blocks/layers/merge_test.py
+++ b/src/tqec/compile/blocks/layers/merge_test.py
@@ -328,6 +328,11 @@ def test_merge_composed_layers_unknown_layer_type(
         ) -> SequencedLayers:
             raise NotImplementedError()
 
+        def get_temporal_layer_on_border(
+            self, border: TemporalBlockBorder
+        ) -> BaseLayer:
+            raise NotImplementedError()
+
     plaquette_layer, plaquette_layer2, raw_layer = base_layers
     b00 = LayoutPosition2D.from_block_position(BlockPosition2D(0, 0))
     b01 = LayoutPosition2D.from_block_position(BlockPosition2D(0, 1))

--- a/src/tqec/compile/blocks/layers/merge_test.py
+++ b/src/tqec/compile/blocks/layers/merge_test.py
@@ -113,9 +113,6 @@ def test_merge_repeated_layers_different_inner_durations(
     )
     assert isinstance(merged_layer, RepeatedLayer)
     assert merged_layer.scalable_timesteps == LinearFunction(2, 2)
-    assert merged_layer.scalable_shape == PhysicalQubitScalable2D(
-        logical_qubit_shape.x, 2 * logical_qubit_shape.y - 1
-    )
     assert merged_layer.repetitions == LinearFunction(1, 1)
     assert isinstance(merged_layer.internal_layer, SequencedLayers)
     assert merged_layer.internal_layer.scalable_timesteps == LinearFunction(0, 2)
@@ -161,9 +158,6 @@ def test_merge_sequenced_layers(
     )
     assert isinstance(merged_layer, SequencedLayers)
     assert merged_layer.scalable_timesteps == LinearFunction(0, 2)
-    assert merged_layer.scalable_shape == PhysicalQubitScalable2D(
-        2 * logical_qubit_shape.x - 1, 2 * logical_qubit_shape.y - 1
-    )
     assert merged_layer.layer_sequence == [
         LayoutLayer(
             {b00: plaquette_layer, b01: plaquette_layer2, b11: raw_layer},
@@ -199,9 +193,6 @@ def test_merge_sequenced_layers_composed(
     )
     assert isinstance(merged_layer, SequencedLayers)
     assert merged_layer.scalable_timesteps == LinearFunction(0, 3)
-    assert merged_layer.scalable_shape == PhysicalQubitScalable2D(
-        2 * logical_qubit_shape.x - 1, 2 * logical_qubit_shape.y - 1
-    )
     assert merged_layer.layer_sequence == [
         SequencedLayers(
             [
@@ -269,9 +260,6 @@ def test_merge_repeated_and_sequenced_layers(
     )
     assert isinstance(merged_layer, SequencedLayers)
     assert merged_layer.scalable_timesteps == LinearFunction(2, 2)
-    assert merged_layer.scalable_shape == PhysicalQubitScalable2D(
-        logical_qubit_shape.x, 2 * logical_qubit_shape.y - 1
-    )
     assert merged_layer.layer_sequence == [
         LayoutLayer({b00: plaquette_layer, b01: plaquette_layer}, logical_qubit_shape),
         RepeatedLayer(

--- a/src/tqec/compile/blocks/layers/spatial.py
+++ b/src/tqec/compile/blocks/layers/spatial.py
@@ -26,6 +26,18 @@ class WithSpatialFootprint(ABC):
     """Base class providing the interface that should be implemented by objects
     that have a spatial footprint."""
 
+    def __init__(
+        self, trimmed_spatial_borders: frozenset[SpatialBlockBorder] = frozenset()
+    ):
+        """Initialise the instance.
+
+        Args:
+            removed_spatial_borders: all the spatial borders that have been
+                trimmed from the layer.
+        """
+        super().__init__()
+        self._trimmed_spatial_borders = trimmed_spatial_borders
+
     @property
     @abstractmethod
     def scalable_shape(self) -> PhysicalQubitScalable2D:
@@ -70,3 +82,7 @@ class WithSpatialFootprint(ABC):
             a copy of ``self`` with the provided ``borders`` removed.
         """
         pass
+
+    @property
+    def trimmed_spatial_borders(self) -> frozenset[SpatialBlockBorder]:
+        return self._trimmed_spatial_borders

--- a/src/tqec/compile/blocks/layers/temporal.py
+++ b/src/tqec/compile/blocks/layers/temporal.py
@@ -60,3 +60,7 @@ class WithTemporalFootprint(ABC):
             empty temporal footprint.
         """
         pass
+
+    @abstractmethod
+    def get_temporal_layer_on_border(self, border: TemporalBlockBorder) -> BaseLayer:
+        pass

--- a/src/tqec/compile/blocks/layers/temporal.py
+++ b/src/tqec/compile/blocks/layers/temporal.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Mapping
 
+from tqec.compile.blocks.enums import TemporalBlockBorder
 from tqec.utils.scale import LinearFunction
+
+if TYPE_CHECKING:
+    # Avoid circular dependency just because of typing annotations.
+    from tqec.compile.blocks.layers.atomic.base import BaseLayer
+    from tqec.compile.blocks.layers.composed.base import BaseComposedLayer
 
 
 class WithTemporalFootprint(ABC):
@@ -35,3 +42,21 @@ class WithTemporalFootprint(ABC):
             the provided scaling parameter ``k``.
         """
         return self.scalable_timesteps.integer_eval(k)
+
+    @abstractmethod
+    def with_temporal_borders_replaced(
+        self, border_replacements: Mapping[TemporalBlockBorder, BaseLayer | None]
+    ) -> BaseLayer | BaseComposedLayer | None:
+        """Returns ``self`` with the provided temporal borders replaced.
+
+        Args:
+            borders: a mapping from temporal borders to replace to their
+                replacement. A value of ``None`` as a replacement means that the
+                border is removed.
+
+        Returns:
+            a copy of ``self`` with the provided ``borders`` replaced, or ``None``
+            if replacing the provided ``borders`` from ``self`` result in an
+            empty temporal footprint.
+        """
+        pass

--- a/src/tqec/compile/blocks/positioning.py
+++ b/src/tqec/compile/blocks/positioning.py
@@ -6,7 +6,7 @@ from typing import Generic
 from typing_extensions import Self, TypeVar
 
 from tqec.utils.exceptions import TQECException
-from tqec.utils.position import BlockPosition2D, BlockPosition3D
+from tqec.utils.position import BlockPosition2D, BlockPosition3D, SignedDirection3D
 
 
 class LayoutPosition2D(ABC):
@@ -132,6 +132,19 @@ class LayoutPosition3D(ABC, Generic[T]):
         u, v = sorted(pipe_position)
         assert u.is_neighbour(v)
         assert u < v
+        return LayoutPosition3D(
+            LayoutPosition2D.from_pipe_position((u.as_2d(), v.as_2d())), u.z
+        )
+
+    @staticmethod
+    def from_block_and_signed_direction(
+        pos: BlockPosition3D, dir: SignedDirection3D
+    ) -> LayoutPosition3D[LayoutPipePosition2D]:
+        neighbour = pos.shift_in_direction(
+            dir.direction, 1 if dir.towards_positive else -1
+        )
+        u, v = sorted((pos, neighbour))
+        assert u.is_neighbour(v)
         return LayoutPosition3D(
             LayoutPosition2D.from_pipe_position((u.as_2d(), v.as_2d())), u.z
         )

--- a/src/tqec/compile/graph_test.py
+++ b/src/tqec/compile/graph_test.py
@@ -114,3 +114,16 @@ def test_add_temporal_pipe_with_spatial_pipe_existing(
     graph.add_pipe(BlockPosition3D(0, 1, 0), BlockPosition3D(0, 1, 1), XZO)
 
     graph.to_layer_tree()
+
+
+def test_sequenced_layers_with_layout_layers_of_different_shapes(
+    scalable_qubit_shape: PhysicalQubitScalable2D, XZZ: Block, XOZ: Block, XZO: Block
+) -> None:
+    graph = TopologicalComputationGraph(scalable_qubit_shape)
+    graph.add_cube(BlockPosition3D(0, 0, 0), XZZ)
+    graph.add_cube(BlockPosition3D(0, 0, 1), XZZ)
+    graph.add_cube(BlockPosition3D(0, 1, 1), XZZ)
+    graph.add_pipe(BlockPosition3D(0, 0, 0), BlockPosition3D(0, 0, 1), XZO)
+    graph.add_pipe(BlockPosition3D(0, 0, 1), BlockPosition3D(0, 1, 1), XOZ)
+
+    graph.to_layer_tree()

--- a/src/tqec/compile/graph_test.py
+++ b/src/tqec/compile/graph_test.py
@@ -1,0 +1,116 @@
+import pytest
+
+from tqec.compile.blocks.block import Block
+from tqec.compile.blocks.layers.atomic.plaquettes import PlaquetteLayer
+from tqec.compile.blocks.layers.composed.repeated import RepeatedLayer
+from tqec.compile.graph import TopologicalComputationGraph
+from tqec.compile.specs.library.generators.memory import (
+    get_memory_horizontal_boundary_plaquettes,
+    get_memory_horizontal_boundary_raw_template,
+    get_memory_qubit_plaquettes,
+    get_memory_qubit_raw_template,
+    get_memory_vertical_boundary_plaquettes,
+    get_memory_vertical_boundary_raw_template,
+)
+from tqec.utils.enums import Basis
+from tqec.utils.position import BlockPosition3D
+from tqec.utils.scale import LinearFunction, PhysicalQubitScalable2D
+
+
+@pytest.fixture(name="scalable_qubit_shape")
+def scalable_qubit_shape_fixture() -> PhysicalQubitScalable2D:
+    return PhysicalQubitScalable2D(LinearFunction(4, 5), LinearFunction(4, 5))
+
+
+@pytest.fixture(name="XZZ")
+def XZZ_fixture() -> Block:
+    return Block(
+        [
+            PlaquetteLayer(
+                get_memory_qubit_raw_template(),
+                get_memory_qubit_plaquettes(reset=Basis.Z),
+            ),
+            RepeatedLayer(
+                PlaquetteLayer(
+                    get_memory_qubit_raw_template(), get_memory_qubit_plaquettes()
+                ),
+                repetitions=LinearFunction(2, -1),
+            ),
+            PlaquetteLayer(
+                get_memory_qubit_raw_template(),
+                get_memory_qubit_plaquettes(measurement=Basis.Z),
+            ),
+        ]
+    )
+
+
+@pytest.fixture(name="XZO")
+def XZO_fixture() -> Block:
+    return Block(
+        [
+            PlaquetteLayer(
+                get_memory_qubit_raw_template(),
+                get_memory_qubit_plaquettes(),
+            )
+            for _ in range(2)
+        ]
+    )
+
+
+@pytest.fixture(name="OZZ")
+def OZZ_fixture() -> Block:
+    return Block(
+        [
+            PlaquetteLayer(
+                get_memory_vertical_boundary_raw_template(),
+                get_memory_vertical_boundary_plaquettes(reset=Basis.Z),
+            ),
+            RepeatedLayer(
+                PlaquetteLayer(
+                    get_memory_vertical_boundary_raw_template(),
+                    get_memory_vertical_boundary_plaquettes(),
+                ),
+                repetitions=LinearFunction(2, -1),
+            ),
+            PlaquetteLayer(
+                get_memory_vertical_boundary_raw_template(),
+                get_memory_vertical_boundary_plaquettes(measurement=Basis.Z),
+            ),
+        ]
+    )
+
+
+@pytest.fixture(name="XOZ")
+def XOZ_fixture() -> Block:
+    return Block(
+        [
+            PlaquetteLayer(
+                get_memory_horizontal_boundary_raw_template(),
+                get_memory_horizontal_boundary_plaquettes(reset=Basis.Z),
+            ),
+            RepeatedLayer(
+                PlaquetteLayer(
+                    get_memory_horizontal_boundary_raw_template(),
+                    get_memory_horizontal_boundary_plaquettes(),
+                ),
+                repetitions=LinearFunction(2, -1),
+            ),
+            PlaquetteLayer(
+                get_memory_horizontal_boundary_raw_template(),
+                get_memory_horizontal_boundary_plaquettes(measurement=Basis.Z),
+            ),
+        ]
+    )
+
+
+def test_add_temporal_pipe_with_spatial_pipe_existing(
+    scalable_qubit_shape: PhysicalQubitScalable2D, XZZ: Block, XOZ: Block, XZO: Block
+) -> None:
+    graph = TopologicalComputationGraph(scalable_qubit_shape)
+    graph.add_cube(BlockPosition3D(0, 0, 0), XZZ)
+    graph.add_cube(BlockPosition3D(0, 1, 0), XZZ)
+    graph.add_cube(BlockPosition3D(0, 1, 1), XZZ)
+    graph.add_pipe(BlockPosition3D(0, 0, 0), BlockPosition3D(0, 1, 0), XOZ)
+    graph.add_pipe(BlockPosition3D(0, 1, 0), BlockPosition3D(0, 1, 1), XZO)
+
+    graph.to_layer_tree()

--- a/src/tqec/templates/enums.py
+++ b/src/tqec/templates/enums.py
@@ -1,5 +1,7 @@
 """Defines enumerations that are only used in :mod:`tqec.templates`."""
 
+from __future__ import annotations
+
 from enum import Enum, auto
 from typing import Literal
 
@@ -20,3 +22,14 @@ class TemplateBorder(Enum):
     BOTTOM = auto()
     LEFT = auto()
     RIGHT = auto()
+
+    def opposite(self) -> TemplateBorder:
+        match self:
+            case TemplateBorder.TOP:
+                return TemplateBorder.BOTTOM
+            case TemplateBorder.BOTTOM:
+                return TemplateBorder.TOP
+            case TemplateBorder.LEFT:
+                return TemplateBorder.RIGHT
+            case TemplateBorder.RIGHT:
+                return TemplateBorder.LEFT

--- a/src/tqec/utils/position.py
+++ b/src/tqec/utils/position.py
@@ -32,6 +32,7 @@ from enum import Enum
 
 import numpy as np
 import numpy.typing as npt
+from typing_extensions import Self
 
 from tqec.utils.exceptions import TQECException
 
@@ -128,11 +129,11 @@ class Position3D(Vec3D):
     y: int
     z: int
 
-    def shift_by(self, dx: int = 0, dy: int = 0, dz: int = 0) -> Position3D:
+    def shift_by(self, dx: int = 0, dy: int = 0, dz: int = 0) -> Self:
         """Shift the position by the given offset."""
-        return Position3D(self.x + dx, self.y + dy, self.z + dz)
+        return self.__class__(self.x + dx, self.y + dy, self.z + dz)
 
-    def shift_in_direction(self, direction: Direction3D, shift: int) -> Position3D:
+    def shift_in_direction(self, direction: Direction3D, shift: int) -> Self:
         """Shift the position in the given direction by the given shift."""
         if direction == Direction3D.X:
             return self.shift_by(dx=shift)


### PR DESCRIPTION
This PR fixes #539.

- [x] Allow adding a temporal pipe on a block with existing spatial pipes,
- [x] Avoid requiring the same spatial shapes in `SequencedLayers`.

Note that the second issue was solved by simply delaying the "same `scalable_shape`" check to when `SequencedLayers.scalable_shape` is called, which is fine for the moment because we never call that property after merging the layers, and the only supported way to get a `LayoutLayer` is by merging the layers.
