### PR TITLE
Remove ignored errors from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,7 +247,7 @@ ignore = [
   # D203 - Requires multiline docstrings to start on the second line. Incompatible with D212. We prefer D212.
   "D203", "D213",
   # D407 - Ignored because ==== under a section heading is considered as a missing underline.
-  "D401", "D407",
+  "D407",
   # PLR091{2,3,5} - A few code blocks have too many {branches,arguments,statements}. Ignored for the moment.
   # PLR2004 - Replace magic values, not a priority at the moment.
   "PLR0912", "PLR0913", "PLR0915", "PLR2004",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,7 +247,7 @@ ignore = [
   # D203 - Requires multiline docstrings to start on the second line. Incompatible with D212. We prefer D212.
   "D203", "D213",
   # D407 - Ignored because ==== under a section heading is considered as a missing underline.
-  "D400", "D401", "D404", "D407", "D415", "D416", "D417",
+  "D401", "D407",
   # PLR091{2,3,5} - A few code blocks have too many {branches,arguments,statements}. Ignored for the moment.
   # PLR2004 - Replace magic values, not a priority at the moment.
   "PLR0912", "PLR0913", "PLR0915", "PLR2004",

--- a/src/tqec/circuit/measurement.py
+++ b/src/tqec/circuit/measurement.py
@@ -60,7 +60,7 @@ class AbstractMeasurement(ABC):
 
     @abstractmethod
     def map_qubit(self, qubit_map: Mapping[GridQubit, GridQubit]) -> AbstractMeasurement:
-        """Returns a copy of ``self`` with qubits mapped according to the provided``qubit_map``.
+        """Return a copy of ``self`` with qubits mapped according to the provided``qubit_map``.
 
         The returned instance represents a measurement on the qubit obtained from ``self.qubit`` and
         the provided ``qubit_map``.

--- a/src/tqec/circuit/qubit.py
+++ b/src/tqec/circuit/qubit.py
@@ -160,7 +160,7 @@ def count_qubit_accesses(circuit: stim.Circuit) -> dict[int, int]:
 
 
 def get_used_qubit_indices(circuit: stim.Circuit) -> set[int]:
-    """Returns the indices of qubits that are used by at least one non-annotation instruction.
+    """Return the indices of qubits that are used by at least one non-annotation instruction.
 
     Args:
         circuit: circuit containing the gates.

--- a/src/tqec/circuit/qubit_map.py
+++ b/src/tqec/circuit/qubit_map.py
@@ -57,7 +57,7 @@ class QubitMap:
 
     @staticmethod
     def from_circuit(circuit: stim.Circuit) -> QubitMap:
-        """Returns a qubit map from the qubit coordinates at the end of the provided ``circuit``.
+        """Return a qubit map from the qubit coordinates at the end of the provided ``circuit``.
 
         Warning:
             This function, just like
@@ -222,7 +222,7 @@ class QubitMap:
 
 
 def get_qubit_map(circuit: stim.Circuit) -> QubitMap:
-    """Returns the existing qubits and their coordinates at the end of the provided ``circuit``.
+    """Return the existing qubits and their coordinates at the end of the provided ``circuit``.
 
     Warning:
         This function, just like

--- a/src/tqec/circuit/qubit_map.py
+++ b/src/tqec/circuit/qubit_map.py
@@ -48,7 +48,7 @@ class QubitMap:
 
     @staticmethod
     def from_qubits(qubits: Iterable[GridQubit]) -> QubitMap:
-        """Creates a qubit map from the provided ``qubits``.
+        """Create a qubit map from the provided ``qubits``.
 
         Qubit indices are associated in the order in which ``qubits`` are provided: the first qubit
         will have index ``0``, the second index ``1`` and so on.

--- a/src/tqec/circuit/schedule/manipulation.py
+++ b/src/tqec/circuit/schedule/manipulation.py
@@ -35,7 +35,7 @@ from tqec.utils.exceptions import TQECError, TQECWarning
 
 class _ScheduledCircuits:
     def __init__(self, circuits: list[ScheduledCircuit], global_qubit_map: QubitMap) -> None:
-        """Represents a collection of :class:`.ScheduledCircuit` instances.
+        """Represent a collection of :class:`.ScheduledCircuit` instances.
 
         This class aims at providing accessors for several compatible instances
         of :class:`~tqec.circuit.schedule.circuit.ScheduledCircuit`. It allows

--- a/src/tqec/compile/blocks/layers/atomic/raw.py
+++ b/src/tqec/compile/blocks/layers/atomic/raw.py
@@ -18,7 +18,7 @@ class RawCircuitLayer(BaseLayer):
         scalable_num_moments: LinearFunction,
         trimmed_spatial_borders: frozenset[SpatialBlockBorder] = frozenset(),
     ):
-        """Represents a layer with a spatial footprint that is defined by a raw circuit.
+        """Represent a layer with a spatial footprint that is defined by a raw circuit.
 
         Args:
             circuit_factory: a function callable returning a quantum circuit for

--- a/src/tqec/compile/blocks/layers/spatial.py
+++ b/src/tqec/compile/blocks/layers/spatial.py
@@ -39,7 +39,7 @@ class WithSpatialFootprint(ABC):
     @property
     @abstractmethod
     def scalable_shape(self) -> PhysicalQubitScalable2D:
-        """Returns the 2-dimensional shape of the object.
+        """Return the 2-dimensional shape of the object.
 
         Note:
             This method should return the shape in qubit-coordinates. That means

--- a/src/tqec/compile/blocks/layers/temporal.py
+++ b/src/tqec/compile/blocks/layers/temporal.py
@@ -19,7 +19,7 @@ class WithTemporalFootprint(ABC):
     @property
     @abstractmethod
     def scalable_timesteps(self) -> LinearFunction:
-        """Returns the number of timesteps needed to implement the object.
+        """Return the number of timesteps needed to implement the object.
 
         Returns:
             the number of timesteps needed to implement the object as an
@@ -30,7 +30,7 @@ class WithTemporalFootprint(ABC):
         pass
 
     def timesteps(self, k: int) -> int:
-        """Returns the number of timesteps needed for the provided scaling parameter ``k``.
+        """Return the number of timesteps needed for the provided scaling parameter ``k``.
 
         Args:
             k: scaling parameter.
@@ -73,7 +73,7 @@ class WithTemporalFootprint(ABC):
     @property
     @abstractmethod
     def scalable_num_moments(self) -> LinearFunction:
-        """Returns the number of moments needed to implement the object,.
+        """Return the number of moments needed to implement the object,.
 
         Returns:
             the number of moments needed to implement the object as an
@@ -84,7 +84,7 @@ class WithTemporalFootprint(ABC):
         pass
 
     def num_moments(self, k: int) -> int:
-        """Returns the number of moments needed for the provided scaling parameter ``k``.
+        """Return the number of moments needed for the provided scaling parameter ``k``.
 
         Args:
             k: scaling parameter.

--- a/src/tqec/compile/blocks/positioning.py
+++ b/src/tqec/compile/blocks/positioning.py
@@ -11,7 +11,7 @@ from tqec.utils.position import BlockPosition2D, BlockPosition3D, SignedDirectio
 
 class LayoutPosition2D(ABC):
     def __init__(self, x: int, y: int) -> None:
-        """Internal class to represent the local indexing used to represent both cubes and pipes.
+        """Represent the local indexing used to represent both cubes and pipes.
 
         Args:
             x: first coordinate.
@@ -104,10 +104,10 @@ T_co = TypeVar("T_co", bound=LayoutPosition2D, covariant=True, default=LayoutPos
 
 class LayoutPosition3D(ABC, Generic[T_co]):
     def __init__(self, spatial_position: T_co, z: int) -> None:
-        """Internal class to represent the local indexing used to represent both 3D cubes and pipes.
+        """Represent the local indexing used to represent both 3D cubes and pipes.
 
-        This class simply wraps a :class:`LayoutPosition2D` instance with an
-        integer-valued z coordinate.
+        This class simply wraps a :class:`LayoutPosition2D` instance with an integer-valued z
+        coordinate.
 
         Because temporal pipes are "absorbed" in its neighbouring blocks, we do not
         have to represent them, hence the z coordinate does not need any kind of

--- a/src/tqec/compile/convention.py
+++ b/src/tqec/compile/convention.py
@@ -38,7 +38,7 @@ class ConventionTriplet:
 
 @dataclass(frozen=True)
 class Convention:
-    """Represents a convention to implement blocks."""
+    """Represent a convention to implement blocks."""
 
     name: str
     triplet: ConventionTriplet

--- a/src/tqec/compile/detectors/compute.py
+++ b/src/tqec/compile/detectors/compute.py
@@ -370,7 +370,7 @@ def compute_detectors_at_end_of_situation(
     only_use_database: bool = False,
     parallel_process_count: int = 1,
 ) -> frozenset[Detector]:
-    """Returns detectors that should be added at the end of the provided situation.
+    """Return detectors that should be added at the end of the provided situation.
 
     Args:
         subtemplates: a sequence of sub-template(s), each entry consisting of

--- a/src/tqec/compile/detectors/database.py
+++ b/src/tqec/compile/detectors/database.py
@@ -387,7 +387,7 @@ class DetectorDatabase:
         self.frozen = False
 
     def to_crumble_urls(self, plaquette_increments: Shift2D = Shift2D(2, 2)) -> list[str]:
-        """Returns a URL pointing to https://algassert.com/crumble for each of the stored situations
+        """Return a URL pointing to https://algassert.com/crumble for each of the stored situations.
 
         Args:
             plaquette_increments: increments between two :class:`Plaquette`

--- a/src/tqec/compile/detectors/database.py
+++ b/src/tqec/compile/detectors/database.py
@@ -108,7 +108,7 @@ class _DetectorDatabaseKey:
 
     @cached_property
     def reliable_hash(self) -> int:
-        """Returns a hash of ``self`` that is guaranteed to be constant.
+        """Return a hash of ``self`` that is guaranteed to be constant.
 
         Python's ``hash`` is not guaranteed to be constant across Python versions, OSes and
         executions. In particular, strings hash will not be repeatable across different Python

--- a/src/tqec/compile/graph.py
+++ b/src/tqec/compile/graph.py
@@ -114,7 +114,7 @@ class TopologicalComputationGraph:
         observable_builder: ObservableBuilder,
         observables: list[AbstractObservable] | None = None,
     ) -> None:
-        """Represents a topological computation with :class:`.Block` instances."""
+        """Represent a topological computation with :class:`.Block` instances."""
         self._blocks: dict[LayoutPosition3D, Block] = {}
         # For fixed-bulk convention, temporal Hadamard pipe has its on space-time
         # extent. We need to keep track of the temporal pipes that are at the

--- a/src/tqec/compile/graph.py
+++ b/src/tqec/compile/graph.py
@@ -274,7 +274,7 @@ class TopologicalComputationGraph:
         spatial_block_border: SpatialBlockBorder,
         temporal_pipe_border: TemporalBlockBorder,
     ) -> None:
