### PR TITLE
Add github badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@
 
 # TQEC
 
-![Python](https://img.shields.io/badge/python-3.10-blue.svg)
-![Python](https://img.shields.io/badge/python-3.11-blue.svg)
-![Python](https://img.shields.io/badge/python-3.12-blue.svg)
-![Python](https://img.shields.io/badge/python-3.13-blue.svg)
+![Compatible with Python versions 3.10 and higher](https://img.shields.io/badge/Python-3.10+-blue.svg?logo=python)
 [![build](https://github.com/tqec/tqec/actions/workflows/ci.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/ci.yml)
 [![docs](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml)
 [![Stars](https://img.shields.io/github/stars/tqec/tqec.svg)](https://github.com/tqec/tqec/stargazers)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![Python](https://img.shields.io/badge/python-3.12-blue.svg)
 [![build](https://github.com/tqec/tqec/actions/workflows/ci.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/ci.yml)
 [![docs](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml)
-[![Stars](https://api.star-history.com/svg?repos=tqec/tqec&type=Date)](https://www.star-history.com/#tqec/tqec&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=tqec/tqec&type=Date)](https://www.star-history.com/#tqec/tqec&Date)
 
 
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 # TQEC
 
+[![build](https://github.com/tqec/tqec/actions/workflows/ci.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/ci.yml)
+[![docs](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml)
+
 TQEC(Topological Quantum Error Correction) is a design automation software for representing,
 constructing and compiling large-scale fault-tolerant quantum computations based on surface code and lattice surgery.
 
@@ -17,7 +20,11 @@ These blocks can then be combined to construct large-scale logical computations,
 
 **Note:** This project is under active development and provide no backwards compatibility at current stage.
 
-## Documentation
+<p align="center">
+  <a href="https://tqec.github.io/tqec/">
+  <img width=30% src="https://img.shields.io/badge/documentation-blue?style=for-the-badge&logo=read%20the%20docs" alt="Documentation" />
+  </a>
+</p>
 
 Documentation is available at <https://tqec.github.io/tqec/index.html>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 ![Python](https://img.shields.io/badge/python-3.13-blue.svg)
 [![build](https://github.com/tqec/tqec/actions/workflows/ci.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/ci.yml)
 [![docs](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml)
-![GitHub Repo stars](https://img.shields.io/github/stars/tqec/tqec?label=Stars)
+![GitHub Repo stars](https://img.shields.io/github/stars/tqec/tqec?style=flat-square&logo=github)
+[![Star History Chart](https://img.shields.io/badge/📈-Star%20History-blue?style=flat-square)](https://star-history.com/#tqec/tqec&amp;Date&Date)
 
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![Python](https://img.shields.io/badge/python-3.13-blue.svg)
 [![build](https://github.com/tqec/tqec/actions/workflows/ci.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/ci.yml)
 [![docs](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml)
-
+![GitHub Repo stars](https://img.shields.io/github/stars/tqec/tqec?label=Stars)
 
 
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 [![docs](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml)
 [![Stars](https://img.shields.io/github/stars/tqec/tqec.svg)](https://github.com/tqec/tqec/stargazers)
 [![Star History Chart](https://img.shields.io/badge/📈-Star%20History-blue?style=flat-square)](https://www.star-history.com/#tqec/tqec&Date)
-
-
+[![Legal Notice](https://img.shields.io/badge/docs-legal%20notice-blue)](https://tqec.github.io/tqec/legal_notice.html)
+[![Licensed under the Apache 2.0 open-source license](https://img.shields.io/badge/License-Apache%202.0-blue.svg?logo=opensourceinitiative)](https://github.com/tqec/tqec/blob/main/LICENSE)
 
 TQEC (Topological Quantum Error Correction) is a design automation software for representing,
 constructing and compiling large-scale fault-tolerant quantum computations based on surface code and lattice surgery.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 
 # TQEC
 
+![Python >= 3.10](https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54)
 [![build](https://github.com/tqec/tqec/actions/workflows/ci.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/ci.yml)
 [![docs](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml)
+
+
 
 TQEC(Topological Quantum Error Correction) is a design automation software for representing,
 constructing and compiling large-scale fault-tolerant quantum computations based on surface code and lattice surgery.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # TQEC
 
-![Compatible with Python versions 3.10 and higher](https://img.shields.io/badge/Python-3.10+-blue.svg?logo=python)
+![Python](https://img.shields.io/badge/python-3.10%20|%203.11%20|%203.12%20|%203.13-blue)
 [![build](https://github.com/tqec/tqec/actions/workflows/ci.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/ci.yml)
 [![docs](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml)
 [![Stars](https://img.shields.io/github/stars/tqec/tqec.svg)](https://github.com/tqec/tqec/stargazers)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@
 
 # TQEC
 
-![Python >= 3.10](https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54)
+![Python](https://img.shields.io/badge/python-3.10-blue.svg)
+![Python](https://img.shields.io/badge/python-3.11-blue.svg)
+![Python](https://img.shields.io/badge/python-3.12-blue.svg)
 [![build](https://github.com/tqec/tqec/actions/workflows/ci.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/ci.yml)
 [![docs](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml)
+[![Stars](https://api.star-history.com/svg?repos=tqec/tqec&type=Date)](https://www.star-history.com/#tqec/tqec&Date)
 
 
 

--- a/README.md
+++ b/README.md
@@ -107,5 +107,5 @@ Please join the [Google group](https://groups.google.com/g/tqec-design-automatio
 >
 > **Use in military, surveillance, or dual-use applications is strictly prohibited.**
 >
-> Please, review the full [`LEGAL_NOTICE.md`](https://github.com/tqec/tqec/blob/main/LEGAL_NOTICE.md) for important terms regarding **export control**, **ethical use**, and **contributor responsibilities**.
+> Please, review the full [`LEGAL_NOTICE.md`](https://tqec.github.io/tqec/legal_notice.html) for important terms regarding **export control**, **ethical use**, and **contributor responsibilities**.
 ---

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
 ![Python](https://img.shields.io/badge/python-3.13-blue.svg)
 [![build](https://github.com/tqec/tqec/actions/workflows/ci.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/ci.yml)
 [![docs](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml)
-![GitHub Repo stars](https://img.shields.io/github/stars/tqec/tqec?style=flat-square&logo=github)
-[![Star History Chart](https://img.shields.io/badge/📈-Star%20History-blue?style=flat-square)](https://star-history.com/#tqec/tqec&amp;Date&Date)
+[![Stars](https://img.shields.io/github/stars/tqec/tqec.svg)](https://github.com/tqec/tqec/stargazers)
+[![Star History Chart](https://img.shields.io/badge/📈-Star%20History-blue?style=flat-square)](https://www.star-history.com/#tqec/tqec&Date)
 
 
 
-TQEC(Topological Quantum Error Correction) is a design automation software for representing,
+TQEC (Topological Quantum Error Correction) is a design automation software for representing,
 constructing and compiling large-scale fault-tolerant quantum computations based on surface code and lattice surgery.
 
 In the past decade, there have been significant advancements in surface code quantum computation based on lattice surgery.
@@ -26,7 +26,7 @@ As a result, many complex logical computations have not been practically simulat
 `tqec` provides numerous building blocks based on state-of-the-art protocols, with verified correct circuits implementation for each block.
 These blocks can then be combined to construct large-scale logical computations, enabling the automatic compilation of large-scale computational circuits.
 
-**Note:** This project is under active development and provide no backwards compatibility at current stage.
+> **_NOTE:_** This project is under active development and provide no backwards compatibility at current stage.
 
 <p align="center">
   <a href="https://tqec.github.io/tqec/">
@@ -102,7 +102,6 @@ All the resources and group meeting recordings are available at [this link](http
 Please join the [Google group](https://groups.google.com/g/tqec-design-automation) to receive more updates and information!
 
 ---
-
 > ### **Legal Notice**
 >
 > This library is intended for **academic, educational, and civilian research only**, in the field of **fault-tolerant quantum computing**, particularly in **surface code compilation** and **topological error correction**.
@@ -112,5 +111,4 @@ Please join the [Google group](https://groups.google.com/g/tqec-design-automatio
 > **Use in military, surveillance, or dual-use applications is strictly prohibited.**
 >
 > Please, review the full [`LEGAL_NOTICE.md`](https://github.com/tqec/tqec/blob/main/LEGAL_NOTICE.md) for important terms regarding **export control**, **ethical use**, and **contributor responsibilities**.
-
 ---

--- a/README.md
+++ b/README.md
@@ -107,5 +107,5 @@ Please join the [Google group](https://groups.google.com/g/tqec-design-automatio
 >
 > **Use in military, surveillance, or dual-use applications is strictly prohibited.**
 >
-> Please, review the full [`LEGAL_NOTICE.md`](https://tqec.github.io/tqec/legal_notice.html) for important terms regarding **export control**, **ethical use**, and **contributor responsibilities**.
+> Please, review the full [`LEGAL_NOTICE.md`](https://github.com/tqec/tqec/blob/main/LEGAL_NOTICE.md) for important terms regarding **export control**, **ethical use**, and **contributor responsibilities**.
 ---

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 ![Python](https://img.shields.io/badge/python-3.10-blue.svg)
 ![Python](https://img.shields.io/badge/python-3.11-blue.svg)
 ![Python](https://img.shields.io/badge/python-3.12-blue.svg)
+![Python](https://img.shields.io/badge/python-3.13-blue.svg)
 [![build](https://github.com/tqec/tqec/actions/workflows/ci.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/ci.yml)
 [![docs](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/tqec/tqec/actions/workflows/gh-pages.yml)
-[![Star History Chart](https://api.star-history.com/svg?repos=tqec/tqec&type=Date)](https://www.star-history.com/#tqec/tqec&Date)
+
 
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,9 +8,9 @@
    :maxdepth: 2
    :hidden:
 
-   Legal Notice <legal_notice>
    Introduction <self>
    User Guide <user_guide/index>
    Gallery <gallery/index>
    Contributor Guide <contributor_guide>
    API Reference <api>
+   Legal Notice <legal_notice>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@
    :maxdepth: 2
    :hidden:
 
+   Legal Notice <legal_notice>
    Introduction <self>
    User Guide <user_guide/index>
    Gallery <gallery/index>

--- a/docs/legal_notice.rst
+++ b/docs/legal_notice.rst
@@ -1,0 +1,5 @@
+Legal Notice
+============
+
+.. include:: ../LEGAL_NOTICE.md
+   :parser: myst_parser.sphinx_


### PR DESCRIPTION
Adds badges to the readme to provide quick access to things a person new to tqec might be interested in. 

<img width="924" height="118" alt="image" src="https://github.com/user-attachments/assets/ac4721b3-81b6-41d2-b5bd-9aebba5106e9" />
