### PR TITLE
Add debug information to `Plaquette`

### DIFF
--- a/src/tqec/plaquette/compilation/base.py
+++ b/src/tqec/plaquette/compilation/base.py
@@ -5,6 +5,10 @@ from typing import Callable, Final, Iterable
 
 from tqec.plaquette.compilation.passes.base import CompilationPass
 from tqec.plaquette.plaquette import Plaquette
+from tqec.utils.instructions import (
+    MEASUREMENT_INSTRUCTION_NAMES,
+    RESET_INSTRUCTION_NAMES,
+)
 
 
 class PlaquetteCompiler:
@@ -40,9 +44,10 @@ class PlaquetteCompiler:
             plaquette.qubits,
             circuit,
             self._mergeable_instructions_modifier(plaquette.mergeable_instructions),
+            plaquette.debug_information,
         )
 
 
 IdentityPlaquetteCompiler: Final[PlaquetteCompiler] = PlaquetteCompiler(
-    "ID", [], lambda x: x
+    "ID", [], lambda x: x | MEASUREMENT_INSTRUCTION_NAMES | RESET_INSTRUCTION_NAMES
 )

--- a/src/tqec/plaquette/debug.py
+++ b/src/tqec/plaquette/debug.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tqec.plaquette.enums import PlaquetteOrientation
+from tqec.plaquette.rpng.rpng import RPNG, RPNGDescription
+
+
+@dataclass(frozen=True)
+class PlaquetteDebugInformation:
+    rpng: RPNGDescription | None = None
+
+    def project_on_boundary(
+        self, projected_orientation: PlaquetteOrientation
+    ) -> PlaquetteDebugInformation:
+        if self.rpng is None:
+            return self
+        corners: list[RPNG] = list(self.rpng.corners)
+        empty_rpng = RPNG.from_string("----")
+        match projected_orientation:
+            case PlaquetteOrientation.UP:
+                corners[0] = corners[1] = empty_rpng
+            case PlaquetteOrientation.DOWN:
+                corners[2] = corners[3] = empty_rpng
+            case PlaquetteOrientation.LEFT:
+                corners[1] = corners[3] = empty_rpng
+            case PlaquetteOrientation.RIGHT:
+                corners[0] = corners[2] = empty_rpng
+        return PlaquetteDebugInformation(
+            RPNGDescription(
+                (corners[0], corners[1], corners[2], corners[3]), self.rpng.ancilla
+            )
+        )

--- a/src/tqec/plaquette/plaquette.py
+++ b/src/tqec/plaquette/plaquette.py
@@ -7,6 +7,7 @@ from typing import Callable, Collection, Iterable, Literal, Mapping
 from typing_extensions import override
 
 from tqec.circuit.schedule import ScheduledCircuit
+from tqec.plaquette.debug import PlaquetteDebugInformation
 from tqec.plaquette.enums import PlaquetteOrientation
 from tqec.plaquette.qubit import PlaquetteQubits
 from tqec.utils.exceptions import TQECException
@@ -49,6 +50,7 @@ class Plaquette:
     qubits: PlaquetteQubits
     circuit: ScheduledCircuit
     mergeable_instructions: frozenset[str] = field(default_factory=frozenset)
+    debug_information: PlaquetteDebugInformation | None = None
 
     def __post_init__(self) -> None:
         plaquette_qubits = set(self.qubits)
@@ -102,11 +104,15 @@ class Plaquette:
         new_scheduled_circuit = self.circuit.filter_by_qubits(
             new_plaquette_qubits.all_qubits
         )
+        debug_info = self.debug_information
+        if debug_info is not None:
+            debug_info = debug_info.project_on_boundary(projected_orientation)
         return Plaquette(
             f"{self.name}_{projected_orientation.name}",
             new_plaquette_qubits,
             new_scheduled_circuit,
             self.mergeable_instructions,
+            debug_info,
         )
 
     def reliable_hash(self) -> int:

--- a/src/tqec/plaquette/rpng/translators/default.py
+++ b/src/tqec/plaquette/rpng/translators/default.py
@@ -5,6 +5,7 @@ import stim
 from typing_extensions import override
 
 from tqec.circuit.schedule.circuit import ScheduledCircuit
+from tqec.plaquette.debug import PlaquetteDebugInformation
 from tqec.plaquette.plaquette import Plaquette
 from tqec.plaquette.qubit import PlaquetteQubits, SquarePlaquetteQubits
 from tqec.plaquette.rpng import BasisEnum, ExtendedBasisEnum, RPNGDescription
@@ -56,10 +57,7 @@ class DefaultRPNGTranslator(RPNGTranslator):
                     circuit.append(f"{op}{basis.value.upper()}", targets, [])
 
     @override
-    def translate(
-        self,
-        rpng_description: RPNGDescription,
-    ) -> Plaquette:
+    def translate(self, rpng_description: RPNGDescription) -> Plaquette:
         # The current RPNG notation is very much tied to the qubit arrangement
         # in SquarePlaquetteQubits, hence the explicit value here.
         qubits: PlaquetteQubits = deepcopy(DefaultRPNGTranslator.QUBITS)
@@ -137,4 +135,5 @@ class DefaultRPNGTranslator(RPNGTranslator):
             mergeable_instructions=(
                 RESET_INSTRUCTION_NAMES | MEASUREMENT_INSTRUCTION_NAMES
             ),
+            debug_information=PlaquetteDebugInformation(rpng_description),
         )


### PR DESCRIPTION
One of the challenge we often face when implementing new plaquettes/features in `tqec` is due to wrong schedules, leading to error when creating the quantum circuit (two gates touching the same qubit at the same time).