-        """Substitutes the plaquettes of the pipe at ``pipe_pos`` using ``neighbouring_block_layer``
+        """Substitute the plaquettes of the pipe at ``pipe_pos`` using ``neighbouring_block_layer``.
 
         The pipe in ``pipe_pos`` is modified in-line.
 

--- a/src/tqec/compile/observables/builder.py
+++ b/src/tqec/compile/observables/builder.py
@@ -66,7 +66,7 @@ Coordinates2D = tuple[float, float] | tuple[int, int]
 
 
 class CubeObservableQubitsBuilder(Protocol):
-    """Builds the qubits whose measurements will be included in the logical observable that is
+    """Build the qubits whose measurements will be included in the logical observable that is
     supported by the cube.
 
     This calculates the coordinates of these data qubits in the local coordinate system.
@@ -74,12 +74,12 @@ class CubeObservableQubitsBuilder(Protocol):
     """
 
     def __call__(self, shape: PlaquetteShape2D, cube: CubeWithArms) -> Sequence[Coordinates2D]:
-        """Builds the qubit coordinates whose measurement will be included in the observable."""
+        """Build the qubit coordinates whose measurement will be included in the observable."""
         ...
 
 
 class PipeObservableQubitsBuilder(Protocol):
-    """Builds the qubits whose measurements will be included in the logical observable that is
+    """Build the qubits whose measurements will be included in the logical observable that is
     supported by the pipe.
 
     This calculates the coordinates of that data qubit in the local coordinate system of the cube at
@@ -88,12 +88,12 @@ class PipeObservableQubitsBuilder(Protocol):
     """
 
     def __call__(self, shape: PlaquetteShape2D, pipe: PipeWithArms) -> Sequence[Coordinates2D]:
-        """Builds the qubit coordinates whose measurement will be included in the observable."""
+        """Build the qubit coordinates whose measurement will be included in the observable."""
         ...
 
 
 class TemporalPipeObservableQubitsBuilder(Protocol):
-    """Builds the qubits whose measurements will be included in the logical observable that is
+    """Build the qubits whose measurements will be included in the logical observable that is
     supported by the temporal pipe.
 
     This calculates the coordinates of that data qubit in the local coordinate system of the cube at
@@ -104,7 +104,7 @@ class TemporalPipeObservableQubitsBuilder(Protocol):
     def __call__(
         self, shape: PlaquetteShape2D, pipe: PipeWithObservableBasis
     ) -> Sequence[Coordinates2D]:
-        """Builds the qubit coordinates whose measurement will be included in the observable."""
+        """Build the qubit coordinates whose measurement will be included in the observable."""
         ...
 
 

--- a/src/tqec/compile/observables/fixed_boundary_builder.py
+++ b/src/tqec/compile/observables/fixed_boundary_builder.py
@@ -12,7 +12,7 @@ from tqec.utils.position import Direction3D, PlaquetteShape2D, SignedDirection3D
 def build_spatial_cube_top_readout_qubits(
     shape: PlaquetteShape2D, arms: SpatialArms
 ) -> Sequence[Coordinates2D]:
-    """Builds the qubit coordinates for a straight or bent middle line of the top face of a spatial
+    """Build the qubit coordinates for a straight or bent middle line of the top face of a spatial
     cube.
     """
     assert len(arms) == 2
@@ -41,7 +41,7 @@ def build_spatial_cube_top_readout_qubits(
 def build_cube_top_readout_qubits(
     shape: PlaquetteShape2D, cube: CubeWithArms
 ) -> Sequence[Coordinates2D]:
-    """Builds the qubit coordinates whose measurements will be included in the observable on the top
+    """Build the qubit coordinates whose measurements will be included in the observable on the top
     face of a cube.
     """
     if not cube.cube.is_spatial:
