### PR TITLE
[WIP] Implement logical Hadamard under fixed-bulk convention

### DIFF
--- a/src/tqec/compile/detectors/database_test.py
+++ b/src/tqec/compile/detectors/database_test.py
@@ -38,7 +38,7 @@ PLAQUETTE_COLLECTIONS: list[Plaquettes] = [
     GENERATOR.get_memory_qubit_plaquettes(Orientation.HORIZONTAL),
     GENERATOR.get_memory_qubit_plaquettes(reset=Basis.Z),
     GENERATOR.get_memory_qubit_plaquettes(reset=Basis.X),
-    GENERATOR.get_memory_qubit_plaquettes(measurement=Basis.Z),
+    GENERATOR.get_memory_qubit_plaquettes(gate=Basis.Z),
     GENERATOR.get_memory_qubit_plaquettes(Orientation.VERTICAL),
 ]
 # Note: sorting is important here to guarantee the order in which subtemplates

--- a/src/tqec/compile/specs/library/fixed_bulk.py
+++ b/src/tqec/compile/specs/library/fixed_bulk.py
@@ -197,7 +197,26 @@ class FixedBulkPipeBuilder(PipeBuilder):
             the block to implement the provided
             ``spec``.
         """
-        raise NotImplementedError()
+        assert spec.pipe_kind.is_temporal
+        assert spec.pipe_kind.has_hadamard
+        z_observable_orientation = (
+            Orientation.HORIZONTAL
+            if spec.pipe_kind.x == Basis.Z
+            else Orientation.VERTICAL
+        )
+        memory_plaquettes = self._generator.get_memory_qubit_plaquettes(
+            z_observable_orientation, None, None
+        )
+        hadamard_plaquettes = self._generator.get_memory_qubit_plaquettes(
+            z_observable_orientation, None, "h"
+        )
+        template = self._generator.get_memory_qubit_raw_template()
+        return Block(
+            [
+                PlaquetteLayer(template, hadamard_plaquettes),
+                PlaquetteLayer(template, memory_plaquettes),
+            ]
+        )
 
     ##############################
     #       SPATIAL PIPE         #

--- a/src/tqec/plaquette/compilation/base.py
+++ b/src/tqec/plaquette/compilation/base.py
@@ -49,5 +49,7 @@ class PlaquetteCompiler:
 
 
 IdentityPlaquetteCompiler: Final[PlaquetteCompiler] = PlaquetteCompiler(
-    "ID", [], lambda x: x | MEASUREMENT_INSTRUCTION_NAMES | RESET_INSTRUCTION_NAMES
+    "ID",
+    [],
+    lambda x: x | MEASUREMENT_INSTRUCTION_NAMES | RESET_INSTRUCTION_NAMES | {"H"},
 )


### PR DESCRIPTION
Fixes #561.

When attempting to implement the temporal logical Hadamard, it appears that simple transversal H gates do not function correctly under the fixed-bulk convention. After applying a layer of transversal Hadamard gates, the boundary stabilizers must shift positions to preserve the fixed-bulk invariant. This shift cuts off some detectors at the boundary, preventing certain errors from being detected.

Before H layer:

<image src="https://github.com/user-attachments/assets/c63a336d-6072-401a-89cf-fa6ec8497b8b" width=50%>

After H layer:

<image src="https://github.com/user-attachments/assets/209f3f96-7ae2-40a2-8a4f-4724ad5da278" width=50%>

Here is the [Cumble link](https://algassert.com/crumble#circuit=Q(0,2)0;Q(0,4)1;Q(1,1)2;Q(1,3)3;Q(1,5)4;Q(2,0)5;Q(2,2)6;Q(2,4)7;Q(2,6)8;Q(3,1)9;Q(3,3)10;Q(3,5)11;Q(4,0)12;Q(4,2)13;Q(4,4)14;Q(4,6)15;Q(5,1)16;Q(5,3)17;Q(5,5)18;Q(6,2)19;Q(6,4)20;R_2_3_4_9_10_11_16_17_18;RX_1_5_6_7_13_14_15_19;POLYGON(0,0,1,0.25)2_9_10_3;POLYGON(0,0,1,0.25)16_17;POLYGON(0,0,1,0.25)3_4;POLYGON(0,0,1,0.25)10_17_18_11;POLYGON(1,0,0,0.25)9_2;POLYGON(1,0,0,0.25)9_16_17_10;POLYGON(1,0,0,0.25)3_10_11_4;POLYGON(1,0,0,0.25)18_11;TICK;CX_7_3_13_9_15_11;CZ_6_2_14_10_19_16;TICK;CX_7_10_13_16_15_18;CZ_1_3;TICK;CX_5_2_7_4_13_10;CZ_6_3_14_11_19_17;TICK;CZ_6_9_14_17;TICK;CX_5_9_7_11_13_17;CZ_1_4_6_10_14_18;TICK;MX_1_5_6_7_13_14_15_19;DT(0,4,0)rec[-8];DT(2,2,0)rec[-6];DT(4,4,0)rec[-3];DT(6,2,0)rec[-1];TICK;RX_1_5_6_7_13_14_15_19;TICK;CX_7_3_13_9_15_11;CZ_6_2_14_10_19_16;TICK;CX_7_10_13_16_15_18;CZ_1_3;TICK;CX_5_2_7_4_13_10;CZ_6_3_14_11_19_17;TICK;CZ_6_9_14_17;TICK;CX_5_9_7_11_13_17;CZ_1_4_6_10_14_18;TICK;MX_1_5_6_7_13_14_15_19;DT(0,4,1)rec[-8]_rec[-16];DT(2,0,1)rec[-7]_rec[-15];DT(2,2,1)rec[-6]_rec[-14];DT(2,4,1)rec[-5]_rec[-13];DT(4,2,1)rec[-4]_rec[-12];DT(4,4,1)rec[-3]_rec[-11];DT(4,6,1)rec[-2]_rec[-10];DT(6,2,1)rec[-1]_rec[-9];TICK;RX_1_5_6_7_13_14_15_19;TICK;CX_7_3_13_9_15_11;CZ_6_2_14_10_19_16;TICK;CX_7_10_13_16_15_18;CZ_1_3;TICK;CX_5_2_7_4_13_10;CZ_6_3_14_11_19_17;TICK;CZ_6_9_14_17;TICK;CX_5_9_7_11_13_17;CZ_1_4_6_10_14_18;TICK;MX_1_5_6_7_13_14_15_19;DT(0,4,2)rec[-8]_rec[-16];DT(2,0,2)rec[-7]_rec[-15];DT(2,2,2)rec[-6]_rec[-14];DT(2,4,2)rec[-5]_rec[-13];DT(4,2,2)rec[-4]_rec[-12];DT(4,4,2)rec[-3]_rec[-11];DT(4,6,2)rec[-2]_rec[-10];DT(6,2,2)rec[-1]_rec[-9];TICK;RX_1_5_6_7_13_14_15_19;TICK;CX_7_3_13_9_15_11;CZ_6_2_14_10_19_16;TICK;CX_7_10_13_16_15_18;CZ_1_3;TICK;CX_5_2_7_4_13_10;CZ_6_3_14_11_19_17;TICK;CZ_6_9_14_17;TICK;CX_5_9_7_11_13_17;CZ_1_4_6_10_14_18;TICK;H_2_3_4_9_10_11_16_17_18;MX_1_5_6_7_13_14_15_19;POLYGON(0,0,1,0.25)16_9;POLYGON(0,0,1,0.25)2_9_10_3;POLYGON(0,0,1,0.25)10_17_18_11;POLYGON(0,0,1,0.25)11_4;POLYGON(1,0,0,0.25)2_3;POLYGON(1,0,0,0.25)9_16_17_10;POLYGON(1,0,0,0.25)3_10_11_4;POLYGON(1,0,0,0.25)17_18;DT(0,4,3)rec[-8]_rec[-16];DT(2,0,3)rec[-7]_rec[-15];DT(2,2,3)rec[-6]_rec[-14];DT(2,4,3)rec[-5]_rec[-13];DT(4,2,3)rec[-4]_rec[-12];DT(4,4,3)rec[-3]_rec[-11];DT(4,6,3)rec[-2]_rec[-10];DT(6,2,3)rec[-1]_rec[-9];TICK;RX_0_6_7_8_12_13_14_20;TICK;CX_7_3_13_9_20_17;CZ_6_2_8_4_14_10;TICK;CX_0_2;CZ_6_9_8_11_14_17;TICK;CX_7_4_13_10_20_18;CZ_6_3_12_9_14_11;TICK;CX_7_10_13_16;TICK;CX_0_3_7_11_13_17;CZ_6_10_12_16_14_18;TICK;MX_0_6_7_8_12_13_14_20;TICK;RX_0_6_7_8_12_13_14_20;TICK;CX_7_3_13_9_20_17;CZ_6_2_8_4_14_10;TICK;CX_0_2;CZ_6_9_8_11_14_17;TICK;CX_7_4_13_10_20_18;CZ_6_3_12_9_14_11;TICK;CX_7_10_13_16;TICK;CX_0_3_7_11_13_17;CZ_6_10_12_16_14_18;TICK;MX_0_2_3_4_6_7_8_9_10_11_12_13_14_16_17_18_20;DT(0,2,4)rec[-17]_rec[-25];DT(1,3,4)rec[-15]_rec[-16]_rec[-17];DT(2,2,4)rec[-13]_rec[-24];DT(2,4,4)rec[-12]_rec[-23];DT(2,6,4)rec[-11]_rec[-22];DT(3,5,4)rec[-8]_rec[-9]_rec[-12]_rec[-14]_rec[-15];DT(4,0,4)rec[-7]_rec[-21];DT(4,2,4)rec[-6]_rec[-20];DT(4,4,4)rec[-5]_rec[-19];DT(5,3,4)rec[-3]_rec[-4]_rec[-6]_rec[-9]_rec[-10];DT(5,5,4)rec[-1]_rec[-2]_rec[-3];DT(6,4,4)rec[-1]_rec[-18];OI(0)rec[-3]_rec[-9]_rec[-15]) for the generated circuit, which has circuit distance 1.

@afowler seems we need to revise the protocol?