These errors are very tedious to debug.

This PR introduces an optional field in `Plaquette` that includes debug information (for the moment, only the RPNG used to create the plaquette, but this can be improved later if the need arise).

The code introduced also allows to plot a `LayerTree` as a collection of `.svg` files. For example, the following code

```py
from pathlib import Path

from tqec.compile.blocks.block import Block
from tqec.compile.blocks.layers.atomic.plaquettes import PlaquetteLayer
from tqec.compile.blocks.layers.composed.repeated import RepeatedLayer
from tqec.compile.graph import TopologicalComputationGraph
from tqec.compile.specs.library.generators.memory import (
    get_memory_horizontal_boundary_plaquettes,
    get_memory_horizontal_boundary_raw_template,
    get_memory_qubit_plaquettes,
    get_memory_qubit_raw_template,
    get_memory_vertical_boundary_plaquettes,
    get_memory_vertical_boundary_raw_template,
)
from tqec.utils.enums import Basis
from tqec.utils.position import BlockPosition3D
from tqec.utils.scale import LinearFunction, PhysicalQubitScalable2D

scalable_qubit_shape = PhysicalQubitScalable2D(
    LinearFunction(4, 5), LinearFunction(4, 5)
)

graph = TopologicalComputationGraph(scalable_qubit_shape)
XZZ = Block(
    [
        PlaquetteLayer(
            get_memory_qubit_raw_template(),
            get_memory_qubit_plaquettes(reset=Basis.Z),
        ),
        RepeatedLayer(
            PlaquetteLayer(
                get_memory_qubit_raw_template(), get_memory_qubit_plaquettes()
            ),
            repetitions=LinearFunction(2, -1),
        ),
        PlaquetteLayer(
            get_memory_qubit_raw_template(),
            get_memory_qubit_plaquettes(measurement=Basis.Z),
        ),
    ]
)
XZZ_1 = Block(
    [
        PlaquetteLayer(
            get_memory_qubit_raw_template(),
            get_memory_qubit_plaquettes(reset=Basis.Z),
        ),
        RepeatedLayer(
            PlaquetteLayer(
                get_memory_qubit_raw_template(), get_memory_qubit_plaquettes()
            ),
            repetitions=LinearFunction(2, -1),
        ),
        PlaquetteLayer(
            get_memory_qubit_raw_template(),
            get_memory_qubit_plaquettes(measurement=Basis.Z),
        ),
    ]
)
XZO = Block(
    [
        PlaquetteLayer(
            get_memory_qubit_raw_template(),
            get_memory_qubit_plaquettes(),
        )
        for _ in range(2)
    ]
)
OZZ = Block(
    [
        PlaquetteLayer(
            get_memory_vertical_boundary_raw_template(),
            get_memory_vertical_boundary_plaquettes(reset=Basis.Z),
        ),
        RepeatedLayer(
            PlaquetteLayer(
                get_memory_vertical_boundary_raw_template(),
                get_memory_vertical_boundary_plaquettes(),
            ),
            repetitions=LinearFunction(2, -1),
        ),
        PlaquetteLayer(
            get_memory_vertical_boundary_raw_template(),
            get_memory_vertical_boundary_plaquettes(measurement=Basis.Z),
        ),
    ]
)

XOZ = Block(
    [
        PlaquetteLayer(
            get_memory_horizontal_boundary_raw_template(),
            get_memory_horizontal_boundary_plaquettes(reset=Basis.Z),
        ),
        RepeatedLayer(
            PlaquetteLayer(
                get_memory_horizontal_boundary_raw_template(),
                get_memory_horizontal_boundary_plaquettes(),
            ),
            repetitions=LinearFunction(2, -1),
        ),
        PlaquetteLayer(
            get_memory_horizontal_boundary_raw_template(),
            get_memory_horizontal_boundary_plaquettes(measurement=Basis.Z),
        ),
    ]
)

graph.add_cube(BlockPosition3D(0, 0, 0), XZZ)
graph.add_cube(BlockPosition3D(0, 1, 0), XZZ)
graph.add_cube(BlockPosition3D(0, 1, 1), XZZ)
graph.add_pipe(BlockPosition3D(0, 0, 0), BlockPosition3D(0, 1, 0), XOZ)
graph.add_pipe(BlockPosition3D(0, 1, 0), BlockPosition3D(0, 1, 1), XZO)

layer_tree = graph.to_layer_tree()
svgs = layer_tree.layers_to_svg(2)

HERE = Path(__file__).parent
ASSETS_FOLDER = HERE / "assets"

for i, svg in enumerate(svgs):
    with open(ASSETS_FOLDER / f"{i}.svg", "w") as f:
        f.write(svg)
```

writes on the disk the following SVG files:

![0](https://github.com/user-attachments/assets/af219cbb-b2a3-4f6b-9124-1a12a7ec7531)
![1](https://github.com/user-attachments/assets/fefecc36-910a-46ef-af04-b8e2c3ea9903)
![2](https://github.com/user-attachments/assets/c93d3cc0-005b-4d44-8fe4-f1ac0aa8acf0)
![3](https://github.com/user-attachments/assets/a308f311-4aca-4fae-ab9f-43b3b68e171e)
![4](https://github.com/user-attachments/assets/42f7d1b5-10a0-4e26-86d1-a0fd8ab8d98d)
![5](https://github.com/user-attachments/assets/d3d8c41f-8176-42d3-8e8a-e575acc0d42d)


With these visualisations, it becomes easy to see that the problem lies in the pipe implementation in this particular case.