### PR TITLE
Remove papers, add gdrive to linkcheck_ignore

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -215,6 +215,8 @@ linkcheck_ignore = [
     r"https://unpkg\.com/.*",
     # quantum-journal.org sometimes rate-limits CI
     r"https://quantum-journal\.org/.*",
+    # Fowler review paper
+    r"https://drive\.google\.com/file/.*",
 ]
 linkcheck_timeout = 30
 linkcheck_retries = 2

--- a/docs/papers/acharya-2024-qec-below-threshold.pdf
+++ b/docs/papers/acharya-2024-qec-below-threshold.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ba05a64dfec13f5d733e0e22484e8f22db2482dc2a5a0d63e6f0766c9c3d368
-size 3825803

--- a/docs/papers/fowler-2012-surface-codes.pdf
+++ b/docs/papers/fowler-2012-surface-codes.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eaeb6b9d1283fc0fe1040aebb8248a6ea2e7f514ed3981cd8bbfa9e1fb4d4000
-size 2552441

--- a/docs/papers/gidney-2021-honeycomb-memory.pdf
+++ b/docs/papers/gidney-2021-honeycomb-memory.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:057ea087e8fadfa3c4be3b62f1602e03282a04c0372654d30ddb8559e91de751
-size 5009051

--- a/docs/papers/gidney-2024-inplace-y-basis.pdf
+++ b/docs/papers/gidney-2024-inplace-y-basis.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:322d664cf5daafcb7772f03f4c9ff42476228f9045cb4b53492c2413e1936007
-size 6092674

--- a/docs/papers/horsman-2012-lattice-surgery.pdf
+++ b/docs/papers/horsman-2012-lattice-surgery.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7537e1195587924c5e1ddbbd92987f32a81aa6a191b1463feb29880419d0687a
-size 3096685

--- a/docs/papers/steane-1996-qec.pdf
+++ b/docs/papers/steane-1996-qec.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f82b8d09cb628d24b436bdb2ef2d947bbf4062395af9115c79257b74aeda2415
-size 310610

--- a/docs/papers/tomita-2014-surface-codes-noise.pdf
+++ b/docs/papers/tomita-2014-surface-codes-noise.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2984c967ac977db57d1c5793d0ab5385cdd5dc18d9b20bcb3b99453ed7fa21b7
-size 3345956

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -10,8 +10,7 @@
    publisher={Springer Science and Business Media LLC},
    author={Acharya et.al, Rajeev},
    year={2024},
-   month=dec, pages={920–926},
-   file={papers/acharya-2024-qec-below-threshold.pdf} }
+   month=dec, pages={920–926} }
 
 
 # Last Name Starts With B
@@ -41,8 +40,7 @@
    publisher={American Physical Society (APS)},
    author={Fowler, Austin G. and Mariantoni, Matteo and Martinis, John M. and Cleland, Andrew N.},
    year={2012},
-   month=sep,
-   file={papers/fowler-2012-surface-codes.pdf} }
+   month=sep }
 # Last Name Starts With G
 @article{Gidney_inplace_access_2024,
    title={Inplace Access to the Surface Code Y Basis},
@@ -54,8 +52,7 @@
    publisher={Verein zur Forderung des Open Access Publizierens in den Quantenwissenschaften},
    author={Gidney, Craig},
    year={2024},
-   month=apr, pages={1310},
-   file={papers/gidney-2024-inplace-y-basis.pdf} }
+   month=apr, pages={1310} }
 
 @article{Gidney_si1000_2021,
    title={A Fault-Tolerant Honeycomb Memory},
@@ -67,8 +64,7 @@
    publisher={Verein zur Forderung des Open Access Publizierens in den Quantenwissenschaften},
    author={Gidney, Craig and Newman, Michael and Fowler, Austin and Broughton, Michael},
    year={2021},
-   month=dec, pages={605},
-   file={papers/gidney-2021-honeycomb-memory.pdf} }
+   month=dec, pages={605} }
 
 # Last Name Starts With H
 @article{Horsman_2012,
@@ -82,8 +78,7 @@
    publisher={IOP Publishing},
    author={Horsman, Dominic and Fowler, Austin G and Devitt, Simon and Meter, Rodney Van},
    year={2012},
-   month=dec, pages={123011},
-   file={papers/horsman-2012-lattice-surgery.pdf} }
+   month=dec, pages={123011} }
 
 # Last Name Starts With I
 
@@ -115,8 +110,7 @@
    author = {Steane, Andrew},
    publisher={The Royal Society},
    year={1996},
-   month=nov, pages={2551–2577},
-   file={papers/steane-1996-qec.pdf} }
+   month=nov, pages={2551–2577} }
 
 
 # Last Name Starts With T
@@ -131,8 +125,7 @@
    publisher={American Physical Society (APS)},
    author={Tomita, Yu and Svore, Krysta M.},
    year={2014},
-   month=dec,
-   file={papers/tomita-2014-surface-codes-noise.pdf} }
+   month=dec }
 
 # Last Name Starts With U
 


### PR DESCRIPTION
Address #903 

Since hosting our own PDFs of the papers isn't license-compliant, remove those papers. Linkcheck now ignores all of the paper sources, so we don't have to worry about timeouts during doc builds in future PRs.