@@ -81,7 +81,7 @@ def _build_pipe_top_readout_qubits_impl(
 def build_pipe_top_readout_qubits(
     shape: PlaquetteShape2D, pipe: PipeWithArms
 ) -> Sequence[Coordinates2D]:
-    """Builds the qubit coordinates whose measurements will be included in the observable on the top
+    """Build the qubit coordinates whose measurements will be included in the observable on the top
     face of a pipe.
     """
     return _build_pipe_top_readout_qubits_impl(
@@ -93,7 +93,7 @@ def build_regular_cube_bottom_stabilizer_qubits(
     shape: PlaquetteShape2D,
     connect_to: SignedDirection3D,
 ) -> Sequence[Coordinates2D]:
-    """Builds the stabilizer measurement coordinates who will be included in the observable spanning
+    """Build the stabilizer measurement coordinates who will be included in the observable spanning
     half of the bottom face of a regular cube.
     """
     stabilizers: list[tuple[float, float]] = []
@@ -132,7 +132,7 @@ def build_regular_cube_bottom_stabilizer_qubits(
 def build_spatial_cube_bottom_stabilizer_qubits(
     shape: PlaquetteShape2D,
 ) -> Sequence[Coordinates2D]:
-    """Builds the stabilizer measurement coordinates who will be included in the observable spanning
+    """Build the stabilizer measurement coordinates who will be included in the observable spanning
     the bottom face of a single spatial cube.
     """
     return [(i + 0.5, j + 0.5) for i in range(shape.x) for j in range(shape.y) if (i + j) % 2 == 0]
@@ -144,7 +144,7 @@ def build_connected_spatial_cube_bottom_stabilizer_qubits(
     connect_to: SignedDirection3D,
     extended_stabilizers_used: bool,
 ) -> Sequence[Coordinates2D]:
-    """Builds the stabilizer measurement coordinates who will be included in the observable spanning
+    """Build the stabilizer measurement coordinates who will be included in the observable spanning
     the bottom face of a spatial cube connected to pipes.
     """
     max_y = (
@@ -164,7 +164,7 @@ def build_connected_spatial_cube_bottom_stabilizer_qubits(
 def build_pipe_bottom_stabilizer_qubits(
     shape: PlaquetteShape2D, pipe: PipeWithArms
 ) -> Sequence[Coordinates2D]:
-    """Builds the stabilizer measurement coordinates who will be included in the observable on the
+    """Build the stabilizer measurement coordinates who will be included in the observable on the
     bottom face of a pipe.
 
     It includes the bottom stabilizers of the connected cubes.

--- a/src/tqec/compile/observables/fixed_bulk_builder.py
+++ b/src/tqec/compile/observables/fixed_bulk_builder.py
@@ -15,7 +15,7 @@ from tqec.utils.position import Direction3D, PlaquetteShape2D, SignedDirection3D
 def build_regular_cube_top_readout_qubits(
     shape: PlaquetteShape2D, observable_orientation: Orientation
 ) -> Sequence[Coordinates2D]:
-    """Builds the qubit coordinates for the middle line of the top face of a regular cube."""
+    """Build the qubit coordinates for the middle line of the top face of a regular cube."""
     if observable_orientation == Orientation.HORIZONTAL:
         return [(x, shape.y // 2) for x in range(1, shape.x)]
     return [(shape.x // 2, y) for y in range(1, shape.y)]
@@ -24,7 +24,7 @@ def build_regular_cube_top_readout_qubits(
 def build_spatial_cube_top_readout_qubits(
     shape: PlaquetteShape2D, arms: SpatialArms, observable_basis: Basis
 ) -> Sequence[Coordinates2D]:
-    """Builds the qubit coordinates for a straight or bent middle line of the top face of a spatial
+    """Build the qubit coordinates for a straight or bent middle line of the top face of a spatial
     cube.
     """
     assert len(arms) == 2
@@ -65,7 +65,7 @@ def build_spatial_cube_top_readout_qubits(
 def build_cube_top_readout_qubits(
     shape: PlaquetteShape2D, cube: CubeWithArms
 ) -> Sequence[Coordinates2D]:
-    """Builds the qubit coordinates whose measurements will be included in the observable on the top
+    """Build the qubit coordinates whose measurements will be included in the observable on the top
     face of a cube.
     """
     if not cube.cube.is_spatial:
@@ -86,7 +86,7 @@ def build_cube_top_readout_qubits(
 def build_pipe_top_readout_qubits(
     shape: PlaquetteShape2D, direction: Direction3D
 ) -> Sequence[Coordinates2D]:
-    """Builds the qubit coordinates whose measurements will be included in the observable on the top
+    """Build the qubit coordinates whose measurements will be included in the observable on the top
     face of a pipe.
     """
     assert direction != Direction3D.Z
@@ -100,7 +100,7 @@ def build_regular_cube_bottom_stabilizer_qubits(
     connect_to: SignedDirection3D,
     stabilizer_basis: Basis,
 ) -> Sequence[Coordinates2D]:
-    """Builds the stabilizer measurement coordinates that will be included in the observable
+    """Build the stabilizer measurement coordinates that will be included in the observable
     spanning half of the bottom face of a regular cube.
     """
     stabilizers: list[tuple[float, float]] = []
@@ -147,7 +147,7 @@ def build_regular_cube_bottom_stabilizer_qubits(
 def build_spatial_cube_bottom_stabilizer_qubits(
     shape: PlaquetteShape2D, stabilizer_basis: Basis
 ) -> Sequence[Coordinates2D]:
-    """Builds the stabilizer measurement coordinates that will be included in the observable
+    """Build the stabilizer measurement coordinates that will be included in the observable
     spanning the bottom face of a spatial cube.
     """
     xy_sum_parity = 0 if stabilizer_basis == Basis.Z else 1
@@ -162,7 +162,7 @@ def build_spatial_cube_bottom_stabilizer_qubits(
 def build_cube_bottom_stabilizer_qubits(
     shape: PlaquetteShape2D, cube: CubeWithArms
 ) -> Sequence[Coordinates2D]:
-    """Builds the stabilizer measurement coordinates that will be included in the observable on the
+    """Build the stabilizer measurement coordinates that will be included in the observable on the
     bottom face of a cube.
     """
     assert cube.cube.is_spatial
@@ -174,7 +174,7 @@ def build_cube_bottom_stabilizer_qubits(
 def build_pipe_bottom_stabilizer_qubits(
     shape: PlaquetteShape2D, pipe: PipeWithArms
 ) -> Sequence[Coordinates2D]:
-    """Builds the stabilizer measurement coordinates that will be included in the observable on the
+    """Build the stabilizer measurement coordinates that will be included in the observable on the
     bottom face of a pipe.
 
     It includes the bottom stabilizers of the connected cubes.

--- a/src/tqec/compile/specs/library/fixed_boundary.py
+++ b/src/tqec/compile/specs/library/fixed_boundary.py
@@ -111,7 +111,7 @@ class FixedBoundaryCubeBuilder(CubeBuilder):
     def __init__(
         self, compiler: PlaquetteCompiler, translator: RPNGTranslator = DefaultRPNGTranslator()
     ) -> None:
-        """Implementation of the :class:`.CubeBuilder` interface for the fixed boundary convention.
+        """Implement the :class:`.CubeBuilder` interface for the fixed boundary convention.
 
         This class provides an implementation following the fixed-boundary convention.
         This convention consists in the fact that 2-body stabilizers on the boundary
@@ -178,7 +178,7 @@ class FixedBoundaryPipeBuilder(PipeBuilder):
     def __init__(
         self, compiler: PlaquetteCompiler, translator: RPNGTranslator = DefaultRPNGTranslator()
     ) -> None:
-        """Implementation of the :class:`.PipeBuilder` interface for the fixed boundary convention.
+        """Implement the :class:`.PipeBuilder` interface for the fixed boundary convention.
 
         This class provides an implementation following the fixed-boundary convention.
         This convention consists in the fact that 2-body stabilizers on the boundary

--- a/src/tqec/compile/specs/library/fixed_boundary.py
+++ b/src/tqec/compile/specs/library/fixed_boundary.py
@@ -203,7 +203,7 @@ class FixedBoundaryPipeBuilder(PipeBuilder):
     #    TEMPORAL PIPE    #
     #######################
     def get_temporal_pipe_block(self, spec: PipeSpec) -> Block:
-        """Returns the block to implement a temporal pipe based on the provided ``spec``.
+        """Return the block to implement a temporal pipe based on the provided ``spec``.
 
         Args:
             spec: description of the pipe that should be implemented by this
@@ -300,7 +300,7 @@ class FixedBoundaryPipeBuilder(PipeBuilder):
         )
 
     def _get_spatial_regular_pipe_template(self, spec: PipeSpec) -> RectangularTemplate:
-        """Returns the template needed to implement the pipe representing the provided ``spec``."""
+        """Return the template needed to implement the pipe representing the provided ``spec``."""
         assert spec.pipe_kind.is_spatial
         match spec.pipe_kind.direction, spec.pipe_kind.has_hadamard:
             case Direction3D.X, False:

--- a/src/tqec/compile/specs/library/fixed_bulk.py
+++ b/src/tqec/compile/specs/library/fixed_bulk.py
@@ -38,7 +38,7 @@ class FixedBulkCubeBuilder(CubeBuilder):
         compiler: PlaquetteCompiler,
         translator: RPNGTranslator = DefaultRPNGTranslator(),
     ) -> None:
-        """Implementation of the :class:`.CubeBuilder` interface for the fixed bulk convention.
+        """Implement the :class:`.CubeBuilder` interface for the fixed bulk convention.
 
         This class provides an implementation following the fixed-bulk convention. This convention
         consists in the fact that the top-left most plaquette in the bulk always measures a known-
@@ -100,7 +100,7 @@ class FixedBulkPipeBuilder(PipeBuilder):
         compiler: PlaquetteCompiler,
         translator: RPNGTranslator = DefaultRPNGTranslator(),
     ) -> None:
-        """Implementation of the :class:`.PipeBuilder` interface for the fixed bulk convention.
+        """Implement the :class:`.PipeBuilder` interface for the fixed bulk convention.
 
         This class provides an implementation following the fixed-bulk convention. This convention
         consists in the fact that the top-left most plaquette in the bulk always measures a known-

--- a/src/tqec/compile/specs/library/fixed_bulk.py
+++ b/src/tqec/compile/specs/library/fixed_bulk.py
@@ -120,7 +120,7 @@ class FixedBulkPipeBuilder(PipeBuilder):
     #######################
 
     def _get_temporal_pipe_block(self, spec: PipeSpec) -> Block:
-        """Returns the block to implement a temporal pipe based on the provided ``spec``.
+        """Return the block to implement a temporal pipe based on the provided ``spec``.
 
         Args:
             spec: description of the pipe that should be implemented by this
@@ -141,7 +141,7 @@ class FixedBulkPipeBuilder(PipeBuilder):
         return self._get_temporal_non_hadamard_pipe_block(spec)
 
     def _get_temporal_non_hadamard_pipe_block(self, spec: PipeSpec) -> Block:
-        """Returns the block to implement a regular temporal junction without Hadamard transition.
+        """Return the block to implement a regular temporal junction without Hadamard transition.
 
         Args:
             spec: description of the pipe that should be implemented by this
@@ -278,7 +278,7 @@ class FixedBulkPipeBuilder(PipeBuilder):
         )
 
     def _get_spatial_regular_pipe_template(self, spec: PipeSpec) -> RectangularTemplate:
-        """Returns the template needed to implement the pipe representing the provided ``spec``."""
+        """Return the template needed to implement the pipe representing the provided ``spec``."""
         assert spec.pipe_kind.is_spatial
         match spec.pipe_kind.direction, spec.pipe_kind.has_hadamard:
             case Direction3D.X, False:

--- a/src/tqec/compile/specs/library/generators/fixed_boundary.py
+++ b/src/tqec/compile/specs/library/generators/fixed_boundary.py
@@ -263,7 +263,7 @@ class FixedBoundaryConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> tuple[RPNGDescription, RPNGDescription, RPNGDescription]:
-        """Returns a description of the 3 different plaquettes needed to perform a spatial hadamard
+        """Return a description of the 3 different plaquettes needed to perform a spatial hadamard
         transformation between two qubits aligned on the X axis.
 
         Args:
@@ -316,7 +316,7 @@ class FixedBoundaryConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> tuple[RPNGDescription, RPNGDescription, RPNGDescription]:
-        """Returns a description of the 3 different plaquettes needed to perform a spatial hadamard
+        """Return a description of the 3 different plaquettes needed to perform a spatial hadamard
         transformation between two qubits aligned on the Y axis.
 
         Args:
@@ -378,7 +378,7 @@ class FixedBoundaryConventionGenerator:
     #             Regular qubit            #
     ########################################
     def get_memory_qubit_raw_template(self) -> RectangularTemplate:
-        """Returns the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
+        """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement a single logical qubit.
         """
         return QubitTemplate()
@@ -390,7 +390,7 @@ class FixedBoundaryConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> FrozenDefaultDict[int, RPNGDescription]:
-        """Returns a description of the plaquettes needed to implement a standard memory operation
+        """Return a description of the plaquettes needed to implement a standard memory operation
         on a logical qubit.
 
         Warning:
@@ -448,7 +448,7 @@ class FixedBoundaryConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> Plaquettes:
-        """Returns the plaquettes needed to implement a standard memory operation on a logical
+        """Return the plaquettes needed to implement a standard memory operation on a logical
         qubit.
 
         Warning:
@@ -488,7 +488,7 @@ class FixedBoundaryConventionGenerator:
     #                X pipe                #
     ########################################
     def get_memory_vertical_boundary_raw_template(self) -> RectangularTemplate:
-        """Returns the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
+        """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement a regular spatial pipe between two logical qubits aligned on the ``X`` axis.
         """
         return QubitVerticalBorders()
@@ -500,7 +500,7 @@ class FixedBoundaryConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> FrozenDefaultDict[int, RPNGDescription]:
-        """Returns a description of the plaquettes needed to implement a standard memory operation
+        """Return a description of the plaquettes needed to implement a standard memory operation
         on a pipe between two neighbouring logical qubits aligned on the ``X``-axis.
 
         Note:
@@ -572,7 +572,7 @@ class FixedBoundaryConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> Plaquettes:
-        """Returns the plaquettes needed to implement a standard memory operation on a pipe between
+        """Return the plaquettes needed to implement a standard memory operation on a pipe between
         two neighbouring logical qubits aligned on the ``X``-axis.
 
         Note:
@@ -619,7 +619,7 @@ class FixedBoundaryConventionGenerator:
     #                Y pipe                #
     ########################################
     def get_memory_horizontal_boundary_raw_template(self) -> RectangularTemplate:
-        """Returns the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
+        """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement a regular spatial pipe between two logical qubits aligned on the ``Y`` axis.
         """
         return QubitHorizontalBorders()
@@ -631,7 +631,7 @@ class FixedBoundaryConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> FrozenDefaultDict[int, RPNGDescription]:
-        """Returns a description of the plaquettes needed to implement a standard memory operation
+        """Return a description of the plaquettes needed to implement a standard memory operation
         on a pipe between two neighbouring logical qubits aligned on the ``Y``-axis.
 
         Note:
@@ -703,7 +703,7 @@ class FixedBoundaryConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> Plaquettes:
-        """Returns the plaquettes needed to implement a standard memory operation on a pipe between
+        """Return the plaquettes needed to implement a standard memory operation on a pipe between
         two neighbouring logical qubits aligned on the ``Y``-axis.
 
         Note:
@@ -750,7 +750,7 @@ class FixedBoundaryConventionGenerator:
     #                          Spatial                         #
     ############################################################
     def get_spatial_cube_qubit_raw_template(self) -> RectangularTemplate:
-        """Returns the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
+        """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement a spatial cube.
 
         Note:
@@ -772,7 +772,7 @@ class FixedBoundaryConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> FrozenDefaultDict[int, RPNGDescription]:
-        """Returns a description of the plaquettes needed to implement a spatial cube.
+        """Return a description of the plaquettes needed to implement a spatial cube.
 
         Note:
             A spatial cube is defined as a cube with all its spatial boundaries
@@ -1036,7 +1036,7 @@ class FixedBoundaryConventionGenerator:
     #              Spatial arm             #
     ########################################
     def get_spatial_cube_arm_raw_template(self, arms: SpatialArms) -> RectangularTemplate:
-        """Returns the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
+        """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement the given spatial ``arms``.
 
         Args:
@@ -1083,7 +1083,7 @@ class FixedBoundaryConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> Plaquettes:
-        """Returns the plaquettes needed to implement **one** pipe connecting to a spatial cube.
+        """Return the plaquettes needed to implement **one** pipe connecting to a spatial cube.
 
         Note:
             A spatial cube is defined as a cube with all its spatial boundaries
@@ -1379,7 +1379,7 @@ class FixedBoundaryConventionGenerator:
     #           Regular junction           #
     ########################################
     def get_temporal_hadamard_raw_template(self) -> RectangularTemplate:
-        """Returns the :class:`~tqec.templates.base.Template` instance needed to implement a
+        """Return the :class:`~tqec.templates.base.Template` instance needed to implement a
         transversal Hadamard gate applied on one logical qubit.
         """
         return QubitTemplate()
@@ -1387,7 +1387,7 @@ class FixedBoundaryConventionGenerator:
     def get_temporal_hadamard_rpng_descriptions(
         self, is_reversed: bool, z_orientation: Orientation = Orientation.HORIZONTAL
     ) -> FrozenDefaultDict[int, RPNGDescription]:
-        """Returns a description of the plaquettes needed to implement a transversal Hadamard gate
+        """Return a description of the plaquettes needed to implement a transversal Hadamard gate
         applied on one logical qubit.
 
         Warning:
@@ -1475,7 +1475,7 @@ class FixedBoundaryConventionGenerator:
     #                X pipe                #
     ########################################
     def get_spatial_vertical_hadamard_raw_template(self) -> RectangularTemplate:
-        """Returns the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
+        """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement a spatial Hadamard pipe between two logical qubits aligned on the ``X`` axis.
         """
         return QubitVerticalBorders()
@@ -1487,7 +1487,7 @@ class FixedBoundaryConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> FrozenDefaultDict[int, RPNGDescription]:
-        """Returns a description of the plaquettes needed to implement a Hadamard spatial transition
+        """Return a description of the plaquettes needed to implement a Hadamard spatial transition
         between two neighbouring logical qubits aligned on the ``X`` axis.
 
         The Hadamard transition basically exchanges the ``X`` and ``Z`` logical
@@ -1597,7 +1597,7 @@ class FixedBoundaryConventionGenerator:
     #                Y pipe                #
     ########################################
     def get_spatial_horizontal_hadamard_raw_template(self) -> RectangularTemplate:
-        """Returns the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
+        """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement a spatial Hadamard pipe between two logical qubits aligned on the ``Y`` axis.
         """
         return QubitHorizontalBorders()
@@ -1609,7 +1609,7 @@ class FixedBoundaryConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> FrozenDefaultDict[int, RPNGDescription]:
-        """Returns a description of the plaquettes needed to implement a Hadamard spatial transition
+        """Return a description of the plaquettes needed to implement a Hadamard spatial transition
         between two neighbouring logical qubits aligned on the ``Y`` axis.
 
         The Hadamard transition basically exchanges the ``X`` and ``Z`` logical

--- a/src/tqec/compile/specs/library/generators/fixed_bulk.py
+++ b/src/tqec/compile/specs/library/generators/fixed_bulk.py
@@ -246,7 +246,7 @@ class FixedBulkConventionGenerator:
     #             Regular qubit            #
     ########################################
     def get_memory_qubit_raw_template(self) -> RectangularTemplate:
-        """Returns the template instance needed to implement a single logical qubit."""
+        """Return the template instance needed to implement a single logical qubit."""
         return QubitTemplate()
 
     def get_memory_qubit_rpng_descriptions(
@@ -255,7 +255,7 @@ class FixedBulkConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> FrozenDefaultDict[int, RPNGDescription]:
-        """Returns a description of the plaquettes needed to implement a standard memory operation
+        """Return a description of the plaquettes needed to implement a standard memory operation
         on a logical qubit.
 
         Warning:
@@ -315,7 +315,7 @@ class FixedBulkConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> Plaquettes:
-        """Returns the plaquettes needed to implement a standard memory operation on a logical
+        """Return the plaquettes needed to implement a standard memory operation on a logical
         qubit.
 
         Warning:
@@ -351,7 +351,7 @@ class FixedBulkConventionGenerator:
     #                X pipe                #
     ########################################
     def get_memory_vertical_boundary_raw_template(self) -> RectangularTemplate:
-        """Returns the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
+        """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement a regular spatial pipe between two logical qubits aligned on the ``X`` axis.
         """
         return QubitVerticalBorders()
@@ -362,7 +362,7 @@ class FixedBulkConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> FrozenDefaultDict[int, RPNGDescription]:
-        """Returns a description of the plaquettes needed to implement a standard memory operation
+        """Return a description of the plaquettes needed to implement a standard memory operation
         on a pipe between two neighbouring logical qubits aligned on the ``X``-axis.
 
         Note:
@@ -429,7 +429,7 @@ class FixedBulkConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> Plaquettes:
-        """Returns the plaquettes needed to implement a standard memory operation on a pipe between
+        """Return the plaquettes needed to implement a standard memory operation on a pipe between
         two neighbouring logical qubits aligned on the ``X``-axis.
 
         Note:
@@ -472,7 +472,7 @@ class FixedBulkConventionGenerator:
     #                Y pipe                #
     ########################################
     def get_memory_horizontal_boundary_raw_template(self) -> RectangularTemplate:
-        """Returns the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
+        """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement a regular spatial pipe between two logical qubits aligned on the ``Y`` axis.
         """
         return QubitHorizontalBorders()
@@ -483,7 +483,7 @@ class FixedBulkConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> FrozenDefaultDict[int, RPNGDescription]:
-        """Returns a description of the plaquettes needed to implement a standard memory operation
+        """Return a description of the plaquettes needed to implement a standard memory operation
         on a pipe between two neighbouring logical qubits aligned on the ``Y``-axis.
 
         Note:
@@ -550,7 +550,7 @@ class FixedBulkConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> Plaquettes:
-        """Returns the plaquettes needed to implement a standard memory operation on a pipe between
+        """Return the plaquettes needed to implement a standard memory operation on a pipe between
         two neighbouring logical qubits aligned on the ``Y``-axis.
 
         Note:
@@ -593,7 +593,7 @@ class FixedBulkConventionGenerator:
     #                          Spatial                         #
     ############################################################
     def get_spatial_cube_qubit_raw_template(self) -> RectangularTemplate:
-        """Returns the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
+        """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement a spatial cube.
 
         Note:
@@ -614,7 +614,7 @@ class FixedBulkConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> FrozenDefaultDict[int, RPNGDescription]:
-        """Returns a description of the plaquettes needed to implement a spatial cube.
+        """Return a description of the plaquettes needed to implement a spatial cube.
 
         Note:
             A spatial cube is defined as a cube with all its spatial boundaries
@@ -836,7 +836,7 @@ class FixedBulkConventionGenerator:
     #              Spatial arm             #
     ########################################
     def get_spatial_cube_arm_raw_template(self, arms: SpatialArms) -> RectangularTemplate:
-        """Returns the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
+        """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement the given spatial ``arms``.
 
         Args:
@@ -870,7 +870,7 @@ class FixedBulkConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> FrozenDefaultDict[int, RPNGDescription]:
-        """Returns a description of the plaquettes needed to implement **one** pipe connecting to a
+        """Return a description of the plaquettes needed to implement **one** pipe connecting to a
         spatial cube.
 
         Note:
@@ -944,7 +944,7 @@ class FixedBulkConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> Plaquettes:
-        """Returns the plaquettes needed to implement **one** pipe connecting to a spatial cube.
+        """Return the plaquettes needed to implement **one** pipe connecting to a spatial cube.
 
         Note:
             A spatial cube is defined as a cube with all its spatial boundaries
@@ -1111,7 +1111,7 @@ class FixedBulkConventionGenerator:
     ############################################################
 
     def get_temporal_hadamard_raw_template(self) -> RectangularTemplate:
-        """Returns the :class:`~tqec.templates.base.Template` instance needed to implement a
+        """Return the :class:`~tqec.templates.base.Template` instance needed to implement a
         transversal Hadamard gate applied on one logical qubit.
         """
         return QubitTemplate()
@@ -1183,7 +1183,7 @@ class FixedBulkConventionGenerator:
     #                X pipe                #
     ########################################
     def get_spatial_vertical_hadamard_raw_template(self) -> RectangularTemplate:
-        """Returns the :class:`~tqec.templates.base.Template` instance needed to implement a spatial
+        """Return the :class:`~tqec.templates.base.Template` instance needed to implement a spatial
         Hadamard pipe between two logical qubits aligned on the ``X`` axis.
         """
         raise self._not_implemented_exception()
@@ -1194,7 +1194,7 @@ class FixedBulkConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> FrozenDefaultDict[int, RPNGDescription]:
-        """Returns a description of the plaquettes needed to implement a Hadamard spatial transition
+        """Return a description of the plaquettes needed to implement a Hadamard spatial transition
         between two neighbouring logical qubits aligned on the ``X`` axis.
 
         The Hadamard transition basically exchanges the ``X`` and ``Z`` logical
@@ -1287,7 +1287,7 @@ class FixedBulkConventionGenerator:
     #                Y pipe                #
     ########################################
     def get_spatial_horizontal_hadamard_raw_template(self) -> RectangularTemplate:
-        """Returns the :class:`~tqec.templates.base.Template` instance needed to implement a spatial
+        """Return the :class:`~tqec.templates.base.Template` instance needed to implement a spatial
         Hadamard pipe between two neighbouring logical qubits aligned on the ``Y`` axis.
         """
         raise self._not_implemented_exception()
@@ -1298,7 +1298,7 @@ class FixedBulkConventionGenerator:
         reset: Basis | None = None,
         measurement: Basis | None = None,
     ) -> FrozenDefaultDict[int, RPNGDescription]:
-        """Returns a description of the plaquettes needed to implement a Hadamard spatial transition
+        """Return a description of the plaquettes needed to implement a Hadamard spatial transition
         between two neighbouring logical qubits aligned on the ``Y`` axis.
 
         The Hadamard transition basically exchanges the ``X`` and ``Z`` logical

--- a/src/tqec/compile/specs/library/generators/fixed_bulk.py
+++ b/src/tqec/compile/specs/library/generators/fixed_bulk.py
@@ -76,7 +76,7 @@ def make_fixed_bulk_realignment_plaquette(
 
 class FixedBulkConventionGenerator:
     def __init__(self, translator: RPNGTranslator, compiler: PlaquetteCompiler):
-        """Helper class containing the plaquette generation to implement the fixed bulk convention.
+        """Contain the plaquette generation procedures to implement the fixed bulk convention.
 
         Args:
             translator: instance used to translate :class:`.RPNGDescription` instances into

--- a/src/tqec/compile/tree/node.py
+++ b/src/tqec/compile/tree/node.py
@@ -89,7 +89,7 @@ class LayerNode:
 
     @property
     def is_leaf(self) -> bool:
-        """Returns ``True`` if ``self`` does not have any children and so is a leaf node."""
+        """Return ``True`` if ``self`` does not have any children and so is a leaf node."""
         return isinstance(self._layer, LayoutLayer)
 
     @property
@@ -99,7 +99,7 @@ class LayerNode:
 
     @property
     def repetitions(self) -> LinearFunction | None:
-        """Returns the number of repetitions of the node if ``self.is_repeated`` else ``None``."""
+        """Return the number of repetitions of the node if ``self.is_repeated`` else ``None``."""
         return self._layer.repetitions if isinstance(self._layer, RepeatedLayer) else None
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/tqec/computation/correlation.py
+++ b/src/tqec/computation/correlation.py
@@ -80,7 +80,7 @@ class ZXEdge:
 
 @dataclass(frozen=True)
 class CorrelationSurface:
-    """Represents a set of measurements whose values determine the parity of the logical operators.
+    """Represent a set of measurements whose values determine the parity of the logical operators.
 
     A correlation surface in a computation is a set of measurements whose values determine the
     parity of the logical operators at the inputs and outputs associated with the surface.

--- a/src/tqec/interop/collada/_correlation.py
+++ b/src/tqec/interop/collada/_correlation.py
@@ -16,7 +16,7 @@ TransformationResult = tuple[Basis, _Transformation]
 
 class CorrelationSurfaceTransformationHelper:
     def __init__(self, block_graph: BlockGraph, pipe_length: float):
-        """Helper class to compute transformations of correlation surfaces pieces in a BlockGraph.
+        """Help computing transformations of correlation surfaces pieces in a :class:`.BlockGraph`.
 
         The correlation surface is decomposed into small pieces of surfaces that can be transformed
         from a single 1x1 square surface in the XY-plane. This class computes the transformations

--- a/src/tqec/interop/collada/_correlation.py
+++ b/src/tqec/interop/collada/_correlation.py
@@ -31,7 +31,7 @@ class CorrelationSurfaceTransformationHelper:
         self,
         correlation_surface: CorrelationSurface,
     ) -> list[TransformationResult]:
-        """Returns the transformations representing each piece of the ``correlation_surface``."""
+        """Return the transformations representing each piece of the ``correlation_surface``."""
         transformations: list[TransformationResult] = []
 
         # Surfaces in the pipes

--- a/src/tqec/interop/collada/read_write.py
+++ b/src/tqec/interop/collada/read_write.py
@@ -430,7 +430,7 @@ class _BaseColladaData:
         self,
         pop_faces_at_direction: SignedDirection3D | None = None,
     ) -> None:
-        """Base model template.
+        """Encode the base model template.
 
         This class includes the definition of all the library nodes and the necessary material,
         geometry definitions.

--- a/src/tqec/interop/color.py
+++ b/src/tqec/interop/color.py
@@ -36,7 +36,7 @@ class RGBA:
         return RGBA(self.r, self.g, self.b, a)
 
     def as_floats(self) -> tuple[float, float, float, float]:
-        """Returns the color as a tuple of floats. RGB values are normalized to the range [0, 1].
+        """Return the color as a tuple of floats. RGB values are normalized to the range [0, 1].
 
         Returns:
             Length 4 tuple of floats representing the color.
@@ -81,7 +81,7 @@ class TQECColor(Enum):
             return RGBA(0, 0, 255, 0.8)
 
     def with_zx_flipped(self) -> TQECColor:
-        """Returns a ``X`` or ``Z`` color from a ``Z`` or ``X`` color and vice versa."""
+        """Return a ``X`` or ``Z`` color from a ``Z`` or ``X`` color and vice versa."""
         if self == TQECColor.X:
             return TQECColor.Z
         if self == TQECColor.Z:

--- a/src/tqec/plaquette/compilation/base.py
+++ b/src/tqec/plaquette/compilation/base.py
@@ -18,7 +18,7 @@ class PlaquetteCompiler:
         passes: Iterable[CompilationPass],
         mergeable_instructions_modifier: Callable[[frozenset[str]], frozenset[str]],
     ):
-        """A wrapper around a list of :class:`.CompilationPass` instances."""
+        """Wrap a list of :class:`.CompilationPass` instances."""
         self._name = name
         self._passes = passes
         self._mergeable_instructions_modifier = mergeable_instructions_modifier

--- a/src/tqec/plaquette/compilation/passes/scheduling.py
+++ b/src/tqec/plaquette/compilation/passes/scheduling.py
@@ -9,7 +9,7 @@ from tqec.utils.exceptions import TQECError
 
 @dataclass
 class ScheduleMap:
-    """Represents a map from schedules to schedules."""
+    """Represent a map from schedules to schedules."""
 
     map: dict[int, int]
 

--- a/src/tqec/plaquette/debug.py
+++ b/src/tqec/plaquette/debug.py
@@ -66,7 +66,7 @@ class PlaquetteDebugInformation:
         return None
 
     def with_data_qubits_removed(self, removed_data_qubits: list[int]) -> PlaquetteDebugInformation:
-        """Returns a copy of ``self`` without any information on ``removed_data_qubits``."""
+        """Return a copy of ``self`` without any information on ``removed_data_qubits``."""
         if self.rpng is None:
             return self
         corners: list[RPNG] = list(self.rpng.corners)

--- a/src/tqec/plaquette/plaquette.py
+++ b/src/tqec/plaquette/plaquette.py
@@ -20,7 +20,7 @@ from tqec.utils.position import PhysicalQubitPosition2D
 
 @dataclass(frozen=True)
 class Plaquette:
-    """Represents a QEC plaquette.
+    """Represent a QEC plaquette.
 
     This class stores qubits in the plaquette local coordinate system and a
     scheduled circuit that should be applied on those qubits to perform the

--- a/src/tqec/plaquette/rpng/rpng.py
+++ b/src/tqec/plaquette/rpng/rpng.py
@@ -34,7 +34,7 @@ class ExtendedBasis(Enum):
 
 @dataclass(frozen=True)
 class RPNG:
-    """Represents a single ``RPNG`` string.
+    """Represent a single ``RPNG`` string.
 
     ## Format specification
 

--- a/src/tqec/plaquette/rpng/rpng.py
+++ b/src/tqec/plaquette/rpng/rpng.py
@@ -194,7 +194,7 @@ class RPNGDescription:
     ancilla: RG = field(default=RG(PauliBasis.X, PauliBasis.X))
 
     def __post_init__(self) -> None:
-        """Validation of the initialization arguments.
+        """Validate the initialization arguments.
 
         Constraints:
         - the n values for the corners must be unique

--- a/src/tqec/post_processing/filter.py
+++ b/src/tqec/post_processing/filter.py
@@ -9,7 +9,7 @@ from tqec.utils.exceptions import TQECWarning
 def subcircuit_only_on_indices(
     circuit: stim.Circuit, qubit_indices: frozenset[int]
 ) -> stim.Circuit:
-    """Returns a new circuit with only operations applied on qubit targets in ``qubit_indices``.
+    """Return a new circuit with only operations applied on qubit targets in ``qubit_indices``.
 
     Note:
         Non-qubit targets are not considered for filtering. That means that an

--- a/src/tqec/simulation/plotting/inset.py
+++ b/src/tqec/simulation/plotting/inset.py
@@ -15,7 +15,7 @@ from tqec.interop.pyzx.positioned import PositionedZX
 
 
 def add_inset_axes3d(ax_target: Axes, bounds: tuple[float, float, float, float]) -> Axes3D:
-    """Wrapper around ``fig.add_axes`` to achieve ``ax.inset_axes`` functionality for 3D."""
+    """Wrap ``fig.add_axes`` to achieve ``ax.inset_axes`` functionality for 3D."""
     ax = ax_target.inset_axes(bounds, projection="3d")
     assert isinstance(ax, Axes3D)
     return ax

--- a/src/tqec/templates/base.py
+++ b/src/tqec/templates/base.py
@@ -110,7 +110,7 @@ class Template(ABC):
     @property
     @abstractmethod
     def expected_plaquettes_number(self) -> int:
-        """Returns the number of plaquettes expected from the :py:meth:`instantiate` method.
+        """Return the number of plaquettes expected from the :py:meth:`instantiate` method.
 
         Returns:
             the number of plaquettes expected from the :py:meth:`instantiate` method.
@@ -129,7 +129,7 @@ class Template(ABC):
     def get_spatially_distinct_subtemplates(
         self, k: int, manhattan_radius: int = 1, avoid_zero_plaquettes: bool = True
     ) -> UniqueSubTemplates:
-        """Returns a representation of the distinct sub-templates of the provided Manhattan radius.
+        """Return a representation of the distinct sub-templates of the provided Manhattan radius.
 
         Note:
             This method will likely be inefficient for large templates (i.e., large

--- a/src/tqec/templates/layout.py
+++ b/src/tqec/templates/layout.py
@@ -235,7 +235,7 @@ class LayoutTemplate(Template):
     @property
     @override
     def expected_plaquettes_number(self) -> int:
-        """Returns the number of plaquettes expected from the ``instantiate`` method.
+        """Return the number of plaquettes expected from the ``instantiate`` method.
 
         Returns:
             the number of plaquettes expected from the `instantiate` method.

--- a/src/tqec/templates/layout.py
+++ b/src/tqec/templates/layout.py
@@ -171,7 +171,7 @@ class LayoutTemplate(Template):
     def get_global_plaquettes(
         self, individual_plaquettes: Mapping[BlockPosition2D, Plaquettes]
     ) -> Plaquettes:
-        """Merges ``individual_plaquettes`` into a single :class:`.Plaquettes` instance.
+        """Merge ``individual_plaquettes`` into a single :class:`.Plaquettes` instance.
 
         The returned :class:`.Plaquettes` instance can then be used to instantiate ``self``.
 

--- a/src/tqec/templates/subtemplates.py
+++ b/src/tqec/templates/subtemplates.py
@@ -125,7 +125,7 @@ def get_spatially_distinct_subtemplates(
     manhattan_radius: int = 1,
     avoid_zero_plaquettes: bool = True,
 ) -> UniqueSubTemplates:
-    r"""Returns a representation of all the distinct sub-templates of the provided Manhattan radius.
+    r"""Return a representation of all the distinct sub-templates of the provided Manhattan radius.
 
     Note:
         This function will likely be inefficient for large templates (i.e.,
@@ -332,7 +332,7 @@ class Unique3DSubTemplates:
 def get_spatially_distinct_3d_subtemplates(
     instantiations: Sequence[npt.NDArray[numpy.int_]], manhattan_radius: int = 1
 ) -> Unique3DSubTemplates:
-    r"""Returns all the distinct 3-dimensional sub-templates of the provided Manhattan radius.
+    r"""Return all the distinct 3-dimensional sub-templates of the provided Manhattan radius.
 
     Note:
         This function will likely be inefficient for large templates (i.e.,

--- a/src/tqec/utils/noise_model.py
+++ b/src/tqec/utils/noise_model.py
@@ -419,7 +419,7 @@ class NoiseModel:
 
 
 def occurs_in_classical_control_system(op: stim.CircuitInstruction) -> bool:
-    """Determines if an operation is an annotation or a classical control system update."""
+    """Determine if an operation is an annotation or a classical control system update."""
     t = OP_TYPES[op.name]
     if t == ANNOTATION:
         return True
@@ -439,7 +439,7 @@ def occurs_in_classical_control_system(op: stim.CircuitInstruction) -> bool:
 def _split_targets_if_needed(
     op: stim.CircuitInstruction, immune_qubits: Set[int]
 ) -> Iterator[stim.CircuitInstruction]:
-    """Splits operations into pieces as needed.
+    """Split operations into pieces as needed.
 
     This function splits operations, for example ``MPP`` into each product, classical control away
     from quantum ops, ...
@@ -470,7 +470,7 @@ def _split_targets_if_needed_clifford_1q(
 def _split_targets_if_needed_clifford_2q(
     op: stim.CircuitInstruction, immune_qubits: Set[int]
 ) -> Iterator[stim.CircuitInstruction]:
-    """Splits classical control system operations away from quantum operations."""
+    """Split classical control system operations away from quantum operations."""
     assert OP_TYPES[op.name] == CLIFFORD_2Q
     targets = op.targets_copy()
     if immune_qubits or any(t.is_measurement_record_target for t in targets):
@@ -484,7 +484,7 @@ def _split_targets_if_needed_clifford_2q(
 def _split_targets_if_needed_m_basis(
     op: stim.CircuitInstruction, immune_qubits: Set[int]
 ) -> Iterator[stim.CircuitInstruction]:
-    """Splits an MPP operation into one operation for each Pauli product it measures."""
+    """Split an MPP operation into one operation for each Pauli product it measures."""
     targets = op.targets_copy()
     args = op.gate_args_copy()
     k = 0
@@ -534,7 +534,7 @@ def _iter_split_op_moments(
 
 
 def _measure_basis(*, split_op: stim.CircuitInstruction) -> str | None:
-    """Converts an operation into a string describing the Pauli product basis it measures.
+    """Convert an operation into a string describing the Pauli product basis it measures.
 
     Returns:
         None: This is not a measurement (or not *just* a measurement).

--- a/src/tqec/utils/noise_model.py
+++ b/src/tqec/utils/noise_model.py
@@ -369,7 +369,7 @@ class NoiseModel:
         system_qubits: set[int] | None = None,
         immune_qubits: set[int] | None = None,
     ) -> stim.Circuit:
-        """Returns a noisy version of the given circuit, by applying the receiving noise model.
+        """Return a noisy version of the given circuit, by applying the receiving noise model.
 
         Args:
             circuit: The circuit to layer noise over.

--- a/src/tqec/utils/position.py
+++ b/src/tqec/utils/position.py
@@ -52,7 +52,7 @@ class Vec3D:
 
 
 class Position2D(Vec2D):
-    """Represents a position on a 2-dimensional plane.
+    """Represent a position on a 2-dimensional plane.
 
     Warning:
         This class represents a position without any knowledge of the coordinate
@@ -76,11 +76,11 @@ class Position2D(Vec2D):
 
 
 class PhysicalQubitPosition2D(Position2D):
-    """Represents the position of a physical qubit on a 2-dimensional plane."""
+    """Represent the position of a physical qubit on a 2-dimensional plane."""
 
 
 class PlaquettePosition2D(Position2D):
-    """Represents the position of a plaquette on a 2-dimensional plane."""
+    """Represent the position of a plaquette on a 2-dimensional plane."""
 
     def get_origin_position(self, shift: Shift2D) -> PhysicalQubitPosition2D:
         """Return the position of the plaquette origin."""
@@ -88,7 +88,7 @@ class PlaquettePosition2D(Position2D):
 
 
 class BlockPosition2D(Position2D):
-    """Represents the position of a block on a 2-dimensional plane."""
+    """Represent the position of a block on a 2-dimensional plane."""
 
     def get_top_left_plaquette_position(self, block_shape: PlaquetteShape2D) -> PlaquettePosition2D:
         """Return the position of the top-left plaquette of the block."""
@@ -112,11 +112,11 @@ class Shape2D(Vec2D):
 
 
 class PlaquetteShape2D(Shape2D):
-    """Represents a 2-dimensional shape using plaquette coordinate system."""
+    """Represent a 2-dimensional shape using plaquette coordinate system."""
 
 
 class PhysicalQubitShape2D(Shape2D):
-    """Represents a 2-dimensional shape using physical qubit coordinate system."""
+    """Represent a 2-dimensional shape using physical qubit coordinate system."""
 
 
 class Shift2D(Vec2D):
@@ -164,7 +164,7 @@ class Position3D(Vec3D):
 
 
 class BlockPosition3D(Position3D):
-    """Represents the position of a block in 3D space."""
+    """Represent the position of a block in 3D space."""
 
     def as_2d(self) -> BlockPosition2D:
         """Return ``self`` as a 2-dimensional position, ignoring the ``z`` coordinate."""

--- a/src/tqec/utils/rotations.py
+++ b/src/tqec/utils/rotations.py
@@ -47,7 +47,7 @@ from tqec.utils.scale import round_or_fail
 def calc_rotation_angles(
     rotation_matrix: npt.NDArray[np.float32],
 ) -> npt.NDArray[np.float32]:
-    """Calculates the rotation angles of the three rows of matrix (M) from the original X/Y/Z axes.
+    """Calculate the rotation angles of the three rows of matrix (M) from the original X/Y/Z axes.
 
     Args:
         rotation_matrix: rotation matrix for node, extracted from `.dae` file.
@@ -207,7 +207,7 @@ def rotate_on_import(
     scale_matrix: npt.NDArray[np.float32],
     kind: BlockKind,
 ) -> tuple[FloatPosition3D, BlockKind]:
-    """Updates the kind of an incoming block when rotated.
+    """Update the kind of an incoming block when rotated.
 
     The block kind is only updated when its translation matrix indicates the original block has been
     rotated, rejecting any invalid rotation in the process.

--- a/src/tqec/utils/scale.py
+++ b/src/tqec/utils/scale.py
@@ -28,7 +28,7 @@ from tqec.utils.position import PhysicalQubitShape2D, PlaquetteShape2D, Shape2D,
 
 @dataclass(frozen=True)
 class LinearFunction:
-    """Represents a linear function.
+    """Represent a linear function.
 
     A linear function is fully described with a slope and an offset.
 

--- a/src/tqec/visualisation/computation/errors.py
+++ b/src/tqec/visualisation/computation/errors.py
@@ -51,7 +51,7 @@ def get_errors_svg(
     size: float = 1,
     add_detectors_from_errors: bool = True,
 ) -> svg.G:
-    """Returns an SVG element with the provided ``errors`` drawn and a transparent background.
+    """Return an SVG element with the provided ``errors`` drawn and a transparent background.
 
     Args:
         errors: a sequence of errors to plot. It is often desirable to filter

--- a/src/tqec/visualisation/computation/observable.py
+++ b/src/tqec/visualisation/computation/observable.py
@@ -40,7 +40,7 @@ def get_observable_svg(
     plaquette_height: float,
     configuration: DrawerConfiguration = DrawerConfiguration(),
 ) -> svg.G:
-    """Returns an SVG element with the provided ``observable`` drawn and a transparent background.
+    """Return an SVG element with the provided ``observable`` drawn and a transparent background.
 
     Args:
         observable: the observable to plot. It is represented as a list of qubits

--- a/src/tqec/visualisation/computation/plaquette/extended.py
+++ b/src/tqec/visualisation/computation/plaquette/extended.py
@@ -207,7 +207,7 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
         self,
         configuration: DrawerConfiguration = DrawerConfiguration(),
     ) -> list[svg.Text]:
-        """Returns a SVG element containing data-qubit interaction orders as text.
+        """Return a SVG element containing data-qubit interaction orders as text.
 
         This function returns one SVG element per non-empty corners, each containing a text element
         with the time slice at which a 2-qubit operation is applied on the corner qubit.
@@ -268,7 +268,7 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
         self,
         configuration: DrawerConfiguration = DrawerConfiguration(),
     ) -> svg.Line | None:
-        """Returns a SVG line showing the direction of the hook error.
+        """Return a SVG line showing the direction of the hook error.
 
         Args:
             configuration: drawing configuration.
@@ -317,7 +317,7 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
         self,
         configuration: DrawerConfiguration = DrawerConfiguration(),
     ) -> svg.G:
-        """Returns a SVG layer containing a representation of data-qubit resets/measurements.
+        """Return a SVG layer containing a representation of data-qubit resets/measurements.
 
         Args:
             configuration: drawing configuration.

--- a/src/tqec/visualisation/computation/plaquette/rpng.py
+++ b/src/tqec/visualisation/computation/plaquette/rpng.py
@@ -98,7 +98,7 @@ class RPNGPlaquetteDrawer(SVGPlaquetteDrawer):
         self,
         configuration: DrawerConfiguration = DrawerConfiguration(),
     ) -> svg.Element:
-        """Returns the plaquette shape, filled iff it measures in a uniform Pauli basis.
+        """Return the plaquette shape, filled iff it measures in a uniform Pauli basis.
 
         This method returns the plaquette shape as an SVG path. It might also fill this shape if
         ``self`` represents a plaquette measuring its qubits in the same Pauli basis, else without
@@ -166,7 +166,7 @@ class RPNGPlaquetteDrawer(SVGPlaquetteDrawer):
         self,
         configuration: DrawerConfiguration = DrawerConfiguration(),
     ) -> list[svg.Element]:
-        """Returns one SVG element per non-empty corners filling each corresponding quarter.
+        """Return one SVG element per non-empty corners filling each corresponding quarter.
 
         This method should only be called if the plaquette drawn by self measures data-qubits in a
         non-uniform Pauli basis (e.g. ZXXZ).
@@ -208,7 +208,7 @@ class RPNGPlaquetteDrawer(SVGPlaquetteDrawer):
         self,
         configuration: DrawerConfiguration = DrawerConfiguration(),
     ) -> list[svg.Text]:
-        """Returns a SVG element containing data-qubit interaction orders as text.
+        """Return a SVG element containing data-qubit interaction orders as text.
 
         This function returns one SVG element per non-empty corners, each containing a text element
         with the time slice at which a 2-qubit operation is applied on the corner qubit.
@@ -244,7 +244,7 @@ class RPNGPlaquetteDrawer(SVGPlaquetteDrawer):
         self,
         configuration: DrawerConfiguration = DrawerConfiguration(),
     ) -> svg.Line | None:
-        """Returns a SVG line showing the direction of the hook error.
+        """Return a SVG line showing the direction of the hook error.
 
         Args:
             configuration: drawing configuration.
@@ -273,7 +273,7 @@ class RPNGPlaquetteDrawer(SVGPlaquetteDrawer):
         self,
         configuration: DrawerConfiguration = DrawerConfiguration(),
     ) -> svg.G:
-        """Returns a SVG layer containing a representation of data-qubit resets/measurements.
+        """Return a SVG layer containing a representation of data-qubit resets/measurements.
 
         Args:
             configuration: drawing configuration.

--- a/src/tqec/visualisation/computation/tree.py
+++ b/src/tqec/visualisation/computation/tree.py
@@ -158,7 +158,7 @@ class LayerVisualiser(NodeWalker):
             return 0
 
     def get_moment_text(self, start: int, end: int) -> svg.Text:
-        """Returns an SVG representation of a text indicating the moments covered by [start, end].
+        """Return an SVG representation of a text indicating the moments covered by [start, end].
 
         Args:
             start: initial moment.


### PR DESCRIPTION
Some Ruff error codes were still ignored, probably due to a merge mistake. 

This PR un-ignore them, and fix the errors.