### PR TITLE
A polynomial-time algorithm for finding correlation surfaces

### DIFF
--- a/src/tqec/interop/pyzx/correlation_experimental.py
+++ b/src/tqec/interop/pyzx/correlation_experimental.py
@@ -1,0 +1,427 @@
+"""Defines the :class:`.CorrelationSurface` class and functions to find them in a ZX graph."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from functools import partial, reduce
+from itertools import chain, combinations, product
+
+import networkx as nx
+import stim
+from pyzx.graph.graph_s import GraphS
+from pyzx.pauliweb import PauliWeb, multiply_paulis
+from pyzx.utils import FractionLike, VertexType
+
+from tqec.computation.correlation import CorrelationSurface, ZXEdge, ZXNode
+from tqec.interop.pyzx.utils import (
+    is_boundary,
+    is_hardmard,
+    is_s,
+    is_x_no_phase,
+    is_z_no_phase,
+    is_zx_no_phase,
+)
+from tqec.utils.enums import Basis, Pauli
+from tqec.utils.exceptions import TQECError
+
+
+def correlation_surface_to_pauli_web(
+    correlation_surface: CorrelationSurface, g: GraphS
+) -> PauliWeb[int, tuple[int, int]]:
+    """Convert the correlation surface to a Pauli web.
+
+    Args:
+        correlation_surface: The correlation surface to convert.
+        g: The ZX graph the correlation surface is based on.
+
+    Returns:
+        A `PauliWeb` representation of the correlation surface.
+
+    """
+    half_edge_bases: dict[tuple[int, int], set[str]] = {}
+    for edge in correlation_surface.span:
+        u, v = edge.u, edge.v
+        half_edge_bases.setdefault((u.id, v.id), set()).add(u.basis.value)
+        half_edge_bases.setdefault((v.id, u.id), set()).add(v.basis.value)
+
+    pauli_web = PauliWeb(g)
+    for e, bases in half_edge_bases.items():
+        pauli = reduce(multiply_paulis, bases, "I")
+        pauli_web.add_half_edge(e, pauli)
+    return pauli_web
+
+
+def pauli_web_to_correlation_surface(
+    pauli_web: PauliWeb[int, tuple[int, int]],
+) -> CorrelationSurface:
+    """Create a correlation surface from a Pauli web."""
+    span: set[ZXEdge] = set()
+    half_edges: dict[tuple[int, int], str] = pauli_web.half_edges()
+    while half_edges:
+        (u, v), pauli_u = half_edges.popitem()
+        pauli_v = half_edges.pop((v, u))
+        if pauli_u == "Y":  # pragma: no cover
+            span.add(ZXEdge(ZXNode(u, Basis.X), ZXNode(v, Basis.Z)))
+            span.add(ZXEdge(ZXNode(u, Basis.Z), ZXNode(v, Basis.Z)))
+            continue
+        span.add(ZXEdge(ZXNode(u, Basis(pauli_u)), ZXNode(v, Basis(pauli_v))))
+    return CorrelationSurface(frozenset(span))
+
+
+def find_correlation_surfaces(
+    g: GraphS, reduce_to_minimal_generators: bool = True
+) -> list[CorrelationSurface]:
+    """Find the correlation surfaces in a ZX graph.
+
+    Starting from each leaf node in the graph, the function explores how can the X/Z logical
+    observable move through the graph to form a correlation surface:
+
+    - For a X/Z type leaf node, it can only support the logical observable with the opposite type.
+      Only a single type of logical observable is explored from the leaf node.
+    - For a Y type leaf node, it can only support the Y logical observable, i.e. the presence of
+      both X and Z logical observable. Both X and Z type logical observable are explored from the
+      leaf node. And the two correlation surfaces are combined to form the Y type correlation
+      surface.
+    - For the BOUNDARY node, it can support any type of logical observable. Both X and Z type
+      logical observable are explored from it.
+
+    Args:
+        g: The ZX graph to find the correlation surfaces.
+        reduce_to_minimal_generators: Whether to reduce the correlation surfaces to the minimal
+            generators. Other correlation surfaces can be obtained by multiplying the generators.
+            The generators are chosen to be the smallest in terms of the correlation surface area.
+            Default is `True`.
+
+    Returns:
+        A list of `CorrelationSurface` in the graph.
+
+    """
+    _check_spiders_are_supported(g)
+    # Edge case: single node graph
+    if g.num_vertices() == 1:
+        v = next(iter(g.vertices()))
+        basis = Basis.X if is_z_no_phase(g, v) else Basis.Z
+        node = ZXNode(v, basis)
+        return [CorrelationSurface(frozenset({ZXEdge(node, node)}))]
+    # Find correlation surfaces starting from each leaf node
+    leaves = {v for v in g.vertices() if g.vertex_degree(v) == 1}
+    if not leaves:
+        raise TQECError(
+            "The graph must contain at least one leaf node to find correlation surfaces."
+        )
+    correlation_surfaces = _find_correlation_surfaces_from_leaf(g, next(iter(leaves)))
+
+    if CorrelationSurface(frozenset()) in correlation_surfaces:
+        correlation_surfaces.remove(CorrelationSurface(frozenset()))
+
+    if reduce_to_minimal_generators:
+        stabilizers_to_surfaces = {
+            surface.external_stabilizer(sorted(leaves)): surface for surface in correlation_surfaces
+        }
+        stabilizers_to_surfaces.pop("I" * len(leaves), None)
+        correlation_surfaces = set(
+            reduce_observables_to_minimal_generators(stabilizers_to_surfaces).values()
+        )
+
+    # sort the correlation surfaces to make the result deterministic
+    return sorted(correlation_surfaces, key=lambda x: sorted(x.span))
+
+
+def _find_correlation_surfaces_from_leaf(
+    g: GraphS,
+    leaf: int,
+) -> list[CorrelationSurface]:
+    """Find the correlation surfaces starting from a leaf node in the graph."""
+    bases_at_leaves: dict[int, Pauli] = {}
+    for closed_leaf in filter(
+        lambda v: g.vertex_degree(v) == 1 and not is_boundary(g, v), g.vertices()
+    ):
+        if is_s(g, closed_leaf):
+            bases_at_leaves[closed_leaf] = Pauli.Y
+        elif is_z_no_phase(g, closed_leaf):
+            bases_at_leaves[closed_leaf] = Pauli.X
+        elif is_x_no_phase(g, closed_leaf):
+            bases_at_leaves[closed_leaf] = Pauli.Z
+        else:
+            raise TQECError(f"Unsupported leaf node type: {g.type(closed_leaf)}.")
+    neighbor = next(iter(g.neighbors(leaf)))
+    pauli_graphs = []
+    for basis in (
+        [bases_at_leaves[leaf]] if leaf in bases_at_leaves else [Pauli.X, Pauli.Z, Pauli.Y]
+    ) + [Pauli.I]:
+        graph = nx.Graph()
+        graph.add_node(leaf)
+        graph.nodes[leaf][neighbor] = basis
+        graph.add_node(neighbor)
+        graph.nodes[neighbor][leaf] = _flip_pauli_based_on_edge_type(g, (leaf, neighbor), basis)
+        graph.add_edge(leaf, neighbor)
+        pauli_graphs.append(graph)
+    if g.vertex_degree(neighbor) == 1:  # make sure no leaf node will be in the frontier
+        frontier = []
+        if neighbor in bases_at_leaves:
+            pauli_graphs = filter(
+                lambda pg: pg.nodes[neighbor][leaf] in (bases_at_leaves[neighbor], Pauli.I),
+                pauli_graphs,
+            )
+    else:
+        frontier = [neighbor]
+        explored_leaves = [leaf]
+
+    while frontier:
+        cur = frontier.pop()
+        unconnected_neighbors = sorted(
+            filter(lambda n: n not in pauli_graphs[0][cur], g.neighbors(cur))
+        )
+        neighbor_leaves_bases = {
+            n: _flip_pauli_based_on_edge_type(g, (cur, n), bases_at_leaves[n])
+            for n in unconnected_neighbors
+            if n in bases_at_leaves
+        }
+        unexplored_neighbors = [n for n in unconnected_neighbors if n not in pauli_graphs[0]]
+
+        new_pauli_graphs = []
+        stabilizer_list = []
+        for pauli_graph in pauli_graphs:
+            incident_paulis = list(pauli_graph.nodes[cur].values())
+            if not is_zx_no_phase(g, cur):
+                raise TQECError(
+                    f"Unsupported non-leaf node type: {g.type(cur)} with phase {g.phase(cur)}."
+                )
+            broadcast_basis = "X" if g.type(cur) == VertexType.Z else "Z"
+            broadcast_supports = [p.has_basis(broadcast_basis) for p in incident_paulis]
+            if all(broadcast_supports):
+                broadcast_pauli = Pauli[broadcast_basis]
+            elif not any(broadcast_supports):
+                broadcast_pauli = Pauli.I
+            else:  # invalid broadcast
+                continue
+
+            passthrough_basis = Basis[broadcast_basis].flipped()
+            passthrough_parity = sum(p.has_basis(passthrough_basis) for p in incident_paulis) % 2
+            if not unconnected_neighbors and passthrough_parity:  # invalid passthrough
+                continue
+
+            passthrough_nodes_list = list(
+                chain.from_iterable(
+                    combinations(unconnected_neighbors, num_passthrough)
+                    for num_passthrough in range(
+                        passthrough_parity,
+                        len(unconnected_neighbors) + 1,
+                        2,
+                    )
+                )
+            )
+            out_paulis_list = [
+                {
+                    n: (
+                        broadcast_pauli * Pauli[passthrough_basis.value]
+                        if n in passthrough_nodes
+                        else broadcast_pauli
+                    )
+                    for n in unconnected_neighbors
+                }
+                for passthrough_nodes in passthrough_nodes_list
+            ]
+
+            for out_paulis in out_paulis_list:
+                if any(
+                    out_paulis[n] not in (pauli, Pauli.I)
+                    for n, pauli in neighbor_leaves_bases.items()
+                ):
+                    continue
+                stabilizer = stim.PauliString(
+                    "".join(
+                        pauli.value
+                        for pauli in list(
+                            chain.from_iterable(
+                                pauli_graph.nodes[n].values() for n in explored_leaves + frontier
+                            )
+                        )
+                        + list(out_paulis.values())
+                    )
+                )
+                if _can_be_generated_by(stabilizer, stabilizer_list):
+                    continue
+                if stabilizer != stim.PauliString("I" * len(stabilizer)):
+                    stabilizer_list.append(stabilizer)
+                new_pauli_graph = pauli_graph.copy()
+                for n, pauli in out_paulis.items():
+                    if n not in new_pauli_graph:
+                        new_pauli_graph.add_node(n)
+                    new_pauli_graph.nodes[n][cur] = _flip_pauli_based_on_edge_type(
+                        g, (cur, n), pauli
+                    )
+                    new_pauli_graph.add_edge(cur, n)
+                    new_pauli_graph.nodes[cur][n] = pauli
+                new_pauli_graphs.append(new_pauli_graph)
+
+        pauli_graphs = new_pauli_graphs
+        if not pauli_graphs:  # there is no valid correlation surface on this ZX graph
+            return []
+        frontier.extend(
+            filter(
+                lambda n: g.vertex_degree(n) > 1 and n not in pauli_graph,
+                unexplored_neighbors,
+            )
+        )
+        explored_leaves.extend(filter(lambda n: g.vertex_degree(n) == 1, unexplored_neighbors))
+
+    correlation_surfaces = list(map(partial(_pauli_graph_to_correlation_surface, g), pauli_graphs))
+    return correlation_surfaces
+
+
+def _pauli_graph_to_correlation_surface(
+    g: GraphS,
+    pauli_graph: nx.Graph,
+) -> CorrelationSurface:
+    """Convert a Pauli graph to a correlation surface."""
+    span: set[ZXEdge] = set()
+    for u, v in pauli_graph.edges():
+        pauli_u = pauli_graph.nodes[u][v]
+        pauli_v = pauli_graph.nodes[v][u]
+        for basis_u, basis_v in product(Basis, repeat=2):
+            if (
+                (is_hardmard(g, (u, v)) ^ (basis_u == basis_v))
+                and pauli_u.has_basis(basis_u)
+                and pauli_v.has_basis(basis_v)
+            ):
+                span.add(ZXEdge(ZXNode(u, basis_u), ZXNode(v, basis_v)))
+    return CorrelationSurface(frozenset(span))
+
+
+def _flip_pauli_based_on_edge_type(g: GraphS, edge: tuple[int, int], pauli: Pauli) -> Pauli:
+    """Flip the Pauli operator based on the edge type."""
+    return pauli.flipped() if is_hardmard(g, edge) else pauli
+
+
+def _leaf_nodes_can_support_span(g: GraphS, span: frozenset[ZXEdge]) -> bool:
+    """Check if the leaf nodes in the graph can support the correlation span.
+
+    The compatibility is determined by comparing the logical observable basis
+    and the node type for the leaf nodes in the graph:
+
+    - The Z/X observable must be supported on the opposite type node.
+    - The Y observable can only be supported on the Y type node.
+    - The BOUNDARY node can support any type of logical observable.
+
+    """
+    no_boundary_leaves = {
+        v for v in g.vertices() if g.vertex_degree(v) == 1 and not is_boundary(g, v)
+    }
+    bases_at_leaves: dict[int, set[Basis]] = {}
+    for edge in span:
+        u, ub = edge.u.id, edge.u.basis
+        v, vb = edge.v.id, edge.v.basis
+        if u in no_boundary_leaves:
+            bases_at_leaves.setdefault(u, set()).add(ub)
+        if v in no_boundary_leaves:
+            bases_at_leaves.setdefault(v, set()).add(vb)
+    for leaf, bases in bases_at_leaves.items():
+        # If there is correlation surface touching a Y leaf node, then the
+        # correlation surface must support both X and Z type logical observable.
+        if is_s(g, leaf):
+            return bases == {Basis.X, Basis.Z}
+        # Z(X) type leaf node can only support the X(Z) type logical observable.
+        if is_z_no_phase(g, leaf) and bases != {Basis.X}:
+            return False
+        if is_x_no_phase(g, leaf) and bases != {Basis.Z}:
+            return False
+    return True
+
+
+_SUPPORTED_SPIDERS: set[tuple[VertexType, FractionLike]] = {
+    (VertexType.Z, 0),  # Z
+    (VertexType.X, 0),  # X
+    (VertexType.Z, Fraction(1, 2)),  # S
+    (VertexType.BOUNDARY, 0),  # Boundary
+}
+
+
+def _check_spiders_are_supported(g: GraphS) -> None:
+    """Check the preconditions for the correlation surface finding algorithm."""
+    # 1. Check the spider types and phases are supported
+    for v in g.vertices():
+        vt = g.type(v)
+        phase = g.phase(v)
+        if (vt, phase) not in _SUPPORTED_SPIDERS:
+            raise TQECError(f"Unsupported spider type and phase: {vt} and {phase}.")
+    # 2. Check degree of the spiders
+    for v in g.vertices():
+        degree = g.vertex_degree(v)
+        if is_boundary(g, v) and degree != 1:
+            raise TQECError(f"Boundary spider must be dangling, but got {degree} neighbors.")
+        if is_s(g, v) and degree != 1:
+            raise TQECError(f"S spider must be dangling, but got {degree} neighbors.")
+
+
+def reduce_observables_to_minimal_generators(
+    stabilizers_to_surfaces: dict[str, CorrelationSurface],
+    hint_num_generators: int | None = None,
+) -> dict[str, CorrelationSurface]:
+    """Reduce a set of observables to generators with the smallest correlation surface area.
+
+    Args:
+        stabilizers_to_surfaces: The mapping from the stabilizer to the correlation surface.
+        hint_num_generators: The hint number of generators to find. If provided,
+            the function will stop after finding the specified number of generators.
+            Otherwise, the function will iterate through all the stabilizers.
+
+    Returns:
+        A mapping from the generators' stabilizers to the correlation surfaces.
+
+    """
+    if not stabilizers_to_surfaces:
+        return {}
+    # Sort the stabilizers by its corresponding correlation surface's area to
+    # find the generators with the smallest area
+    stabs_ordered_by_area = sorted(
+        stabilizers_to_surfaces.keys(),
+        key=lambda s: (stabilizers_to_surfaces[s].area(), s),
+    )
+    # find a complete set of generators, starting from the smallest area
+    generators: list[str] = stabs_ordered_by_area[:1]
+    generators_stim: list[stim.PauliString] = [stim.PauliString(generators[0])]
+    for stabilizer in stabs_ordered_by_area[1:]:
+        pauli_string = stim.PauliString(stabilizer)
+        if not _can_be_generated_by(pauli_string, generators_stim):
+            generators.append(stabilizer)
+            generators_stim.append(pauli_string)
+        if hint_num_generators is not None and len(generators) == hint_num_generators:
+            break
+    return {g: stabilizers_to_surfaces[g] for g in generators}
+
+
+def _can_be_generated_by(
+    pauli_string: stim.PauliString,
+    basis: list[stim.PauliString],
+) -> bool:
+    """Check if the given Pauli string can be generated by the given basis.
+
+    The following procedure is used to check if a Pauli string can be generated by
+    a given basis of stabilizers:
+
+    1. ``stim.Tableau.from_stabilizers`` constructs a tableau, which represents
+       a Clifford circuit mapping the Z Pauli on the nth input to the nth
+       stabilizer specified in the argument at the output. That means that the
+       inverse tableau maps the nth stabilizer to Z on the nth output.
+    2. Apply the inverse tableau to the Pauli string. If the Pauli string is a
+       product of the stabilizers, it can be decomposed into them. As a result,
+       after applying the tableau, the result will have `Z` operators only on
+       the specific outputs. If not, the Pauli string cannot be generated by the
+       given stabilizers.
+
+    """
+    if not basis:
+        return False
+    tableau = stim.Tableau.from_stabilizers(
+        basis,
+        allow_redundant=False,
+        allow_underconstrained=True,
+    )
+    inv = tableau.inverse(unsigned=True)
+    out_paulis = inv(pauli_string)
+    # use `bool()` to avoid type error
+    return bool(
+        out_paulis[len(basis) :].weight == 0
+        and all(xy not in str(out_paulis[: len(basis)]) for xy in "XY")
+    )

--- a/src/tqec/utils/enums.py
+++ b/src/tqec/utils/enums.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum, auto
+from typing import Literal
 
 
 class Orientation(Enum):
@@ -30,6 +31,50 @@ class Basis(Enum):
 
     def __lt__(self, other: Basis) -> bool:
         return self.value < other.value
+
+
+class Pauli(Enum):
+    I = "I"  # noqa: E741
+    X = "X"
+    Y = "Y"
+    Z = "Z"
+
+    def flipped(self) -> Pauli:
+        """Flip ``self``, returning the opposite Pauli."""
+        if self == Pauli.X:
+            return Pauli.Z
+        if self == Pauli.Z:
+            return Pauli.X
+        return self
+
+    def has_x(self) -> bool:
+        """Return True if ``self`` has an X component."""
+        return self in (Pauli.X, Pauli.Y)
+
+    def has_z(self) -> bool:
+        """Return True if ``self`` has a Z component."""
+        return self in (Pauli.Z, Pauli.Y)
+
+    def has_basis(self, basis: Basis | Literal["X", "Z"]) -> bool:
+        """Return True if ``self`` has the given basis component."""
+        if isinstance(basis, str):
+            basis = Basis(basis)
+        if basis == Basis.X:
+            return self.has_x()
+        return self.has_z()
+
+    def __mul__(self, other: Pauli) -> Pauli:
+        if self == Pauli.I:
+            return other
+        if other == Pauli.I:
+            return self
+        if self == other:
+            return Pauli.I
+        if {self, other} == {Pauli.X, Pauli.Z}:
+            return Pauli.Y
+        if {self, other} == {Pauli.X, Pauli.Y}:
+            return Pauli.Z
+        return Pauli.X
 
 
 class PatchStyle(Enum):


### PR DESCRIPTION
A new algorithm for finding correlation surfaces, exponentially faster than the original algorithm, doesn't require gflow, and doesn't need info about input and output leaf nodes. See also #696.

It's currently in `src/tqec/interop/pyzx/correlation_experimental.py` as it's still in a draft form. I plan to add mid-exploration pruning based on leaf nodes, change the data structure to be X-and-Z-based, and polish it more. 

Happy to discuss how it should be modified to best integrate into the existing codebase. For example, the `reduce_to_minimal_generators` argument doesn't make sense anymore since the algorithm doesn't return all possible correlation surfaces. And how the tests should be adapted accordingly (it should pass all tests up to equivalence, except for those requiring all possible correlation surfaces).

Basic benchmarking using stacked Steane encoding block graphs:
```
Finding 7 correlation surfaces for block graph with 19 cubes, 20 pipes, and 7 leaf cubes took 0.01 s
Finding 8 correlation surfaces for block graph with 35 cubes, 40 pipes, and 8 leaf cubes took 0.03 s
Finding 9 correlation surfaces for block graph with 51 cubes, 60 pipes, and 9 leaf cubes took 0.07 s
Finding 10 correlation surfaces for block graph with 67 cubes, 80 pipes, and 10 leaf cubes took 0.13 s
Finding 11 correlation surfaces for block graph with 83 cubes, 100 pipes, and 11 leaf cubes took 0.29 s
Finding 12 correlation surfaces for block graph with 99 cubes, 120 pipes, and 12 leaf cubes took 0.31 s
Finding 13 correlation surfaces for block graph with 115 cubes, 140 pipes, and 13 leaf cubes took 0.81 s
Finding 14 correlation surfaces for block graph with 131 cubes, 160 pipes, and 14 leaf cubes took 0.84 s
Finding 15 correlation surfaces for block graph with 147 cubes, 180 pipes, and 15 leaf cubes took 1.63 s
Finding 16 correlation surfaces for block graph with 163 cubes, 200 pipes, and 16 leaf cubes took 1.62 s
Finding 17 correlation surfaces for block graph with 179 cubes, 220 pipes, and 17 leaf cubes took 2.22 s
Finding 18 correlation surfaces for block graph with 195 cubes, 240 pipes, and 18 leaf cubes took 2.85 s
Finding 19 correlation surfaces for block graph with 211 cubes, 260 pipes, and 19 leaf cubes took 4.63 s
Finding 20 correlation surfaces for block graph with 227 cubes, 280 pipes, and 20 leaf cubes took 5.85 s
Finding 21 correlation surfaces for block graph with 243 cubes, 300 pipes, and 21 leaf cubes took 7.03 s
Finding 22 correlation surfaces for block graph with 259 cubes, 320 pipes, and 22 leaf cubes took 7.10 s
Finding 23 correlation surfaces for block graph with 275 cubes, 340 pipes, and 23 leaf cubes took 10.39 s
Finding 24 correlation surfaces for block graph with 291 cubes, 360 pipes, and 24 leaf cubes took 12.19 s
Finding 25 correlation surfaces for block graph with 307 cubes, 380 pipes, and 25 leaf cubes took 14.27 s
Finding 26 correlation surfaces for block graph with 323 cubes, 400 pipes, and 26 leaf cubes took 16.79 s
Finding 27 correlation surfaces for block graph with 339 cubes, 420 pipes, and 27 leaf cubes took 19.30 s
Finding 28 correlation surfaces for block graph with 355 cubes, 440 pipes, and 28 leaf cubes took 18.09 s
Finding 29 correlation surfaces for block graph with 371 cubes, 460 pipes, and 29 leaf cubes took 20.49 s
Finding 30 correlation surfaces for block graph with 387 cubes, 480 pipes, and 30 leaf cubes took 25.62 s
```