### PR TITLE
Add option to show lines missing unit test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           python -m pip install -e '.[test]'
       - name: Compute code coverage
         run: |
-          python -m pytest --cov=tqec --cov-report=xml:coverage.xml ./
+          python -m pytest --cov=tqec --cov-report=xml:coverage.xml --cov-report term-missing:skip-covered ./
       - name: Code Coverage Report
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ module = ["tqec.interop.pyzx.*"]
 disallow_untyped_calls = false
 
 [tool.coverage.run]
-omit = ["*/*_test.py"]
+omit = ["*/*_test.py", "*/simulation/plotting/*"]
 
 [tool.coverage.report]
 exclude_also = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ module = ["tqec.interop.pyzx.*"]
 disallow_untyped_calls = false
 
 [tool.coverage.run]
-omit = ["*/*_test.py", "*/simulation/plotting/*"]
+omit = ["*/*_test.py", "*/simulation/*"]
 
 [tool.coverage.report]
 exclude_also = [


### PR DESCRIPTION
This PR adds the option to show which lines are not covered by unit tests. I noticed two modules are missing proper unit test coverage, but there wasn't enough information. 

![image](https://github.com/user-attachments/assets/18e7bf8d-eb38-4a4a-92e0-d5523489b7bb)

This PR adds the option to show such lines. 

https://github.com/tqec/tqec/actions/runs/15336433395/job/43154562414?pr=593#step:6:167
