### PR TITLE
Fix Y half cube z double-scaling in DAE/JSON/bgraph importers

### DIFF
--- a/src/tqec/interop/bgraph/read_write.py
+++ b/src/tqec/interop/bgraph/read_write.py
@@ -51,9 +51,7 @@ def load_bgraph(bgraph_str_or_path: str | Path, graph_name: str = "") -> BlockGr
                     kind = "Y"
                     if isinstance(block_kind_from_str(kind), YHalfCube):
                         position = int_position_before_scale(
-                            offset_y_cube_position(
-                                FloatPosition3D(*(int(x), int(y), int(z))), pipe_length
-                            ),
+                            offset_y_cube_position(FloatPosition3D(*(int(x), int(y), int(z)))),
                             pipe_length,
                         )
                 else:

--- a/src/tqec/interop/collada/read_write.py
+++ b/src/tqec/interop/collada/read_write.py
@@ -147,7 +147,7 @@ def read_block_graph_from_dae_file(
     for pos, cube_kind, axes_directions in parsed_cubes:
         if isinstance(cube_kind, YHalfCube):
             graph.add_cube(
-                int_position_before_scale(offset_y_cube_position(pos, pipe_length), pipe_length),
+                int_position_before_scale(offset_y_cube_position(pos), pipe_length),
                 cube_kind,
             )
         else:
@@ -369,9 +369,7 @@ def read_block_graph_from_json(
     # Add cubes
     for pos, cube_kind, axes_directions in parsed_cubes:
         if isinstance(cube_kind, YHalfCube):
-            graph.add_cube(
-                int_position_before_scale(offset_y_cube_position(pos, 0.0), 0.0), cube_kind
-            )
+            graph.add_cube(int_position_before_scale(offset_y_cube_position(pos), 0.0), cube_kind)
         else:
             graph.add_cube(int_position_before_scale(pos, 0.0), cube_kind)
     port_index = 0

--- a/src/tqec/interop/shared.py
+++ b/src/tqec/interop/shared.py
@@ -25,12 +25,22 @@ def int_position_before_scale(pos: FloatPosition3D, pipe_length: float) -> Posit
     )
 
 
-def offset_y_cube_position(pos: FloatPosition3D, pipe_length: float) -> FloatPosition3D:
-    """Offsets the position of a Y-cube according to the length of pipes in the model.
+def offset_y_cube_position(pos: FloatPosition3D) -> FloatPosition3D:
+    """Undo the writer's +0.5 z-shift for Y half cubes that had a pipe above.
+
+    The DAE writer shifts a Y half cube's DAE z by +0.5 when there is a pipe
+    directly above it, so that the upper-half geometry sits flush against the
+    pipe. This helper detects that fractional z (z ≈ floor(z) + 0.5) and
+    reverses the shift, leaving an integer DAE z that
+    :func:`int_position_before_scale` then maps onto the TQEC grid.
+
+    The previous signature took a ``pipe_length`` argument and divided z by
+    ``(1 + pipe_length)``. That scaling was redundant with
+    :func:`int_position_before_scale` and caused a double-scaling bug for any
+    Y cube at z > 0.
 
     Args:
         pos: (x, y, z) position where x, y, and z are floats.
-        pipe_length: the length of the pipes in the model.
 
     Returns:
         An offset (x, y, z)  position where x, y, and z are floats.
@@ -38,7 +48,7 @@ def offset_y_cube_position(pos: FloatPosition3D, pipe_length: float) -> FloatPos
     """
     if np.isclose(pos.z - 0.5, np.floor(pos.z), atol=1e-9):
         pos = pos.shift_by(dz=-0.5)
-    return FloatPosition3D(pos.x, pos.y, pos.z / (1 + pipe_length))
+    return FloatPosition3D(pos.x, pos.y, pos.z)
 
 
 def scale_position(pos: Position3D, pipe_length: float = 0.0) -> FloatPosition3D:

--- a/tests/interop/collada/read_write_test.py
+++ b/tests/interop/collada/read_write_test.py
@@ -5,7 +5,8 @@ from pathlib import Path
 import pytest
 
 from tqec.computation.block_graph import BlockGraph
-from tqec.computation.cube import ZXCube
+from tqec.computation.cube import YHalfCube, ZXCube
+from tqec.computation.pipe import PipeKind
 from tqec.gallery.cnot import cnot
 from tqec.gallery.three_cnots import three_cnots
 from tqec.utils.enums import Basis
@@ -127,3 +128,27 @@ def test_collada_write_read_with_correlation_surface() -> None:
             assert block_graph_from_file == block_graph
 
     os.remove(temp_file.name)
+
+
+def test_dae_roundtrip_preserves_y_cube_position_above_origin():
+    """Y half cubes at z > 0 must survive a write -> read round-trip.
+
+    Before this fix, offset_y_cube_position(pos, pipe_length) divided z by
+    (1 + pipe_length) and int_position_before_scale(..., pipe_length) did so
+    again, scaling Y cube z down by an extra factor of (1 + pipe_length).
+    A Y at TQEC (1,1,3) landed at (1,1,1), colliding with any cube there.
+    """
+    g = BlockGraph()
+    g.add_cube(Position3D(1, 1, 1), ZXCube.from_str("XZZ"))
+    g.add_cube(Position3D(1, 1, 2), ZXCube.from_str("XZZ"))
+    g.add_cube(Position3D(1, 1, 3), YHalfCube())
+    g.add_pipe(Position3D(1, 1, 1), Position3D(1, 1, 2), PipeKind.from_str("XZO"))
+    g.add_pipe(Position3D(1, 1, 2), Position3D(1, 1, 3), PipeKind.from_str("XZO"))
+
+    with tempfile.NamedTemporaryFile(suffix=".dae", delete=False) as f:
+        g.to_dae_file(f.name)
+        g2 = BlockGraph.from_dae_file(f.name)
+
+    y_cubes = [c for c in g2.cubes if isinstance(c.kind, YHalfCube)]
+    assert len(y_cubes) == 1
+    assert y_cubes[0].position == Position3D(1, 1, 3)

--- a/tests/interop/shared_test.py
+++ b/tests/interop/shared_test.py
@@ -22,13 +22,22 @@ def test_int_position_before_scale(pos: tuple[float, float, float], expected: tu
 @pytest.mark.parametrize(
     "pos, expected",
     [
+        # Original cases — identity for any z that doesn't trigger the +0.5 shift.
         [(0.5, 0.0, 0.0), (0.5, 0.0, 0.0)],
         [(1.0, 0.0, 0.0), (1.0, 0.0, 0.0)],
         [(2.0, 0.0, 0.0), (2.0, 0.0, 0.0)],
         [(2.5, 0.0, 0.0), (2.5, 0.0, 0.0)],
+        # New cases — Integer z at z > 0: still no shift.
+        [(3.0, 3.0, 9.0), (3.0, 3.0, 9.0)],
+        # z = floor(z) + 0.5: the writer's pipe-above marker -> subtract 0.5.
+        [(3.0, 3.0, 9.5), (3.0, 3.0, 9.0)],
+        [(0.0, 0.0, 0.5), (0.0, 0.0, 0.0)],
+        # x and y are never touched, even when z triggers the shift.
+        [(1.25, -7.0, 4.5), (1.25, -7.0, 4.0)],
     ],
 )
-def test_offset_y_cube_position(pos: tuple[float, float, float], expected: tuple[int, int, int]):
-    # NB! Varying pipe lengths already tested via COLLADA tests
+def test_offset_y_cube_position(
+    pos: tuple[float, float, float], expected: tuple[float, float, float]
+):
     pos_3d, expected_3d = (FloatPosition3D(*pos), FloatPosition3D(*expected))
-    assert expected_3d == offset_y_cube_position(pos=pos_3d, pipe_length=2.0)
+    assert expected_3d == offset_y_cube_position(pos=pos_3d)


### PR DESCRIPTION
## Summary

`BlockGraph.from_dae_file` (and the JSON and bgraph importers) mis-scale every Y half cube's `z` by an extra factor of `(1 + pipe_length)` during import. The Y silently lands at the wrong grid cell, and surfaces as `TQECError: Cube already exists at position ...` whenever the misplaced cell happens to be occupied.

Minimal repro:

```python
from tqec.computation.block_graph import BlockGraph
from tqec.computation.cube import YHalfCube, ZXCube
from tqec.computation.pipe import PipeKind
from tqec.utils.position import Position3D
import tempfile

g = BlockGraph()
g.add_cube(Position3D(1, 1, 1), ZXCube.from_str("XZZ"))
g.add_cube(Position3D(1, 1, 2), ZXCube.from_str("XZZ"))
g.add_cube(Position3D(1, 1, 3), YHalfCube())
g.add_pipe(Position3D(1, 1, 1), Position3D(1, 1, 2), PipeKind.from_str("XZO"))
g.add_pipe(Position3D(1, 1, 2), Position3D(1, 1, 3), PipeKind.from_str("XZO"))

with tempfile.NamedTemporaryFile(suffix=".dae") as f:
    g.to_dae_file(f.name)
    BlockGraph.from_dae_file(f.name)
# -> TQECError: Cube already exists at position (1,1,1).
```

## Root cause

`offset_y_cube_position(pos, pipe_length)` performs two operations: it undoes the writer's `+0.5` z-shift for Y cubes that had a pipe directly above, *and* it divides `z` by `(1 + pipe_length)`. Every caller then passes the result to `int_position_before_scale(..., pipe_length)`, which divides every coordinate by `(1 + pipe_length)`. The z-division therefore happens twice for Y cubes; `x` and `y` are correctly divided once.

The previous docstring described `pipe_length` as governing the offset itself, but the writer's `+0.5` is a hard-coded constant in DAE space — `pipe_length` only ever drove the redundant scaling.

## Fix

Drop the `pipe_length` argument from `offset_y_cube_position` entirely; remove the internal division. Scaling now lives exclusively in `int_position_before_scale`, which has the unambiguous job of mapping DAE coordinates onto the TQEC grid. The helper now does only what its name says — reverse the writer's `+0.5` shift.

Three call sites updated:

- `src/tqec/interop/collada/read_write.py:150` — DAE importer Y cube
- `src/tqec/interop/collada/read_write.py:373` — JSON importer Y cube
- `src/tqec/interop/bgraph/read_write.py:53` — bgraph importer Y cube (latently affected: any bgraph file with non-zero `pipe_length`)

## Tests

- `tests/interop/shared_test.py`: `test_offset_y_cube_position` was parametrising only the x dimension at z=0, so it never exercised the shift or the bug. Original cases kept verbatim; added cases that cover the +0.5 shift path and confirm x/y are never touched.
- `tests/interop/collada/read_write_test.py`: new `test_dae_roundtrip_preserves_y_cube_position_above_origin` builds a Y-on-top stack, round-trips it through DAE, and asserts the Y cube position is preserved.

## Reference

Reproducer notebook (arithmetic walk-through, isolated misplacement demo, verification of the fix via monkey-patch): https://gist.github.com/PaulCharon/2f9c8e3e12ca553cbf273e84739302a8

Original downstream report: https://github.com/Walrus-Computing/piper-draw/issues/320

## Related observation (not addressed in this PR)

There is a separate geometric oddity worth flagging but not fixing here: the writer in `write_block_graph_to_dae_file` hard-codes the Y-cube shift to `dz=0.5` in DAE space, regardless of `pipe_length`. At `pipe_length != 2.0` this produces a visually misplaced Y in the DAE rendering, even though round-trips are self-consistent.

---

*AI assistance disclosure: bug investigation, fix design, and PR drafting were done in collaboration with Claude (Anthropic). All code changes were reviewed, applied, and verified locally by the author before pushing; CI runs against the actual diff.*

