### PR TITLE
Add pylint checks in Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,9 @@ ignore = [
   "D203", "D213",
   # D407 - Ignored because ==== under a section heading is considered as a missing underline.
   "D400", "D401", "D404", "D407", "D415", "D416", "D417",
-  "PLR0911", "PLR0912", "PLR0913", "PLR0915", "PLR1714", "PLR2004",
+  # PLR091{2,3,5} - A few code blocks have too many {branches,arguments,statements}. Ignored for the moment.
+  # PLR2004 - Replace magic values, not a priority at the moment.
+  "PLR0912", "PLR0913", "PLR0915", "PLR2004",
   # N802 - functions involving {I,L,H,T}-shaped junction make more sense being names with upper-case letters.
   "N802",
   "PLC0414", "PLC0105",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,7 +248,6 @@ ignore = [
   # N802 - functions involving {I,L,H,T}-shaped junction make more sense being names with upper-case letters.
   "N802",
   "PLC0414", "PLC0105",
-  "PLW2901",
   # UP038 - Soon-to-be-deprecated rule, we prefer using isinstance(obj, (A, B)).
   "UP038"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,6 +247,7 @@ ignore = [
   "PLR0912", "PLR0913", "PLR0915", "PLR2004",
   # N802 - functions involving {I,L,H,T}-shaped junction make more sense being names with upper-case letters.
   "N802",
+  # PLC0414 - "from A.B.C import X as X" is flagged as an error, but should not in __init__.py files. Ignored for that reason.
   "PLC0414",
   # UP038 - Soon-to-be-deprecated rule, we prefer using isinstance(obj, (A, B)).
   "UP038"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,7 +247,7 @@ ignore = [
   "PLR0912", "PLR0913", "PLR0915", "PLR2004",
   # N802 - functions involving {I,L,H,T}-shaped junction make more sense being names with upper-case letters.
   "N802",
-  "PLC0414", "PLC0105",
+  "PLC0414",
   # UP038 - Soon-to-be-deprecated rule, we prefer using isinstance(obj, (A, B)).
   "UP038"
 ]

--- a/src/tqec/compile/blocks/positioning.py
+++ b/src/tqec/compile/blocks/positioning.py
@@ -99,11 +99,11 @@ class LayoutPipePosition2D(LayoutPosition2D):
         )
 
 
-T = TypeVar("T", bound=LayoutPosition2D, covariant=True, default=LayoutPosition2D)
+T_co = TypeVar("T_co", bound=LayoutPosition2D, covariant=True, default=LayoutPosition2D)
 
 
-class LayoutPosition3D(ABC, Generic[T]):
-    def __init__(self, spatial_position: T, z: int) -> None:
+class LayoutPosition3D(ABC, Generic[T_co]):
+    def __init__(self, spatial_position: T_co, z: int) -> None:
         """Internal class to represent the local indexing used to represent both 3D cubes and pipes.
 
         This class simply wraps a :class:`LayoutPosition2D` instance with an

--- a/src/tqec/compile/detectors/compute_test.py
+++ b/src/tqec/compile/detectors/compute_test.py
@@ -364,8 +364,8 @@ def test_compute_superimposed_template_instantiations_shifted(k: int) -> None:
         reverse_indices = numpy.zeros(
             (templates[i].expected_plaquettes_number + 1,), dtype=numpy.int_
         )
-        for i, mapped_i in indices_map.items():
-            reverse_indices[i] = mapped_i
+        for j, mapped_j in indices_map.items():
+            reverse_indices[j] = mapped_j
 
         numpy.testing.assert_array_equal(reverse_indices[template.instantiate(k)], inst)
 

--- a/src/tqec/interop/collada/read_write.py
+++ b/src/tqec/interop/collada/read_write.py
@@ -171,8 +171,12 @@ def read_block_graph_from_dae_file(
     # Add cubes
     for pos, cube_kind, axes_directions in parsed_cubes:
         if isinstance(cube_kind, YHalfCube):
-            pos = _offset_y_cube_position(pos, pipe_length)
-        graph.add_cube(_int_position_before_scale(pos, pipe_length), cube_kind)
+            graph.add_cube(
+                _int_position_before_scale(_offset_y_cube_position(pos, pipe_length), pipe_length),
+                cube_kind,
+            )
+        else:
+            graph.add_cube(_int_position_before_scale(pos, pipe_length), cube_kind)
     port_index = 0
 
     # Add pipes
@@ -388,8 +392,11 @@ def read_block_graph_from_json(
     # Add cubes
     for pos, cube_kind, axes_directions in parsed_cubes:
         if isinstance(cube_kind, YHalfCube):
-            pos = _offset_y_cube_position(pos, 0.0)
-        graph.add_cube(_int_position_before_scale(pos, 0.0), cube_kind)
+            graph.add_cube(
+                _int_position_before_scale(_offset_y_cube_position(pos, 0.0), 0.0), cube_kind
+            )
+        else:
+            graph.add_cube(_int_position_before_scale(pos, 0.0), cube_kind)
     port_index = 0
 
     # Add pipes

--- a/src/tqec/post_processing/coords.py
+++ b/src/tqec/post_processing/coords.py
@@ -10,11 +10,15 @@ def add_tick_coordinate_to_detectors(circuit: stim.Circuit) -> stim.Circuit:
         assert instruction.name != "SHIFT_COORDS"
         if instruction.name == "TICK":
             num_ticks += 1
+            ret.append(instruction)
         elif instruction.name == "DETECTOR":
-            instruction = stim.CircuitInstruction(
-                instruction.name,
-                instruction.targets_copy(),
-                [*instruction.gate_args_copy(), num_ticks],
+            ret.append(
+                stim.CircuitInstruction(
+                    instruction.name,
+                    instruction.targets_copy(),
+                    [*instruction.gate_args_copy(), num_ticks],
+                )
             )
-        ret.append(instruction)
+        else:
+            ret.append(instruction)
     return ret

--- a/src/tqec/utils/noise_model.py
+++ b/src/tqec/utils/noise_model.py
@@ -25,8 +25,9 @@ Modifications to the original code:
    REPEAT blocks (not before the block, the first instruction in the repeated
    inner block, and after the block).
 6. Re-phrase slightly the docstrings.
-7. Replace typing.AbstractSet by collection.abc.Set
-
+7. Replace ``typing.AbstractSet`` by ``collection.abc.Set``
+8. Replace several equalities by inclusion in set (``obj == A or obj == B`` becomes
+   ``obj in {A, B}``)
 """
 
 from collections import Counter, defaultdict
@@ -123,9 +124,7 @@ OP_MEASURE_BASES = {
     "MPP": "",
 }
 COLLAPSING_OPS = {
-    op
-    for op, t in OP_TYPES.items()
-    if t == JUST_RESET_1Q or t == JUST_MEASURE_1Q or t == MPP or t == MEASURE_RESET_1Q
+    op for op, t in OP_TYPES.items() if t in {JUST_RESET_1Q, JUST_MEASURE_1Q, MPP, MEASURE_RESET_1Q}
 }
 
 
@@ -175,7 +174,7 @@ class NoiseRule:
         args = split_op.gate_args_copy()
         if self.flip_result:
             t = OP_TYPES[split_op.name]
-            assert t == MPP or t == JUST_MEASURE_1Q or t == MEASURE_RESET_1Q
+            assert t in {MPP, JUST_MEASURE_1Q, MEASURE_RESET_1Q}
             assert len(args) == 0
             args = [self.flip_result]
 


### PR DESCRIPTION
Fix #605.

- The "too many XXX" warnings have been ignored because I think there are valid cases where these fail. We might be able to configure the threshold though.
- Replacing all magic values by named variables would be nice, but is likely not a priority and would take a lot of time.