### PR TITLE
Stabilize gallery circuit generation order

### DIFF
--- a/src/tqec/compile/blocks/layers/atomic/layout.py
+++ b/src/tqec/compile/blocks/layers/atomic/layout.py
@@ -57,7 +57,7 @@ class LayoutLayer(BaseLayer):
 
         """
         super().__init__(frozenset())
-        self._layers = layers
+        self._layers = dict(sorted(layers.items(), key=lambda item: (item[0]._x, item[0]._y)))
         self._element_shape = element_shape
         self._post_init_check()
 

--- a/src/tqec/compile/observables/builder.py
+++ b/src/tqec/compile/observables/builder.py
@@ -265,7 +265,7 @@ def get_observable_with_measurement_records(
 
     measured_qubits = [
         q
-        for q in qubits
+        for q in sorted(qubits)
         # Ignore those qubits that are not measured in the circuit.
         # This is required because the some observable builders
         # include the qubits that are not in the circuit like qubits

--- a/src/tqec/compile/observables/builder.py
+++ b/src/tqec/compile/observables/builder.py
@@ -263,14 +263,9 @@ def get_observable_with_measurement_records(
             "ignore_qubits_with_no_measurement to True to ignore them."
         )
 
-    measured_qubits = [
-        q
-        for q in sorted(qubits)
-        # Ignore those qubits that are not measured in the circuit.
-        # This is required because the some observable builders
-        # include the qubits that are not in the circuit like qubits
-        # in the scretched stabilizers to simplify the calculation.
-        if q in measurement_records
-    ]
+    # Ignore qubits that are not measured in the circuit. Some observable
+    # builders include out-of-circuit qubits in stretched stabilizers to
+    # simplify the calculation.
+    measured_qubits = [q for q in sorted(qubits) if q in measurement_records]
     measurement_offsets = [measurement_records[q][-1] for q in measured_qubits]
     return Observable(observable_index, measured_qubits, measurement_offsets)

--- a/tests/compile/blocks/layers/merge_test.py
+++ b/tests/compile/blocks/layers/merge_test.py
@@ -71,6 +71,22 @@ def test_merge_base_layers(
     assert merged_layer.element_shape == logical_qubit_shape
 
 
+def test_layout_layer_stores_layers_in_coordinate_order(
+    base_layers: list[BaseLayer], logical_qubit_shape: PhysicalQubitScalable2D
+) -> None:
+    plaquette_layer, plaquette_layer2, raw_layer = base_layers
+    b00 = LayoutPosition2D.from_block_position(BlockPosition2D(0, 0))
+    b01 = LayoutPosition2D.from_block_position(BlockPosition2D(0, 1))
+    b11 = LayoutPosition2D.from_block_position(BlockPosition2D(1, 1))
+
+    layout = LayoutLayer(
+        {b11: raw_layer, b01: plaquette_layer2, b00: plaquette_layer},
+        logical_qubit_shape,
+    )
+
+    assert list(layout.layers) == [b00, b01, b11]
+
+
 def test_merge_repeated_layers(
     base_layers: list[BaseLayer], logical_qubit_shape: PhysicalQubitScalable2D
 ) -> None:

--- a/tests/compile/blocks/layers/merge_test.py
+++ b/tests/compile/blocks/layers/merge_test.py
@@ -77,14 +77,22 @@ def test_layout_layer_stores_layers_in_coordinate_order(
     plaquette_layer, plaquette_layer2, raw_layer = base_layers
     b00 = LayoutPosition2D.from_block_position(BlockPosition2D(0, 0))
     b01 = LayoutPosition2D.from_block_position(BlockPosition2D(0, 1))
+    b10 = LayoutPosition2D.from_block_position(BlockPosition2D(1, 0))
     b11 = LayoutPosition2D.from_block_position(BlockPosition2D(1, 1))
+    b20 = LayoutPosition2D.from_block_position(BlockPosition2D(2, 0))
 
     layout = LayoutLayer(
-        {b11: raw_layer, b01: plaquette_layer2, b00: plaquette_layer},
+        {
+            b20: raw_layer,
+            b11: plaquette_layer,
+            b01: plaquette_layer2,
+            b10: raw_layer,
+            b00: plaquette_layer,
+        },
         logical_qubit_shape,
     )
 
-    assert list(layout.layers) == [b00, b01, b11]
+    assert list(layout.layers) == [b00, b01, b10, b11, b20]
 
 
 def test_merge_repeated_layers(

--- a/tests/compile/observables/builder_test.py
+++ b/tests/compile/observables/builder_test.py
@@ -1,5 +1,9 @@
+from tqec.circuit.measurement_map import MeasurementRecordsMap
 from tqec.circuit.qubit import GridQubit
-from tqec.compile.observables.builder import ObservableBuilder
+from tqec.compile.observables.builder import (
+    ObservableBuilder,
+    get_observable_with_measurement_records,
+)
 from tqec.templates.layout import LayoutTemplate
 from tqec.templates.qubit import QubitTemplate
 from tqec.utils.position import (
@@ -33,3 +37,19 @@ def test_transform_coords_into_grid() -> None:
     x = -1 + 3 * 2
     y = (12 * 2 + 2) * 2 - 1 + 1 * 2
     assert qubits == {GridQubit(x, y)}
+
+
+def test_get_observable_with_measurement_records_sorts_qubits() -> None:
+    q0 = GridQubit(0, 0)
+    q1 = GridQubit(1, 0)
+    unmeasured_qubit = GridQubit(2, 0)
+    measurement_records = MeasurementRecordsMap({q1: [-1], q0: [-2]})
+
+    observable = get_observable_with_measurement_records(
+        {q1, unmeasured_qubit, q0},
+        measurement_records,
+        observable_index=0,
+    )
+
+    assert observable.measured_qubits == [q0, q1]
+    assert observable.measurement_offsets == [-2, -1]

--- a/tests/compile/observables/builder_test.py
+++ b/tests/compile/observables/builder_test.py
@@ -40,16 +40,18 @@ def test_transform_coords_into_grid() -> None:
 
 
 def test_get_observable_with_measurement_records_sorts_qubits() -> None:
-    q0 = GridQubit(0, 0)
-    q1 = GridQubit(1, 0)
-    unmeasured_qubit = GridQubit(2, 0)
-    measurement_records = MeasurementRecordsMap({q1: [-1], q0: [-2]})
+    q0 = GridQubit(-1, 2)
+    q1 = GridQubit(0, 0)
+    q2 = GridQubit(1, -1)
+    q3 = GridQubit(1, 0)
+    unmeasured_qubit = GridQubit(0, -1)
+    measurement_records = MeasurementRecordsMap({q3: [-1], q0: [-4], q2: [-2], q1: [-3]})
 
     observable = get_observable_with_measurement_records(
-        {q1, unmeasured_qubit, q0},
+        {q3, q1, unmeasured_qubit, q2, q0},
         measurement_records,
         observable_index=0,
     )
 
-    assert observable.measured_qubits == [q0, q1]
-    assert observable.measurement_offsets == [-2, -1]
+    assert observable.measured_qubits == [q0, q1, q2, q3]
+    assert observable.measurement_offsets == [-4, -3, -2, -1]


### PR DESCRIPTION
Closes #825

## Summary
- store layout layers in coordinate order so generated layout circuits do not depend on upstream mapping insertion order
- sort observable qubits before resolving measurement records
- add regression coverage for both deterministic-ordering paths

## Validation
- `uv run --no-default-groups --group test pytest tests/compile/observables/builder_test.py tests/compile/blocks/layers/merge_test.py`
- `uvx ruff==0.15.15 check src/tqec/compile/observables/builder.py src/tqec/compile/blocks/layers/atomic/layout.py tests/compile/observables/builder_test.py tests/compile/blocks/layers/merge_test.py`
- `uvx ruff==0.15.15 format --check src/tqec/compile/observables/builder.py src/tqec/compile/blocks/layers/atomic/layout.py tests/compile/observables/builder_test.py tests/compile/blocks/layers/merge_test.py`
- generated memory, move-rotation, CNOT, and three-CNOT gallery circuits with `PYTHONHASHSEED=1` and `PYTHONHASHSEED=2`; SHA-256 hashes matched for every checked case

## AI assistance disclosure
I used OpenAI Codex to help inspect the deterministic-ordering paths and draft the small regression tests. The code path was manually reviewed and validated locally with the commands above.