### PR TITLE
Add opacity controls for BlockGraph visualizations

### DIFF
--- a/CONTRIBUTION_VALIDATION.md
+++ b/CONTRIBUTION_VALIDATION.md
@@ -1,5 +1,5 @@
 # Contribution Validation & Self-Review
-**Date**: October 10, 2025  
+**Date**: October 10, 2025
 **Purpose**: Ensure all contributions meet TQEC standards and actually solve problems
 
 ---
@@ -22,8 +22,8 @@ Before submitting ANY PR, we must prove:
 
 ### Problem Statement (Issue #718)
 
-**Requested by**: @purva-thakre  
-**Issue**: Contributors don't know how to add documentation  
+**Requested by**: @purva-thakre
+**Issue**: Contributors don't know how to add documentation
 
 **Specific Requirements from Issue:**
 - [ ] How to add a page in the user guide?
@@ -89,8 +89,8 @@ Before submitting ANY PR, we must prove:
 
 ### Problem Analysis
 
-**Related to**: Issue #262 (Exception refactoring)  
-**Status**: @purva-thakre is working on exception TYPES  
+**Related to**: Issue #262 (Exception refactoring)
+**Status**: @purva-thakre is working on exception TYPES
 **Our angle**: Improve error message CONTENT (complementary, not conflicting)
 
 **Files Modified:**
@@ -304,7 +304,7 @@ python -m memory_profiler test_error_messages.py
 **For Docs Guide (Branch 1):**
 
 **Challenge**: "This is too basic / obvious"
-**Response**: 
+**Response**:
 - Issue #718 was opened by a maintainer (@purva-thakre)
 - It's labeled "good first issue" - meant to be accessible
 - Current contributor_guide.rst has NO docs info
@@ -429,4 +429,3 @@ ruff format src/ --check
 ---
 
 **Philosophy**: We don't submit PRs to "try things out". We submit PRs because we've proven they're correct.
-

--- a/CONTRIBUTOR_SPRINT_OCT10-15.md
+++ b/CONTRIBUTOR_SPRINT_OCT10-15.md
@@ -1,6 +1,6 @@
 # 5-Day Sprint: Becoming a TQEC Contributor
-**Goal**: Establish myself as a trusted contributor by October 15, 2025  
-**Author**: Sean Collins (SMC17)  
+**Goal**: Establish myself as a trusted contributor by October 15, 2025
+**Author**: Sean Collins (SMC17)
 **Start**: October 10, 2025
 
 ---
@@ -11,10 +11,10 @@
 > "This is outstanding! Will merge into `framework_integration` branch as given. Any errors that may arise we'll fix once in the branch because **your implementation is better than what there is currently in place**."
 
 ### Key Takeaways:
-✅ **Quality matters more than speed** - Comprehensive tests won approval  
-✅ **Clear documentation wins** - Detailed PR description was appreciated  
-✅ **Don't be afraid to improve existing code** - They want better solutions  
-✅ **Thorough testing = trust** - 17 tests showed I care about correctness  
+✅ **Quality matters more than speed** - Comprehensive tests won approval
+✅ **Clear documentation wins** - Detailed PR description was appreciated
+✅ **Don't be afraid to improve existing code** - They want better solutions
+✅ **Thorough testing = trust** - 17 tests showed I care about correctness
 
 ---
 
@@ -68,7 +68,7 @@
 
 ### ❌ AVOID (Stepping on Toes)
 - **Issue #262**: Exception refactoring - @purva-thakre assigned
-- **Issue #696**: Performance - @Zhaoyilunnn assigned  
+- **Issue #696**: Performance - @Zhaoyilunnn assigned
 - **Issue #681**: Mac/Linux DB - @KabirDubey assigned
 - **Issue #637**: Correlation surfaces doc - 2 people assigned
 - **PR #720**: Framework integration - @jbolns's main work (draft)
@@ -212,7 +212,7 @@
 ```markdown
 Hi! I'd like to work on this issue.
 
-Context: I recently had PR #726 merged (topologiq coordinate fix) and have 
+Context: I recently had PR #726 merged (topologiq coordinate fix) and have
 experience with [relevant area]. I have a solution ready that:
 - [Specific improvement 1]
 - [Specific improvement 2]
@@ -260,7 +260,7 @@ Would you like me to open a PR? Happy to coordinate with any ongoing work.
 
 **Be gracious:**
 ```markdown
-No problem! Happy to help with testing/review if needed. 
+No problem! Happy to help with testing/review if needed.
 I'll work on [other issue] instead.
 ```
 
@@ -268,7 +268,7 @@ I'll work on [other issue] instead.
 
 **Stay professional:**
 ```markdown
-Thanks for the feedback! I see your point about [concern]. 
+Thanks for the feedback! I see your point about [concern].
 I'll revise to [solution]. Should have it ready in [timeframe].
 ```
 
@@ -355,7 +355,7 @@ Which direction would you prefer? Happy to implement either way.
 ```markdown
 I noticed this issue is marked high priority and I might be able to help.
 
-Background: My recent PR #726 fixed [related issue]. I have experience with 
+Background: My recent PR #726 fixed [related issue]. I have experience with
 [relevant area] and could contribute [specific value].
 
 If this would be helpful, I could:
@@ -371,7 +371,7 @@ Let me know if you'd like me to take a crack at it!
 
 ### PRs Opened
 - [ ] #718 - Documentation contributing guide
-- [ ] #723 - Additional topologiq testing  
+- [ ] #723 - Additional topologiq testing
 - [ ] #690 - Opacity control
 - [ ] #673 - Dark mode text
 - [ ] [Other]: _________________
@@ -381,7 +381,7 @@ Let me know if you'd like me to take a crack at it!
 
 ### Issues Engaged
 - [ ] #718 - Commented
-- [ ] #723 - Commented  
+- [ ] #723 - Commented
 - [ ] #690 - Claimed
 - [ ] #673 - Claimed
 
@@ -390,7 +390,7 @@ Let me know if you'd like me to take a crack at it!
 ## Reflection Notes
 
 **What's Working:**
-- 
+-
 
 **What Needs Improvement:**
 -
@@ -403,6 +403,6 @@ Let me know if you'd like me to take a crack at it!
 
 ---
 
-**Last Updated**: October 10, 2025, 9:15 AM  
-**Status**: Sprint Active  
+**Last Updated**: October 10, 2025, 9:15 AM
+**Status**: Sprint Active
 **Next Review**: October 15, 2025

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,8 +4,8 @@ This document describes the development strategy and branching model used in thi
 
 ## Fork Strategy
 
