### PR TITLE
Fix cnot_all_observables.py

### DIFF
--- a/benchmarks/cnot_all_observables.py
+++ b/benchmarks/cnot_all_observables.py
@@ -4,8 +4,9 @@ from pathlib import Path
 import stim
 from tqecd.construction import annotate_detectors_automatically
 
-from tqec.compile.deprecated.compile import CompiledGraph, compile_block_graph
-from tqec.compile.specs.library.css import CSS_BLOCK_BUILDER, CSS_SUBSTITUTION_BUILDER
+from tqec.compile.compile import compile_block_graph
+from tqec.compile.graph import TopologicalComputationGraph
+from tqec.compile.convention import FIXED_BULK_CONVENTION
 from tqec.utils.enums import Basis
 from tqec.utils.noise_model import NoiseModel
 from tqec.gallery import cnot
@@ -17,7 +18,7 @@ CNOT_DAE_FILE = ASSETS_FOLDER / "logical_cnot.dae"
 
 
 def generate_stim_circuit(
-    compiled_graph: CompiledGraph, k: int, p: float
+    compiled_graph: TopologicalComputationGraph, k: int, p: float
 ) -> stim.Circuit:
     circuit_without_detectors = compiled_graph.generate_stim_circuit(
         k, noise_model=NoiseModel.uniform_depolarizing(p)
@@ -36,8 +37,7 @@ def generate_cnot_circuits(*ks: int) -> None:
     # 3. Compile the `BlockGraph`
     compiled_graph = compile_block_graph(
         block_graph,
-        block_builder=CSS_BLOCK_BUILDER,
-        substitution_builder=CSS_SUBSTITUTION_BUILDER,
+        convention=FIXED_BULK_CONVENTION,  # this is the default, but worth making explicit
         observables=[correlation_surfaces[1]],
     )
 


### PR DESCRIPTION
This fixes issue #566.

The code now runs. The output looks plausible. It is difficult to confirm that it is the same as that output by the old compile pipeline as there have been several commits since the deprecated compile script was deleted. 

My changes to the script are minimal. I have replaced the default arguments of CSS_BLOCK_BUILDER and CSS_SUBSTITUTION_BUILDER in compile_block_graph(), with the new default parameter of FIXED_BULK_CONVENTION in the new compile_block_graph function. It would be good if someone more familiar with the new pipeline could confirm that the new default parameters are intended to produce the same result as the old default parameters. 




