### PR TITLE
Remove `# pragma no cover` from fixed boundary

### DIFF
--- a/src/tqec/compile/specs/library/generators/fixed_boundary.py
+++ b/src/tqec/compile/specs/library/generators/fixed_boundary.py
@@ -368,7 +368,7 @@ class FixedBoundaryConventionGenerator:
     ########################################
     #             Regular qubit            #
     ########################################
-    def get_memory_qubit_raw_template(self) -> RectangularTemplate:  # pragma: no cover
+    def get_memory_qubit_raw_template(self) -> RectangularTemplate:
         """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement a single logical qubit.
         """
@@ -438,7 +438,7 @@ class FixedBoundaryConventionGenerator:
         z_orientation: Orientation = Orientation.HORIZONTAL,
         reset: Basis | None = None,
         measurement: Basis | None = None,
-    ) -> Plaquettes:  # pragma: no cover
+    ) -> Plaquettes:
         """Return the plaquettes needed to implement a standard memory operation on a logical
         qubit.
 
@@ -478,7 +478,7 @@ class FixedBoundaryConventionGenerator:
     ########################################
     #                X pipe                #
     ########################################
-    def get_memory_vertical_boundary_raw_template(self) -> RectangularTemplate:  # pragma: no cover
+    def get_memory_vertical_boundary_raw_template(self) -> RectangularTemplate:
         """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement a regular spatial pipe between two logical qubits aligned on the ``X`` axis.
         """
@@ -562,7 +562,7 @@ class FixedBoundaryConventionGenerator:
         z_orientation: Orientation = Orientation.HORIZONTAL,
         reset: Basis | None = None,
         measurement: Basis | None = None,
-    ) -> Plaquettes:  # pragma: no cover
+    ) -> Plaquettes:
         """Return the plaquettes needed to implement a standard memory operation on a pipe between
         two neighbouring logical qubits aligned on the ``X``-axis.
 
@@ -611,7 +611,7 @@ class FixedBoundaryConventionGenerator:
     ########################################
     def get_memory_horizontal_boundary_raw_template(
         self,
-    ) -> RectangularTemplate:  # pragma: no cover
+    ) -> RectangularTemplate:
         """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement a regular spatial pipe between two logical qubits aligned on the ``Y`` axis.
         """
@@ -695,7 +695,7 @@ class FixedBoundaryConventionGenerator:
         z_orientation: Orientation = Orientation.HORIZONTAL,
         reset: Basis | None = None,
         measurement: Basis | None = None,
-    ) -> Plaquettes:  # pragma: no cover
+    ) -> Plaquettes:
         """Return the plaquettes needed to implement a standard memory operation on a pipe between
         two neighbouring logical qubits aligned on the ``Y``-axis.
 
@@ -742,7 +742,7 @@ class FixedBoundaryConventionGenerator:
     ############################################################
     #                          Spatial                         #
     ############################################################
-    def get_spatial_cube_qubit_raw_template(self) -> RectangularTemplate:  # pragma: no cover
+    def get_spatial_cube_qubit_raw_template(self) -> RectangularTemplate:
         """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement a spatial cube.
 
@@ -976,7 +976,7 @@ class FixedBoundaryConventionGenerator:
         is_reversed: bool,
         reset: Basis | None = None,
         measurement: Basis | None = None,
-    ) -> Plaquettes:  # pragma: no cover
+    ) -> Plaquettes:
         """Return the plaquettes needed to implement a spatial cube.
 
         Note:
@@ -1028,9 +1028,7 @@ class FixedBoundaryConventionGenerator:
     ########################################
     #              Spatial arm             #
     ########################################
-    def get_spatial_cube_arm_raw_template(
-        self, arms: SpatialArms
-    ) -> RectangularTemplate:  # pragma: no cover
+    def get_spatial_cube_arm_raw_template(self, arms: SpatialArms) -> RectangularTemplate:
         """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement the given spatial ``arms``.
 
@@ -1164,7 +1162,7 @@ class FixedBoundaryConventionGenerator:
         is_reversed: bool,
         reset: Basis | None = None,
         measurement: Basis | None = None,
-    ) -> Plaquettes:  # pragma: no cover
+    ) -> Plaquettes:
         # This is a regular memory arm, except that we should make sure that one
         # of the boundary does not override the extended stabilizer.
         z_orientation = (
@@ -1183,7 +1181,7 @@ class FixedBoundaryConventionGenerator:
     @staticmethod
     def pipe_needs_extended_stabilizers(
         linked_cubes: tuple[CubeSpec, CubeSpec],
-    ) -> bool:  # pragma: no cover
+    ) -> bool:
         """Check if the pipe represented by the given ``arms`` and ``linked_cubes`` requires
         extended stabilizers.
 
@@ -1213,7 +1211,7 @@ class FixedBoundaryConventionGenerator:
     @staticmethod
     def pipe_has_boundary_extended_stabilizer_at_left(
         linked_cubes: tuple[CubeSpec, CubeSpec],
-    ) -> bool:  # pragma: no cover
+    ) -> bool:
         """Check if the pipe represented by the given ``linked_cubes`` has an extended stabilizer at
         the left boundary.
 
