### PR TITLE
Fixed pip install command in documentation not working

### DIFF
--- a/docs/contributor_guide.rst
+++ b/docs/contributor_guide.rst
@@ -38,7 +38,7 @@ of ``tqec`` through ``pip`` or ``uv``.
             cd tqec
 
             # Update pip to at least v25.1
-            python -m pip install --upgrade pip>=25.1
+            python -m pip install --upgrade "pip>=25.1"
 
             # Install developer dependencies
             python -m pip install --group all


### PR DESCRIPTION
In the documentation contributing page, the command to make sure pip is up to date was returning ``zsh: 25.1 not found``. I simply added quotes to the last part, and it worked:

```python -m pip install --upgrade pip>=25.1```

vs.

(updated)
```python -m pip install --upgrade "pip>=25.1"```