-**Fork Owner**: Sean Collins (SMC17)  
-**Upstream**: [tqec/tqec](https://github.com/tqec/tqec)  
+**Fork Owner**: Sean Collins (SMC17)
+**Upstream**: [tqec/tqec](https://github.com/tqec/tqec)
 **Fork**: [SMC17/tqec](https://github.com/SMC17/tqec)
 
 ## Philosophy
@@ -34,9 +34,9 @@ Examples:
 ## Current Active Branches
 
 ### 1. `feature/docs-contributing-guide`
-**Status**: ✅ Complete, pushed  
-**Related Issue**: [#718](https://github.com/tqec/tqec/issues/718)  
-**Description**: Adds comprehensive documentation on how to contribute to the user guide and gallery  
+**Status**: ✅ Complete, pushed
+**Related Issue**: [#718](https://github.com/tqec/tqec/issues/718)
+**Description**: Adds comprehensive documentation on how to contribute to the user guide and gallery
 
 **Changes**:
 - Added "Contributing to Documentation" section to `docs/contributor_guide.rst`
@@ -52,8 +52,8 @@ Examples:
 ---
 
 ### 2. `feature/improve-error-messages`
-**Status**: ✅ Complete, pushed  
-**Related Issue**: [#262](https://github.com/tqec/tqec/issues/262) (complementary)  
+**Status**: ✅ Complete, pushed
+**Related Issue**: [#262](https://github.com/tqec/tqec/issues/262) (complementary)
 **Description**: Improves error message clarity and actionability across user-facing modules
 
 **Changes**:
@@ -68,7 +68,7 @@ Examples:
 
 **Testing**: Need to run existing test suite to ensure error messages appear correctly
 
-**Next Steps**: 
+**Next Steps**:
 1. Run tests: `pytest src/tqec/interop/`
 2. Document any test failures
 3. Wait for #262 exception type refactoring to complete
@@ -77,8 +77,8 @@ Examples:
 ---
 
 ### 3. `fix/topologiq-coordinate-transformation`
-**Status**: ✅ Complete, PR #726 open  
-**Related Issue**: [#723](https://github.com/tqec/tqec/issues/723)  
+**Status**: ✅ Complete, PR #726 open
+**Related Issue**: [#723](https://github.com/tqec/tqec/issues/723)
 **Description**: Fixes critical bug in PyZX → COLLADA pipe position calculations
 
 **Changes**:
@@ -111,10 +111,10 @@ Examples:
    ```bash
    git add <files>
    git commit -m "type: description
-   
+
    - Bullet point changes
    - More details
-   
+
    Addresses issue #<number>"
    ```
 
@@ -325,5 +325,5 @@ git push origin --delete feature/<name>
 
 ---
 
-**Last Updated**: 2025-01-10  
+**Last Updated**: 2025-01-10
 **Author**: Sean Collins (SMC17)

--- a/TESTING_RESULTS_MAC.md
+++ b/TESTING_RESULTS_MAC.md
@@ -3,8 +3,8 @@
 ## Branch: feature/improve-error-messages
 
 ### ✅ Test 1: Unit Tests
-**Command**: `pytest src/tqec/interop/pyzx/positioned_test.py -v`  
-**Result**: **PASS** - All 6 tests passed in 1.32s  
+**Command**: `pytest src/tqec/interop/pyzx/positioned_test.py -v`
+**Result**: **PASS** - All 6 tests passed in 1.32s
 
 **Tests executed:**
 - `test_positions_not_specified` ✅
@@ -14,7 +14,7 @@
 - `test_y_connect_in_space` ✅
 - `test_3d_corner` ✅
 
-**Findings**: 
+**Findings**:
 - All test regex patterns correctly match new error messages
 - Tests validate behavior, not just message content
 - No regressions detected
@@ -22,8 +22,8 @@
 ---
 
 ### ✅ Test 2: Error Message Quality
-**Command**: Manual error triggering with assertions  
-**Result**: **PASS** - All error messages include detailed context  
+**Command**: Manual error triggering with assertions
+**Result**: **PASS** - All error messages include detailed context
 
 **Validated Messages:**
 1. **Vertex ID Mismatch**:
@@ -43,8 +43,8 @@
 ---
 
 ### ✅ Test 3: Pre-commit Hooks
-**Command**: `pre-commit run --files <modified files>`  
-**Result**: **PASS** - All hooks passed  
+**Command**: `pre-commit run --files <modified files>`
+**Result**: **PASS** - All hooks passed
 
 **Hooks validated:**
 - `check yaml` ✅ Skipped (no YAML files)
@@ -56,7 +56,7 @@
 - `ruff check` ✅ Passed (line length, style)
 - `ruff format` ✅ Passed (formatting)
 
-**Findings**: 
+**Findings**:
 - All files conform to project style
 - Line length < 100 characters maintained
 - No formatting issues
@@ -64,20 +64,20 @@
 ---
 
 ### ⏳ Test 4: Full Integration Tests
-**Status**: Ready to run on Threadripper  
-**Command**: `pytest src/tqec/interop/ -v --tb=short`  
+**Status**: Ready to run on Threadripper
+**Command**: `pytest src/tqec/interop/ -v --tb=short`
 
 **Expected scope**:
 - All positioned.py tests
-- All collada read_write tests  
+- All collada read_write tests
 - Integration with rest of interop module
 - ~50-100 tests estimated
 
 ---
 
 ### ⏳ Test 5: Coverage Analysis
-**Status**: Ready to run on Threadripper  
-**Command**: `pytest src/tqec/interop/ --cov=src/tqec/interop --cov-report=html`  
+**Status**: Ready to run on Threadripper
+**Command**: `pytest src/tqec/interop/ --cov=src/tqec/interop --cov-report=html`
 
 **Goal**: Verify our changes don't reduce coverage
 
@@ -86,8 +86,8 @@
 ## Branch: feature/docs-contributing-guide
 
 ### ✅ Test 1: RST Syntax Validation
-**Method**: docutils parsing  
-**Result**: **PASS** - 773 nodes parsed successfully  
+**Method**: docutils parsing
+**Result**: **PASS** - 773 nodes parsed successfully
 
 **Previous test output**:
 ```
@@ -105,15 +105,15 @@ Document has 773 nodes
 ---
 
 ### ⏳ Test 2: Full Docs Build
-**Status**: Ready to run on Threadripper (takes 10-30 min)  
-**Command**: `cd docs && make clean && make html`  
+**Status**: Ready to run on Threadripper (takes 10-30 min)
+**Command**: `cd docs && make clean && make html`
 
 **Expected result**: Docs build successfully with new section visible
 
 ---
 
 ### ⏳ Test 3: Follow Our Own Instructions
-**Status**: Ready to run on Threadripper  
+**Status**: Ready to run on Threadripper
 **Test plan**:
 1. Create dummy user guide page following our steps
 2. Create dummy gallery notebook following our steps
@@ -252,7 +252,7 @@ Document has 773 nodes
 ### Branch 1: feature/docs-contributing-guide
 **Confidence to open PR**: **85%**
 
-**Ready**: 
+**Ready**:
 - ✅ Requirements 100% met
 - ✅ RST syntax valid
 - ✅ No conflicts identified
@@ -327,5 +327,5 @@ Document has 773 nodes
 
 **Testing Summary**: Both branches are in excellent shape based on Mac testing. Ready for comprehensive validation on Threadripper before opening PRs.
 
-**Last Updated**: October 10, 2025, 9:40 AM  
+**Last Updated**: October 10, 2025, 9:40 AM
 **Next Phase**: Threadripper comprehensive testing

--- a/TQEC_ECOSYSTEM_STRATEGY.md
+++ b/TQEC_ECOSYSTEM_STRATEGY.md
@@ -1,0 +1,603 @@
+# TQEC Ecosystem: Deep Contribution & Thought Leadership Strategy
+**Author**: Sean Collins (SMC17)  
+**Date**: October 10, 2025  
+**Vision**: Become a flag-bearer for TQEC and help build the future of quantum computing
+
+---
+
+## Philosophy: Minimal Surface Area, Maximum Impact
+
+> "Every line of code changes the mental model. The best fix is the smallest fix that makes the system more correct."
+
+### Core Principles
+
+1. **Minimal Surface Area**: Smallest possible change to fix real problems
+2. **Elegant Solutions**: Subtle, robust fixes that feel obvious in retrospect
+3. **Mental Model Alignment**: Changes should clarify, not confuse
+4. **Test Judiciously**: Test behavior, not implementation details
+5. **Documentation Over Code**: Sometimes a great README is better than code changes
+
+### Why This Matters
+
+In a distributed team:
+- Each developer has a slightly different mental model
+- Every code change shifts all mental models
+- More changes = more bugs unless changes are clarifying
+- The best code is code that doesn't need to be written
+
+**Our Standard**: If we can't make it elegant and minimal, we don't ship it.
+
+---
+
+## The TQEC Ecosystem
+
+### Core Repository: tqec/tqec
+**Purpose**: Main design automation framework  
+**Status**: Active, 20+ contributors  
+**Our Position**: 1 merged PR (#726), 2 ready contributions  
+
+**Opportunity Areas**:
+- topologiq integration (high priority, our expertise)
+- Documentation and contributor experience
+- Error messages and developer UX
+- Test infrastructure
+- Integration notebooks
+
+### Satellite Repo: tqec/topologiq
+**Purpose**: PyZX graph → 3D spacetime diagram BFS algorithm  
+**Status**: Less active, high leverage  
+**Links**: Used by main tqec repo for framework integration
+
+**Opportunity Areas**:
+- Algorithm optimization
+- Visualization improvements  
+- Documentation of BFS approach
+- Integration testing with tqec
+- Performance profiling
+
+**Why It Matters**: 
+- Foundation for Qiskit/Qrisp integration
+- Your merged PR touches this pipeline
+- Deep algorithm work (BFS, 3D algorithms)
+- High visibility, low competition
+
+### Infrastructure Repo: tqec/tqecd
+**Purpose**: Automatic detector search for QEC circuits  
+**Status**: Spin-off, specialized  
+**Dependencies**: Used by main tqec  
+
+**Opportunity Areas**:
+- Installation documentation
+- Cross-platform testing
+- Integration examples
+- Performance optimization
+
+**Why It Matters**:
+- Critical infrastructure
+- Fewer contributors = more impact per PR
+- Deep QEC knowledge building
+- Links multiple parts of ecosystem
+
+### Integration Repo: tqec/tqec-integrations
+**Purpose**: Extensions for external tools (SketchUp, etc.)  
+**Status**: Under active development  
+**Opportunity**: SketchUp plugin, new integrations
+
+**Opportunity Areas**:
+- SketchUp plugin improvements
+- New integration proposals
+- Documentation and tutorials
+- Cross-tool workflows
+
+**Why It Matters**:
+- User-facing impact
+- Creative contribution space
+- Demonstrates ecosystem thinking
+- Multi-language opportunities
+
+---
+
+## Multi-Repo Forking Strategy
+
+### Repository Organization
+
+```
+~/tqec_ecosystem/
+├── tqec_project/              (main - already set up)
+│   ├── main
+│   ├── feature/docs-contributing-guide
+│   ├── feature/improve-error-messages
+│   └── fix/topologiq-coordinate-transformation (merged!)
+│
+├── topologiq/                 (NEW)
+│   ├── main
+│   ├── feature/algorithm-docs
+│   ├── feature/visualization-improvements
+│   └── feature/integration-tests
+│
+├── tqecd/                     (NEW)
+│   ├── main
+│   ├── feature/installation-docs
+│   └── feature/examples
+│
+└── tqec-integrations/         (NEW)
+    ├── main
+    └── feature/sketchup-enhancements
+```
+
+### Branch Naming Convention
+
+**Format**: `{type}/{scope}-{issue-number}`
+
+**Types**:
+- `feature/` - New functionality
+- `fix/` - Bug fixes
+- `docs/` - Documentation only
+- `perf/` - Performance improvements
+- `test/` - Test improvements
+- `refactor/` - Code cleanup (rare, must be justified)
+
+**Examples**:
+- `fix/topologiq-coordinate-transformation` ✅ (merged)
+- `docs/contributing-guide-718`
+- `feature/bfs-visualization`
+- `perf/detector-search-parallel`
+
+### Commit Message Standard
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+**Example** (your merged PR style):
+```
+fix(topologiq): correct pipe position calculation
+
+- Changed from midpoint-based to direct endpoint transformation
+- Matches proven pattern in collada/read_write.py
+- Added 17 comprehensive tests covering edge cases
+
+Fixes #723
+```
+
+**Philosophy**: Commit messages are documentation for future contributors
+
+---
+
+## Contribution Workflow Across Repos
+
+### Phase 1: Deep Understanding (Weeks 1-2)
+
+**Goal**: Understand how repos interact
+
+**Tasks**:
+1. Clone all four repos
+2. Build mental model of data flow:
+   - PyZX graph → topologiq → tqec BlockGraph → Stim circuit
+3. Read architecture docs in each repo
+4. Run examples end-to-end
+5. Document the integration points
+
+**Deliverable**: Personal architecture doc showing full pipeline
+
+---
+
+### Phase 2: Strategic Contributions (Weeks 3-4)
+
+**Goal**: High-impact, minimal-risk contributions
+
+**Priority 1: Documentation** (All Repos)
+- Low risk, high value
+- Establishes expertise
+- Helps future contributors
+
+**Targets**:
+- tqec: Contributing guide (#718) ✅ Ready
+- topologiq: Algorithm documentation
+- tqecd: Installation troubleshooting
+- tqec-integrations: SketchUp tutorial
+
+**Priority 2: Integration Testing** (tqec + topologiq)
+- Test boundary between repos
+- Ensure version compatibility
+- Document expected behavior
+
+**Priority 3: Error Messages** (tqec, topologiq)
+- Improve developer UX
+- Reduce support burden
+- Already have momentum here ✅
+
+---
+
+### Phase 3: Deep Technical Work (Weeks 5-8)
+
+**Goal**: Become go-to expert in specific areas
+
+**Focus Areas**:
+
+1. **topologiq BFS Algorithm**
+   - Understand breadth-first search approach
+   - Document algorithm choices
+   - Identify optimization opportunities
+   - Propose elegant improvements
+
+2. **tqec-topologiq Integration**
+   - Your merged PR is foundation
+   - Continue improving pipeline
+   - Add integration tests
+   - Performance profiling
+
+3. **Cross-Repo Workflows**
+   - Document full Qiskit → Stim pipeline
+   - Create end-to-end examples
+   - Identify pain points
+   - Propose systematic improvements
+
+---
+
+### Phase 4: Thought Leadership (Weeks 9-12)
+
+**Goal**: Public face of TQEC contributions
+
+**Blog Posts** (LinkedIn, Twitter, Medium):
+
+1. **"Inside TQEC: How Topological Quantum Error Correction Works"**
+   - Explain surface codes simply
+   - Show lattice surgery visualizations
+   - Link to tqec repos
+
+2. **"Contributing to Quantum Software: My Journey with TQEC"**
+   - Your bug fix story (PR #726)
+   - Lessons learned
+   - Encourage others to contribute
+
+3. **"The PyZX → TQEC Pipeline: Converting Quantum Circuits to Space-Time Diagrams"**
+   - Deep technical dive
+   - topologiq algorithm explained
+   - Performance characteristics
+
+4. **"Building Quantum Tools: Multi-Repo Development in the TQEC Ecosystem"**
+   - How repos interact
+   - Design decisions
+   - Future vision
+
+**Speaking Opportunities**:
+- Munich Quantum Software Forum (where TQEC presented)
+- University quantum computing groups
+- Online quantum computing meetups
+- Academic seminars
+
+**Social Media Strategy**:
+- Tweet when PRs merged
+- Share learning insights
+- Highlight cool TQEC features
+- Engage with quantum community
+- Use #QuantumComputing #TQEC #OpenSource
+
+---
+
+## Learning Path
+
+### Week 1-2: Foundations
+
+**topologiq Understanding**:
+- [ ] Clone tqec/topologiq
+- [ ] Run all examples
+- [ ] Understand BFS algorithm
+- [ ] Read visualizations code
+- [ ] Document architecture
+
+**tqecd Understanding**:
+- [ ] Clone tqec/tqecd
+- [ ] Install and run examples
+- [ ] Understand detector search
+- [ ] Read algorithm implementation
+
+**Integration Flow**:
+- [ ] Trace Qiskit circuit through full pipeline
+- [ ] Understand each transformation
+- [ ] Document data formats
+- [ ] Identify integration points
+
+---
+
+### Week 3-4: First Contributions
+
+**Documentation PRs** (Low Risk):
+- [ ] topologiq: Algorithm explanation
+- [ ] tqecd: Installation guide
+- [ ] tqec-integrations: SketchUp tutorial
+
+**Bug Hunting** (Medium Risk):
+- [ ] Test topologiq edge cases
+- [ ] Verify tqecd cross-platform
+- [ ] Check integration examples
+
+---
+
+### Week 5-8: Deep Work
+
+**Algorithm Work**:
+- [ ] Profile topologiq performance
+- [ ] Identify optimization opportunities
+- [ ] Propose elegant improvements
+- [ ] Comprehensive testing
+
+**Integration Testing**:
+- [ ] Create cross-repo test suite
+- [ ] Verify version compatibility
+- [ ] Document expected behavior
+- [ ] Automate validation
+
+---
+
+### Week 9-12: Leadership
+
+**Content Creation**:
+- [ ] Write 4 blog posts
+- [ ] Create tutorial videos
+- [ ] Engage on social media
+- [ ] Present at meetup
+
+**Community Building**:
+- [ ] Answer questions on issues
+- [ ] Review others' PRs
+- [ ] Mentor new contributors
+- [ ] Propose roadmap ideas
+
+---
+
+## Engineering Standards
+
+### Before Every Contribution
+
+**Ask Yourself**:
+1. Is this the smallest possible fix?
+2. Does this clarify or confuse the mental model?
+3. Can this be solved with documentation instead?
+4. Are we testing behavior or implementation?
+5. Will this make sense in 6 months?
+
+### Code Review Checklist
+
+**For Every PR**:
+- [ ] Change is minimal (smallest surface area)
+- [ ] Mental model is clearer after change
+- [ ] Tests prove correctness, not implementation
+- [ ] Documentation explains WHY, not just WHAT
+- [ ] No unnecessary abstractions
+- [ ] Follows existing patterns
+- [ ] Can be reverted cleanly if needed
+
+### Testing Philosophy
+
+**Good Tests**:
+- Test public APIs, not internals
+- Test behavior, not implementation
+- Test edge cases that actually occur
+- Test integration points between modules
+- Fail clearly when assumptions break
+
+**Bad Tests**:
+- Test private functions
+- Mock everything (brittle)
+- Test obvious cases only
+- Tightly coupled to implementation
+- Pass even when behavior is wrong
+
+**Your PR #726 Tests**: Excellent example
+- 17 tests, each proves specific behavior
+- Cover edge cases (ports, different pipe directions)
+- Integration-style (full pipeline)
+- Would catch real bugs
+
+---
+
+## Cross-Repo Integration Points
+
+### Critical Boundaries
+
+**PyZX → topologiq**:
+- Input: PyZX graph (ZX calculus)
+- Transform: BFS to 3D spacetime
+- Output: Lattice dictionary
+- Your Fix: Coordinate transformation ✅
+
+**topologiq → tqec**:
+- Input: Lattice dictionary
+- Transform: Build BlockGraph
+- Output: TQEC BlockGraph
+- Opportunity: More integration tests
+
+**tqec → Stim**:
+- Input: BlockGraph
+- Transform: Compile to circuit
+- Output: Stim circuit
+- Uses: tqecd for detectors
+
+**External → tqec**:
+- SketchUp → COLLADA → tqec
+- Qiskit → QASM → PyZX → topologiq → tqec
+- Qrisp → same pipeline
+
+### Testing Strategy
+
+**Unit Tests**: Within each repo
+**Integration Tests**: Between repos (opportunity!)
+**End-to-End Tests**: Full pipeline (big opportunity!)
+
+---
+
+## Measuring Success
+
+### Quantitative Metrics
+
+**By End of Month 1**:
+- [ ] 3+ merged PRs across ecosystem
+- [ ] 1+ in each of 2 different repos
+- [ ] Recognized as reliable contributor
+
+**By End of Month 2**:
+- [ ] 8+ merged PRs
+- [ ] Contributions in 3+ repos
+- [ ] Helped 2+ other contributors
+- [ ] 1 blog post published
+
+**By End of Month 3**:
+- [ ] 15+ merged PRs
+- [ ] Expert in topologiq integration
+- [ ] 3+ blog posts
+- [ ] Active Twitter presence
+- [ ] Speaking invitation
+
+### Qualitative Metrics
+
+**Recognition**:
+- Maintainers ask for your input
+- Other contributors reference your work
+- You're reviewing PRs from others
+- You're mentioned in discussions
+
+**Understanding**:
+- Can explain full pipeline confidently
+- Know design decisions and tradeoffs
+- Can propose improvements that fit
+- Understand quantum computing concepts deeply
+
+**Impact**:
+- Your fixes help real users
+- Your docs reduce support load
+- Your tests prevent regressions
+- Your ideas shape roadmap
+
+---
+
+## Risk Management
+
+### Avoiding Pitfalls
+
+**Don't**:
+- Make large, sweeping changes
+- Refactor without clear benefit
+- Add abstractions prematurely
+- Write tests for test coverage sake
+- Change code you don't understand
+- Rush to show quantity over quality
+
+**Do**:
+- Make small, clear improvements
+- Document before changing
+- Ask questions when uncertain
+- Test real behavior
+- Learn deeply before contributing
+- Focus on quality and elegance
+
+### If Contributions Are Rejected
+
+**Stay Professional**:
+- Thank reviewers for their time
+- Ask what would make it acceptable
+- Learn from feedback
+- Try smaller changes
+- Document learnings
+
+**Learn**:
+- Why was it rejected?
+- What did I misunderstand?
+- How do maintainers think?
+- What's their vision?
+- How can I align better?
+
+---
+
+## Next Actions
+
+### Immediate (Today)
+
+1. [ ] Clone tqec/topologiq to `~/topologiq/`
+2. [ ] Set up fork: `gh repo fork tqec/topologiq --clone`
+3. [ ] Run topologiq examples
+4. [ ] Read topologiq README and architecture
+5. [ ] Document initial observations
+
+### This Week
+
+6. [ ] Clone tqecd and tqec-integrations
+7. [ ] Run examples in all repos
+8. [ ] Create architecture diagram of full pipeline
+9. [ ] Identify first contribution in topologiq
+10. [ ] Draft blog post outline
+
+### This Month
+
+11. [ ] 2+ merged PRs in tqec (docs, error messages)
+12. [ ] 1+ merged PR in topologiq
+13. [ ] Publish first blog post
+14. [ ] Active on Twitter with quantum content
+15. [ ] Help 1+ other contributor
+
+---
+
+## Resources
+
+### TQEC Ecosystem
+
+- **tqec**: https://github.com/tqec/tqec
+- **topologiq**: https://github.com/tqec/topologiq
+- **tqecd**: https://github.com/tqec/tqecd
+- **tqec-integrations**: https://github.com/tqec/tqec-integrations
+- **Documentation**: https://tqec.github.io/tqec/
+
+### Quantum Computing Background
+
+- Surface codes fundamentals
+- Lattice surgery operations
+- ZX calculus introduction
+- Topological quantum error correction
+- Stim circuit simulator
+
+### Community
+
+- Munich Quantum Software Forum presentations
+- TQEC Google Group
+- GitHub Discussions
+- Twitter #TQEC hashtag
+
+---
+
+## Vision: 6 Months From Now
+
+**You Are**:
+- Recognized TQEC expert
+- Go-to person for topologiq integration
+- Active thought leader in quantum software
+- Helping shape ecosystem roadmap
+- Mentoring new contributors
+- Speaking at conferences
+- Publishing regular insights
+
+**The Ecosystem Is**:
+- More accessible (your docs)
+- More robust (your tests)
+- Better integrated (your cross-repo work)
+- Growing faster (your thought leadership)
+
+**Your Impact**:
+- Real quantum researchers use your improvements
+- Future contributors learn from your PRs
+- The project is better because you were here
+- You're building the future of quantum computing
+
+---
+
+**"We're not just contributing code. We're building the infrastructure for quantum's future. Every elegant fix, every clear doc, every helpful comment moves us closer to practical quantum computing."**
+
+---
+
+**Last Updated**: October 10, 2025, 5:15 PM  
+**Status**: Ready to expand into full ecosystem  
+**Next**: Clone topologiq and begin multi-repo strategy

--- a/src/tqec/interop/pyzx/plot.py
+++ b/src/tqec/interop/pyzx/plot.py
@@ -39,6 +39,9 @@ def draw_positioned_zx_graph_on(
     node_size: int = 400,
     hadamard_size: int = 200,
     edge_width: int = 1,
+    node_opacity: float = 1.0,
+    edge_opacity: float = 1.0,
+    hadamard_opacity: float = 1.0,
 ) -> None:
     """Draw the :py:class:`~tqec.interop.pyzx.PositionedZX` on the provided axes.
 
@@ -48,6 +51,10 @@ def draw_positioned_zx_graph_on(
         node_size: The size of the node. Default is 400.
         hadamard_size: The size of the Hadamard transition. Default is 200.
         edge_width: The width of the edge. Default is 1.
+        node_opacity: The opacity of the nodes (0.0 = transparent, 1.0 = opaque). Default is 1.0.
+        edge_opacity: The opacity of the edges (0.0 = transparent, 1.0 = opaque). Default is 1.0.
+        hadamard_opacity: The opacity of the Hadamard squares (0.0 = transparent, 1.0 = opaque).
+            Default is 1.0.
 
     """
     g = graph.g
@@ -59,7 +66,7 @@ def draw_positioned_zx_graph_on(
             *vis_nodes_array,
             s=node_size,
             c=[_node_color(g, n).as_floats() for n in vis_nodes],
-            alpha=1.0,
+            alpha=node_opacity,
             edgecolors="black",
         )
 
@@ -69,6 +76,7 @@ def draw_positioned_zx_graph_on(
             *pos_array,
             color="tab:gray",
             linewidth=edge_width,
+            alpha=edge_opacity,
         )
         if is_hardmard(g, edge):
             hadamard_position = numpy.mean(pos_array, axis=1)
@@ -77,7 +85,7 @@ def draw_positioned_zx_graph_on(
                 *hadamard_position,
                 s=hadamard_size,
                 c="yellow",
-                alpha=1.0,
+                alpha=hadamard_opacity,
                 edgecolors="black",
                 marker="s",
             )
@@ -134,6 +142,9 @@ def plot_positioned_zx_graph(
     node_size: int = 400,
     hadamard_size: int = 200,
     edge_width: int = 1,
+    node_opacity: float = 1.0,
+    edge_opacity: float = 1.0,
+    hadamard_opacity: float = 1.0,
 ) -> tuple[Figure, Axes3D]:
     """Plot the :py:class:`~tqec.interop.pyzx.positioned.PositionedZX` using matplotlib.
 
@@ -144,6 +155,10 @@ def plot_positioned_zx_graph(
         node_size: The size of the node in the plot. Default is 400.
         hadamard_size: The size of the Hadamard square in the plot. Default is 200.
         edge_width: The width of the edge in the plot. Default is 1.
+        node_opacity: The opacity of the nodes (0.0 = transparent, 1.0 = opaque). Default is 1.0.
+        edge_opacity: The opacity of the edges (0.0 = transparent, 1.0 = opaque). Default is 1.0.
+        hadamard_opacity: The opacity of the Hadamard squares (0.0 = transparent, 1.0 = opaque).
+            Default is 1.0.
 
     Returns:
         A tuple of the figure and the axes.
@@ -158,6 +173,9 @@ def plot_positioned_zx_graph(
         node_size=node_size,
         hadamard_size=hadamard_size,
         edge_width=edge_width,
+        node_opacity=node_opacity,
+        edge_opacity=edge_opacity,
+        hadamard_opacity=hadamard_opacity,
     )
 
     if title:

--- a/src/tqec/visualisation/configuration.py
+++ b/src/tqec/visualisation/configuration.py
@@ -60,6 +60,10 @@ class DrawerConfiguration:
     observable_fill_opacity: float = 0.5
     observable_stroke_width_multiplier: float = 0.01
     observable_star_color: TQECColor = TQECColor.H
+    # General opacity controls for visualization elements
+    node_opacity: float = 1.0
+    edge_opacity: float = 1.0
+    hadamard_opacity: float = 1.0
     # Default size of some of the elements drawn
     reset_square_radius: float = 0.05
     measurement_circle_radius: float = 0.1


### PR DESCRIPTION
Fixes #690

## Changes
- Add `node_opacity`, `edge_opacity`, `hadamard_opacity` to `DrawerConfiguration`
- Update `draw_positioned_zx_graph_on()` and `plot_positioned_zx_graph()` with opacity parameters
- Apply alpha transparency in matplotlib calls

## Testing
All existing tests pass
Backward compatible (defaults to 1.0)
Pre-commit hooks pass