### PR TITLE
Fix correlation surface plotting

### DIFF
--- a/src/tqec/interop/collada/_correlation.py
+++ b/src/tqec/interop/collada/_correlation.py
@@ -152,9 +152,14 @@ class CorrelationSurfaceTransformationHelper:
 
         # Surfaces with even parity constraint
         if kind.normal_basis in surface_bases:
-            assert len(correlation_edges) in {2, 4}, "Even parity constraint violated"
-            if len(correlation_edges) == 2:
-                e1, e2 = sorted(correlation_edges)
+            normal_basis_edges: set[ZXEdge] = set()
+            for edge in correlation_edges:
+                this_node = edge.u if edge.u.id == v else edge.v
+                if this_node.basis == kind.normal_basis:
+                    normal_basis_edges.add(edge)
+            assert len(normal_basis_edges) in {2, 4}, "Even parity constraint violated"
+            if len(normal_basis_edges) == 2:
+                e1, e2 = sorted(normal_basis_edges)
                 # passthrough
                 if self._edge_direction(e1) == self._edge_direction(e2):
                     normal_direction = self._surface_normal_direction(e1)
@@ -175,7 +180,7 @@ class CorrelationSurfaceTransformationHelper:
                         self._compute_turn_transformation(scaled_pos, v, (e1, e2))
                     )
             else:
-                e1, e2, e3, e4 = sorted(correlation_edges)
+                e1, e2, e3, e4 = sorted(normal_basis_edges)
                 transformations.extend(self._compute_turn_transformation(scaled_pos, v, (e1, e2)))
                 transformations.extend(self._compute_turn_transformation(scaled_pos, v, (e3, e4)))
 


### PR DESCRIPTION
The correlation edges were not correctly filtered in the current `_compute_cube_transformations` function when drawing correlation surface in 3D. Only those surfaces with the same basis as the cube's normal basis should be checked and drew in this `if` branch.

I discovered this bug when trying to draw a 3D block graph with correlation surface for logical S gate (implemented by gate teleportation with Y measurement):

```py
from tqec import BlockGraph
from tqec.utils.position import Position3D

g = BlockGraph()
n1 = g.add_cube(Position3D(0, 0, 0), "P", "P1")
n2 = g.add_cube(Position3D(0, 0, 1), "XZX")
n3 = g.add_cube(Position3D(0, 0, 2), "P", "P2")
n4 = g.add_cube(Position3D(1, 0, 1), "XZX")
n5 = g.add_cube(Position3D(1, 0, 2), "Y")
g.add_pipe(n1, n2)
g.add_pipe(n2, n3)
g.add_pipe(n4, n5)
g.add_pipe(n2, n4)
correlation = g.find_correlation_surfaces()
g.view_as_html("diagram.html", show_correlation_surface=correlation[0], pop_faces_at_direction="-Y")
```

P.S. I'm preparing a talk to introduce surface code computation and topological quantum error correction (TQEC) to the authors of [Quon](https://arxiv.org/abs/2505.07804). They believe it might offer a better diagrammatic tool than ZX for high-level representations of quantum computations. We'll see how it goes.