### PR TITLE
Add ruff to CI and ignore additional rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,11 @@ jobs:
           python -m pip install -e '.[test]'
           python -m pip install pytest pytest-cov
       # Only perform quick tests when pushing on a PR
-      - name: Code health format
+      - name: Code health - format
         uses: astral-sh/ruff-action@v3
         with:
           args: "format --check --diff"
-      - name: Code health lint
+      - name: Code health - lint
         run: ruff check --fix
       - name: Code coverage for partial tests
         if: github.ref != 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,12 @@ jobs:
           python -m pip install -e '.[test]'
           python -m pip install pytest pytest-cov
       # Only perform quick tests when pushing on a PR
-      - name: Code health
+      - name: Code health format
         uses: astral-sh/ruff-action@v3
         with:
           args: "format --check --diff"
-      - run: ruff check --fix
+      - name: Code health lint
+        run: ruff check --fix
       - name: Code coverage for partial tests
         if: github.ref != 'refs/heads/main'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,11 @@ jobs:
           python -m pip install -e '.[test]'
           python -m pip install pytest pytest-cov
       # Only perform quick tests when pushing on a PR
+      - name: Code health
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check --diff"
+      - run: ruff check --fix
       - name: Code coverage for partial tests
         if: github.ref != 'refs/heads/main'
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,17 @@ repos:
     rev: v8.21.1
     hooks:
       - id: gitleaks
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.12.3
+    hooks:
+      # Run the linter.
+      - id: ruff-check
+        types_or: [ python, pyi ]
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format
+        types_or: [ python, pyi ]
   # - repo: https://github.com/PyCQA/docformatter
   #   rev: v1.7.5
   #   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,11 +23,11 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff-check
-        types_or: [ python, pyi ]
+        types_or: [ python, pyi, jupyter ]
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
-        types_or: [ python, pyi ]
+        types_or: [ python, pyi, jupyter ]
   # - repo: https://github.com/PyCQA/docformatter
   #   rev: v1.7.5
   #   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,7 +248,7 @@ ignore = [
   # N802 - functions involving {I,L,H,T}-shaped junction make more sense being names with upper-case letters.
   "N802",
   "PLC0414", "PLC0105",
-  "PLW2901",
+  "PLW2901", "PLW1641",
   "RUF017", "RUF009", "RUF005", "RUF015", "RUF002", "RUF003",
   "UP038", "UP035"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,9 +216,11 @@ reportPrivateImportUsage = false
 # exclude = ["__init__.py"]
 line-length = 100
 target-version = "py310"
+exclude = ["*.ipynb"]
 
 [tool.ruff.lint]
 select = ["I", "E", "W", "D", "F", "PL", "NPY", "N", "PERF", "RUF", "UP"]
+
 # ruff configuration
 # E, W -- pycodestyle
 # D -- pydocstyle
@@ -237,7 +239,8 @@ ignore = [
   # D100 & D104 - For the moment, we do not require documenting all public modules & packages.
   # D101 - By convention, class docstrings are on the __init__ method, so we do not document classes.
   # D105 - Magic methods have a clear meaning nearly everytime, so we do not require to document them.
-  "D100", "D101", "D104", "D105",
+  # D103 - https://github.com/tqec/tqec/issues/645
+  "D100", "D101", "D103", "D104", "D105",
   "D203", "D205", "D213",
   # D407 - Ignored because ==== under a section heading is considered as a missing underline.
   "D400", "D401", "D404", "D407", "D415", "D416", "D417",
@@ -273,8 +276,10 @@ ignore = [
 # PLR2004 -- Checks if an equality or an inequality is compared to a variable or a num (prefers variable pre)
 # PLR0913 Too many arguments in function definition
 
+
 # Specific per-file ignores
 [tool.ruff.lint.per-file-ignores]
+# no need for docstring in unit tests and functions in user guide and examples gallery
 "**/*_test.py" = ["D103"]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,7 +247,7 @@ ignore = [
   "PLR0911", "PLR0912", "PLR0913", "PLR0915", "PLR1714", "PLR2004",
   # N802 - functions involving {I,L,H,T}-shaped junction make more sense being names with upper-case letters.
   "N802",
-  "PLC0414", "PLC0105",
+  "PLC0105", "PLC0414", "PLC0415",
   "PLW2901", "PLW1641",
   "RUF017", "RUF009", "RUF005", "RUF015", "RUF002", "RUF003",
   "UP038", "UP035"

--- a/src/tqec/post_processing/filter_test.py
+++ b/src/tqec/post_processing/filter_test.py
@@ -12,12 +12,8 @@ def test_identity() -> None:
 
 def test_one_instruction() -> None:
     circuit = stim.Circuit("CX 0 1 2 3 4 5 6 7")
-    assert (
-        subcircuit_only_on_indices(circuit, frozenset((0, 2, 4, 6))) == stim.Circuit()
-    )
-    assert subcircuit_only_on_indices(circuit, frozenset(range(4))) == stim.Circuit(
-        "CX 0 1 2 3"
-    )
+    assert subcircuit_only_on_indices(circuit, frozenset((0, 2, 4, 6))) == stim.Circuit()
+    assert subcircuit_only_on_indices(circuit, frozenset(range(4))) == stim.Circuit("CX 0 1 2 3")
 
 
 def test_non_qubit_targets() -> None:
@@ -26,9 +22,9 @@ def test_non_qubit_targets() -> None:
         TQECWarning,
         match="^Found a measurement record target when filtering a circuit.*",
     ):
-        assert subcircuit_only_on_indices(
-            circuit, frozenset((2, 3, 4))
-        ) == stim.Circuit("M 2 3 4\nDETECTOR rec[-1] rec[-2]")
+        assert subcircuit_only_on_indices(circuit, frozenset((2, 3, 4))) == stim.Circuit(
+            "M 2 3 4\nDETECTOR rec[-1] rec[-2]"
+        )
 
     with pytest.warns(
         TQECWarning,

--- a/src/tqec/post_processing/shift.py
+++ b/src/tqec/post_processing/shift.py
@@ -43,9 +43,7 @@ def shift_qubits(
                     ),
                 )
             )
-        elif instr.name == "QUBIT_COORDS" or (
-            also_shift_detectors and instr.name == "DETECTOR"
-        ):
+        elif instr.name == "QUBIT_COORDS" or (also_shift_detectors and instr.name == "DETECTOR"):
             args = instr.gate_args_copy()
             ret.append(
                 instr.name,


### PR DESCRIPTION
This PR adds ruff to the CI such that it flags failures when a temporarily disabled rule is no longer ignored. Ruff related CI failures can be observed in https://github.com/tqec/tqec/pull/646/commits/1441b115fe6b404377f6691bde471e5ee353737c (format) and https://github.com/tqec/tqec/actions/runs/16300786337/job/46034634853 (lint)

New rules were also ignored. See #645, #647, and #648 for more. I cannot work on a PR locally because pre-commit keeps flagging these errors. 