### PR TITLE
Add ipykernel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ dev = [
     "sphinx<=8.1.3",
     "sphinxcontrib-mermaid<=1.0.0",
     "types-networkx<=3.5.0.20250610",
+    "ipykernel>=6.30.1",
 ]
 
 all = [


### PR DESCRIPTION
This PR adds ipykernel as a dependency because I was having trouble working with a jupyter notebook in a uv venv. `import tqec` would fail with `ModuleNotFoundError: no module named tqec`. 

With the dependency, I was able to create a separate kernel for tqec. Now, I can import tqec without any issues. 