@@ -1240,7 +1238,7 @@ class FixedBoundaryConventionGenerator:
         is_reversed: bool,
         reset: Basis | None = None,
         measurement: Basis | None = None,
-    ) -> Plaquettes:  # pragma: no cover
+    ) -> Plaquettes:
         if not FixedBoundaryConventionGenerator.pipe_needs_extended_stabilizers(linked_cubes):
             # Special case, a little bit simpler, not using extended stabilizers.
             return self._get_up_and_down_spatial_cube_arm_plaquettes(
@@ -1293,7 +1291,7 @@ class FixedBoundaryConventionGenerator:
         is_reversed: bool,
         reset: Basis | None = None,
         measurement: Basis | None = None,
-    ) -> Plaquettes:  # pragma: no cover
+    ) -> Plaquettes:
         return self._mapper(self._get_up_and_down_spatial_cube_arm_rpng_descriptions)(
             spatial_boundary_basis, linked_cubes, is_reversed, reset, measurement
         )
@@ -1305,7 +1303,7 @@ class FixedBoundaryConventionGenerator:
         is_reversed: bool,
         reset: Basis | None = None,
         measurement: Basis | None = None,
-    ) -> FrozenDefaultDict[int, RPNGDescription]:  # pragma: no cover
+    ) -> FrozenDefaultDict[int, RPNGDescription]:
         """Return the RPNG descriptions to implement a pipe connecting at least one spatial cube.
 
         The pipe implemented by this method links two cubes such as:
@@ -1375,7 +1373,7 @@ class FixedBoundaryConventionGenerator:
     ########################################
     #           Regular junction           #
     ########################################
-    def get_temporal_hadamard_raw_template(self) -> RectangularTemplate:  # pragma: no cover
+    def get_temporal_hadamard_raw_template(self) -> RectangularTemplate:
         """Return the :class:`~tqec.templates.base.Template` instance needed to implement a
         transversal Hadamard gate applied on one logical qubit.
         """
@@ -1433,7 +1431,7 @@ class FixedBoundaryConventionGenerator:
 
     def get_temporal_hadamard_plaquettes(
         self, is_reversed: bool, z_orientation: Orientation = Orientation.HORIZONTAL
-    ) -> Plaquettes:  # pragma: no cover
+    ) -> Plaquettes:
         """Return the plaquettes needed to implement a transversal Hadamard gate applied on one
         logical qubit.
 
@@ -1471,7 +1469,7 @@ class FixedBoundaryConventionGenerator:
     ########################################
     #                X pipe                #
     ########################################
-    def get_spatial_vertical_hadamard_raw_template(self) -> RectangularTemplate:  # pragma: no cover
+    def get_spatial_vertical_hadamard_raw_template(self) -> RectangularTemplate:
         """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement a spatial Hadamard pipe between two logical qubits aligned on the ``X`` axis.
         """
@@ -1548,7 +1546,7 @@ class FixedBoundaryConventionGenerator:
         is_reversed: bool,
         reset: Basis | None = None,
         measurement: Basis | None = None,
-    ) -> Plaquettes:  # pragma: no cover
+    ) -> Plaquettes:
         """Return the plaquettes needed to implement a Hadamard spatial transition between two
         neighbouring logical qubits aligned on the ``X`` axis.
 
@@ -1595,7 +1593,7 @@ class FixedBoundaryConventionGenerator:
     ########################################
     def get_spatial_horizontal_hadamard_raw_template(
         self,
-    ) -> RectangularTemplate:  # pragma: no cover
+    ) -> RectangularTemplate:
         """Return the :class:`~tqec.templates.base.RectangularTemplate` instance needed to
         implement a spatial Hadamard pipe between two logical qubits aligned on the ``Y`` axis.
         """
@@ -1672,7 +1670,7 @@ class FixedBoundaryConventionGenerator:
         is_reversed: bool,
         reset: Basis | None = None,
         measurement: Basis | None = None,
-    ) -> Plaquettes:  # pragma: no cover
+    ) -> Plaquettes:
         """Return the plaquettes needed to implement a Hadamard spatial transition between two
         neighbouring logical qubits aligned on the ``Y`` axis.
 


### PR DESCRIPTION
# Description

When unit tests were added for fixed boundary, `#pragma no cover` tags were added to some of the methods. Upon further inspection, these are not needed, since they are invoked by other integration tests.

Fixes #909. Simply removing the no cover tags shows they were not needed.

# How Has This Been Tested?

```
uv run pytest  \
  --cov=. \
  --cov-report=html
```

**Test Configuration**:
* Python version: 3.12.9
* Operating system and system architecture: macOS 26.4.1/amd64

# Checklist:

* &nbsp; [x] My code follows the style guidelines of this project
* &nbsp; [x] I have performed a self-review of my own code
* &nbsp; [x] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation
* &nbsp; [x] My changes generate no new errors or warnings
* &nbsp; [x] I have added tests that prove my fix is effective or that my feature works
* &nbsp; [x] My code and tests have at least 80% line coverage
* &nbsp; [x] New and existing unit tests pass locally with my changes
* &nbsp; [x] Any dependent changes have been merged and published in downstream modules
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked
