### PR TITLE
fix description

### DIFF
--- a/src/tqec/compile/specs/library/generators/fixed_boundary.py
+++ b/src/tqec/compile/specs/library/generators/fixed_boundary.py
@@ -327,9 +327,9 @@ class FixedBoundaryConventionGenerator:
             a tuple ``(bulk1, bulk2, left)`` containing:
 
             - ``bulk1``, a square plaquette with its two top-most data-qubits
-              measuring ``top_left_basis`` stabilizer.
-            - ``bulk2``, a square plaquette with its two left-most data-qubits
               measuring ``top_left_basis.flipped()`` stabilizer.
+            - ``bulk2``, a square plaquette with its two top-most data-qubits
+              measuring ``top_left_basis`` stabilizer.
             - ``left``, a plaquette measuring a weight 2 stabilizer with its
               top-most data-qubit measuring ``top_left_basis`` stabilizer and
               bottom-most data-qubit measuring ``top_left_basis.flipped()``


### PR DESCRIPTION
A quick fix to the description of one of the functions for the spatial horizontal hadamard. The function was behaving correctly, but the description confusingly didn't match. 

I thought it was clearer to push this separately, rather than wrap it into my more complicated push implementing the other spatial hadamard situations.