### PR TITLE
Bump svg-py dependency lower bound to 1.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
   "sphinx-design>=0.6.1",
   "stim>=1.14",
   "stim>=1.15; python_version >= '3.13'",              # Stim only builds wheels for Python 3.13 starting from v1.15
-  "svg-py>=1.8.0",
+  "svg-py>=1.10.0",
   "tqecd>=0.1.3",
   "typing-extensions>=4.2",
   "typing-extensions>=4.12; python_version >= '3.13'",

--- a/src/tqec/visualisation/computation/observable.py
+++ b/src/tqec/visualisation/computation/observable.py
@@ -25,7 +25,7 @@ def _get_observable_star_svg(
         y = r * math.sin(theta)
         points.append((x, y))
     return svg.Polygon(
-        points=points,  # type: ignore[arg-type]
+        points=points,  # type: ignore
         fill=fill,
         stroke=stroke_color,
         stroke_width=stroke_width,

--- a/src/tqec/visualisation/computation/observable.py
+++ b/src/tqec/visualisation/computation/observable.py
@@ -15,7 +15,7 @@ def _get_observable_star_svg(
     stroke_color: str = "red",
     stroke_width: float = 0.5,
 ) -> svg.Polygon:
-    points: list[svg.Point] = []
+    points: list[tuple[float, float]] = []
     n = 5
     angle = math.pi / n
     for i in range(2 * n):
@@ -23,9 +23,9 @@ def _get_observable_star_svg(
         theta = i * angle - math.pi / 2
         x = r * math.cos(theta)
         y = r * math.sin(theta)
-        points.append(svg.Point(x, y))
+        points.append((x, y))
     return svg.Polygon(
-        points=points,
+        points=points,  # type: ignore[arg-type]
         fill=fill,
         stroke=stroke_color,
         stroke_width=stroke_width,

--- a/src/tqec/visualisation/computation/observable.py
+++ b/src/tqec/visualisation/computation/observable.py
@@ -15,7 +15,7 @@ def _get_observable_star_svg(
     stroke_color: str = "red",
     stroke_width: float = 0.5,
 ) -> svg.Polygon:
-    points: list[tuple[float, float]] = []
+    points: list[svg.Point] = []
     n = 5
     angle = math.pi / n
     for i in range(2 * n):
@@ -23,9 +23,9 @@ def _get_observable_star_svg(
         theta = i * angle - math.pi / 2
         x = r * math.cos(theta)
         y = r * math.sin(theta)
-        points.append((x, y))
+        points.append(svg.Point(x, y))
     return svg.Polygon(
-        points=points,  # type: ignore
+        points=points,
         fill=fill,
         stroke=stroke_color,
         stroke_width=stroke_width,


### PR DESCRIPTION
`svg.Point` was added to svg.py in [version 1.10](https://github.com/orsinium-labs/svg.py/releases/tag/1.10.0). So #887 breaks `tests/compile/compile_test.py::test_compile_H_shape_junctions_with_regular_cube_endpoints` tests if svg.py is a version before 1.10. Our current dependency lower bound on svg.py is 1.8.0.

Before 1.10 (1.10 is also backward-compatible on this, see https://github.com/orsinium-labs/svg.py/pull/36), `Polygon` accepts `points` as a `list[Number]`, where `Number = Union[Decimal, float, int]` (https://github.com/orsinium-labs/svg.py/blob/f05d4e363bf1fb39605a40d8c716c5bebb491f9c/svg/_types.py), and we pass in a tuple, thus the typing ignore.

We can consider bumping our svg.py lower bound to 1.10 to use `svg.Point` when we are sure the bump doesn't break other things. The immediate fix and safe option is to restore the change.