### PR TITLE
Bump numpy to 2.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,6 @@ dependencies = { file = "requirements.txt" }
 
 
 [tool.mypy]
-# See https://numpy.org/devdocs/reference/typing.html
-plugins = "numpy.typing.mypy_plugin"
 # Start off with these
 warn_unused_configs = true
 warn_redundant_casts = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib<=3.10.3
-numpy<=2.2.6
+numpy<=2.3.2
 scipy<=1.15.3
 networkx<=3.5
 stim<=1.15.0


### PR DESCRIPTION
This PR bump the numpy version to <=2.3.2. 

Should fix #613, but issues like https://quantumcomputing.stackexchange.com/questions/44307/how-to-fix-assertionerror-in-stim-sinter-collect/ might still exist until a stable version of `stim` including the fix is released. These are not an issue of TQEC per-se, but because `sinter` is part of the whole workflow, we should be sure that it will work correctly, else we will likely get new issues on the TQEC repository.