### PR TITLE
Change SketchUp link to wikipedia to circumvent timeouts

### DIFF
--- a/docs/user_guide/build_computation.rst
+++ b/docs/user_guide/build_computation.rst
@@ -3,7 +3,7 @@ Build Computations
 
 In :code:`tqec`, a logical computation is represented as a :code:`BlockGraph`. There are several ways to build it:
 
-1. Build the structure interactively with `SketchUp <https://www.sketchup.com/app>`_, export and convert it to a :code:`BlockGraph`.
+1. Build the structure interactively with `SketchUp <https://en.wikipedia.org/wiki/SketchUp>`_, export and convert it to a :code:`BlockGraph`.
 2. Build a :code:`BlockGraph` programmatically with :code:`add_cube` and :code:`add_pipe` methods.
 3. Build a :code:`pyzx.GraphS` ZX graph representation of the computation and synthesize it to a :code:`BlockGraph`.
 
@@ -12,7 +12,7 @@ In this notebook, we will guide you through all the methods.
 1. Use SketchUp
 ----------------
 
-`SketchUp <https://www.sketchup.com/app>`_ is a 3D modeling tool widely used in QEC community to build the spacetime diagram for logical computations.
+`SketchUp <https://en.wikipedia.org/wiki/SketchUp>`_ is a 3D modeling tool widely used in QEC community to build the spacetime diagram for logical computations.
 Its user-friendly interface allows you to easily create and manipulate the computation blocks.
 
 Once you make a Trimble account, you may freely use the web version of SketchUp to import a :code:`.skp` file and create a scene. However, unless you are on


### PR DESCRIPTION
# Description

The official SketchUp site often times out during builds ([example](https://github.com/tqec/tqec/actions/runs/25330703589/job/74263365016)). Use Wikipedia instead since SketchUp is a corporate site that is more likely to throttle us, or change/break altogether. Also, the app is linked from the summary page.

I assume eventually, we will want to link a new TQEC frontend like piper draw as well

# How Has This Been Tested?

Not tested locally, using GH pages to check it.

# Checklist:

* &nbsp; [x] My code follows the style guidelines of this project
* &nbsp; [x] I have performed a self-review of my own code
* &nbsp; [x] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation
* &nbsp; [x] My changes generate no new errors or warnings
* &nbsp; [x] My code and tests pass locally and have at least 80% line coverage
* &nbsp; [x] Any dependent changes have been merged and published in downstream modules
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked
