### PR TITLE
Re-introduce extended plaquette drawers

### DIFF
--- a/src/tqec/compile/specs/library/generators/extended_stabilizers.py
+++ b/src/tqec/compile/specs/library/generators/extended_stabilizers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal, cast
 
 import stim
@@ -11,7 +11,6 @@ from tqec.circuit.qubit import GridQubit
 from tqec.circuit.schedule.circuit import ScheduledCircuit
 from tqec.circuit.schedule.schedule import Schedule
 from tqec.compile.specs.library.generators.constants import EXTENDED_PLAQUETTE_SCHEDULES
-from tqec.plaquette.debug import PlaquetteDebugInformation
 from tqec.plaquette.plaquette import Plaquette
 from tqec.plaquette.qubit import PlaquetteQubits
 from tqec.plaquette.rpng.rpng import RPNG, PauliBasis, RPNGDescription
@@ -254,7 +253,8 @@ def _get_drawer_schedule(description: RPNGDescription) -> tuple[int, int, int, i
     return cast(tuple[int, int, int, int], tuple(corner.n or 0 for corner in description.corners))
 
 
-def _validate_extended_plaquette_description(description: RPNGDescription) -> None:
+def _raise_if_undefined_corners(description: RPNGDescription) -> None:
+    """Require a fully specified source description before deriving border shapes."""
     undefined_corners = [
         index
         for index, corner in enumerate(description.corners)
@@ -276,18 +276,15 @@ def _with_extended_plaquette_drawer(
     reset: Basis | None,
     measurement: Basis | None,
 ) -> Plaquette:
-    return plaquette.with_debug_information(
-        PlaquetteDebugInformation(
-            drawer=ExtendedPlaquetteDrawer(
-                plaquette_type,
-                position,
-                basis,
-                schedule,
-                reset,
-                measurement,
-            )
-        )
+    drawer = ExtendedPlaquetteDrawer(
+        plaquette_type,
+        position,
+        basis,
+        schedule,
+        reset,
+        measurement,
     )
+    return plaquette.with_debug_information(replace(plaquette.debug_information, drawer=drawer))
 
 
 def _make_extended_plaquette(
@@ -345,7 +342,7 @@ class ExtendedPlaquetteCollection:
         is_reversed: bool,
     ) -> ExtendedPlaquetteCollection:
         """Build an instance from the provided ``RPNGDescription``."""
-        _validate_extended_plaquette_description(description)
+        _raise_if_undefined_corners(description)
         up, down = get_extended_plaquette(description, reset, measurement, is_reversed)
         drawer_basis = _get_drawer_basis(description)
         drawer_schedule = _get_drawer_schedule(description)
@@ -422,7 +419,7 @@ class ExtendedPlaquetteCollection:
                 reset,
                 measurement,
             ),
-            # bottom left refers to where the right angle is.
+            # top right refers to where the right angle is.
             top_right_triangle=_make_extended_plaquette(
                 up,
                 down.project_on_data_qubit_indices([1]),

--- a/src/tqec/compile/specs/library/generators/extended_stabilizers.py
+++ b/src/tqec/compile/specs/library/generators/extended_stabilizers.py
@@ -254,6 +254,19 @@ def _get_drawer_schedule(description: RPNGDescription) -> tuple[int, int, int, i
     return cast(tuple[int, int, int, int], tuple(corner.n or 0 for corner in description.corners))
 
 
+def _validate_extended_plaquette_description(description: RPNGDescription) -> None:
+    undefined_corners = [
+        index
+        for index, corner in enumerate(description.corners)
+        if corner.p is None or corner.n is None
+    ]
+    if undefined_corners:
+        raise TQECError(
+            "Extended plaquette descriptions must define all four data-qubit interactions. "
+            f"Undefined corner indices: {undefined_corners}."
+        )
+
+
 def _with_extended_plaquette_drawer(
     plaquette: Plaquette,
     plaquette_type: ExtendedPlaquetteType,
@@ -332,6 +345,7 @@ class ExtendedPlaquetteCollection:
         is_reversed: bool,
     ) -> ExtendedPlaquetteCollection:
         """Build an instance from the provided ``RPNGDescription``."""
+        _validate_extended_plaquette_description(description)
         up, down = get_extended_plaquette(description, reset, measurement, is_reversed)
         drawer_basis = _get_drawer_basis(description)
         drawer_schedule = _get_drawer_schedule(description)

--- a/src/tqec/compile/specs/library/generators/extended_stabilizers.py
+++ b/src/tqec/compile/specs/library/generators/extended_stabilizers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, cast
 
 import stim
 
@@ -11,12 +11,18 @@ from tqec.circuit.qubit import GridQubit
 from tqec.circuit.schedule.circuit import ScheduledCircuit
 from tqec.circuit.schedule.schedule import Schedule
 from tqec.compile.specs.library.generators.constants import EXTENDED_PLAQUETTE_SCHEDULES
+from tqec.plaquette.debug import PlaquetteDebugInformation
 from tqec.plaquette.plaquette import Plaquette
 from tqec.plaquette.qubit import PlaquetteQubits
 from tqec.plaquette.rpng.rpng import RPNG, PauliBasis, RPNGDescription
 from tqec.utils.enums import Basis
 from tqec.utils.exceptions import TQECError
 from tqec.utils.instructions import MEASUREMENT_INSTRUCTION_NAMES, RESET_INSTRUCTION_NAMES
+from tqec.visualisation.computation.plaquette.extended import (
+    ExtendedPlaquetteDrawer,
+    ExtendedPlaquettePosition,
+    ExtendedPlaquetteType,
+)
 
 
 def _get_spatial_cube_arm_name(
@@ -237,6 +243,71 @@ class ExtendedPlaquette:
     bottom: Plaquette
 
 
+def _get_drawer_basis(description: RPNGDescription) -> PauliBasis | None:
+    bases = {corner.p for corner in description.corners if corner.p is not None}
+    if len(bases) == 1:
+        return bases.pop()
+    return None
+
+
+def _get_drawer_schedule(description: RPNGDescription) -> tuple[int, int, int, int]:
+    return cast(tuple[int, int, int, int], tuple(corner.n or 0 for corner in description.corners))
+
+
+def _with_extended_plaquette_drawer(
+    plaquette: Plaquette,
+    plaquette_type: ExtendedPlaquetteType,
+    position: ExtendedPlaquettePosition,
+    basis: PauliBasis | None,
+    schedule: tuple[int, int, int, int],
+    reset: Basis | None,
+    measurement: Basis | None,
+) -> Plaquette:
+    return plaquette.with_debug_information(
+        PlaquetteDebugInformation(
+            drawer=ExtendedPlaquetteDrawer(
+                plaquette_type,
+                position,
+                basis,
+                schedule,
+                reset,
+                measurement,
+            )
+        )
+    )
+
+
+def _make_extended_plaquette(
+    top: Plaquette,
+    bottom: Plaquette,
+    plaquette_type: ExtendedPlaquetteType,
+    basis: PauliBasis | None,
+    schedule: tuple[int, int, int, int],
+    reset: Basis | None,
+    measurement: Basis | None,
+) -> ExtendedPlaquette:
+    return ExtendedPlaquette(
+        _with_extended_plaquette_drawer(
+            top,
+            plaquette_type,
+            ExtendedPlaquettePosition.UP,
+            basis,
+            schedule,
+            reset,
+            measurement,
+        ),
+        _with_extended_plaquette_drawer(
+            bottom,
+            plaquette_type,
+            ExtendedPlaquettePosition.DOWN,
+            basis,
+            schedule,
+            reset,
+            measurement,
+        ),
+    )
+
+
 @dataclass(frozen=True)
 class ExtendedPlaquetteCollection:
     """The names reflect the shape of the extended plaquette. E.g.
@@ -262,6 +333,8 @@ class ExtendedPlaquetteCollection:
     ) -> ExtendedPlaquetteCollection:
         """Build an instance from the provided ``RPNGDescription``."""
         up, down = get_extended_plaquette(description, reset, measurement, is_reversed)
+        drawer_basis = _get_drawer_basis(description)
+        drawer_schedule = _get_drawer_schedule(description)
         # In the calls to project_on_data_qubit_indices, it is important to remember
         # that individual plaquettes composing the extended plaquette have slightly
         # unconventional qubit layouts. In the below ASCII representation, "s" means
@@ -281,18 +354,70 @@ class ExtendedPlaquetteCollection:
         # |        |
         # d0 ---- d1
         return ExtendedPlaquetteCollection(
-            bulk=ExtendedPlaquette(up, down),
-            bottom_right_triangle=ExtendedPlaquette(up.project_on_data_qubit_indices([1]), down),
-            right_half_rectangle=ExtendedPlaquette(
-                up.project_on_data_qubit_indices([1]), down.project_on_data_qubit_indices([1])
+            bulk=_make_extended_plaquette(
+                up,
+                down,
+                ExtendedPlaquetteType.BULK,
+                drawer_basis,
+                drawer_schedule,
+                reset,
+                measurement,
             ),
-            top_left_triangle=ExtendedPlaquette(up, down.project_on_data_qubit_indices([0])),
-            left_half_rectangle=ExtendedPlaquette(
-                up.project_on_data_qubit_indices([0]), down.project_on_data_qubit_indices([0])
+            bottom_right_triangle=_make_extended_plaquette(
+                up.project_on_data_qubit_indices([1]),
+                down,
+                ExtendedPlaquetteType.BOTTOM_RIGHT_TRIANGLE,
+                drawer_basis,
+                drawer_schedule,
+                reset,
+                measurement,
             ),
-            bottom_left_triangle=ExtendedPlaquette(up.project_on_data_qubit_indices([0]), down),
+            right_half_rectangle=_make_extended_plaquette(
+                up.project_on_data_qubit_indices([1]),
+                down.project_on_data_qubit_indices([1]),
+                ExtendedPlaquetteType.RIGHT_HALF_RECTANGLE,
+                drawer_basis,
+                drawer_schedule,
+                reset,
+                measurement,
+            ),
+            top_left_triangle=_make_extended_plaquette(
+                up,
+                down.project_on_data_qubit_indices([0]),
+                ExtendedPlaquetteType.TOP_LEFT_TRIANGLE,
+                drawer_basis,
+                drawer_schedule,
+                reset,
+                measurement,
+            ),
+            left_half_rectangle=_make_extended_plaquette(
+                up.project_on_data_qubit_indices([0]),
+                down.project_on_data_qubit_indices([0]),
+                ExtendedPlaquetteType.LEFT_HALF_RECTANGLE,
+                drawer_basis,
+                drawer_schedule,
+                reset,
+                measurement,
+            ),
+            bottom_left_triangle=_make_extended_plaquette(
+                up.project_on_data_qubit_indices([0]),
+                down,
+                ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE,
+                drawer_basis,
+                drawer_schedule,
+                reset,
+                measurement,
+            ),
             # bottom left refers to where the right angle is.
-            top_right_triangle=ExtendedPlaquette(up, down.project_on_data_qubit_indices([1])),
+            top_right_triangle=_make_extended_plaquette(
+                up,
+                down.project_on_data_qubit_indices([1]),
+                ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE,
+                drawer_basis,
+                drawer_schedule,
+                reset,
+                measurement,
+            ),
         )
 
     @staticmethod

--- a/src/tqec/compile/specs/library/generators/extended_stabilizers.py
+++ b/src/tqec/compile/specs/library/generators/extended_stabilizers.py
@@ -276,14 +276,7 @@ def _with_extended_plaquette_drawer(
     reset: Basis | None,
     measurement: Basis | None,
 ) -> Plaquette:
-    drawer = ExtendedPlaquetteDrawer(
-        plaquette_type,
-        position,
-        basis,
-        schedule,
-        reset,
-        measurement,
-    )
+    drawer = ExtendedPlaquetteDrawer(plaquette_type, position, basis, schedule, reset, measurement)
     return plaquette.with_debug_information(replace(plaquette.debug_information, drawer=drawer))
 
 

--- a/src/tqec/visualisation/computation/plaquette/extended.py
+++ b/src/tqec/visualisation/computation/plaquette/extended.py
@@ -6,6 +6,7 @@ from typing import cast
 import svg
 from typing_extensions import override
 
+from tqec.plaquette.rpng import PauliBasis
 from tqec.utils.enums import Basis
 from tqec.visualisation.computation.plaquette.base import (
     PlaquetteCorner,
@@ -39,6 +40,8 @@ class ExtendedPlaquetteType(Enum):
     RIGHT_HALF_RECTANGLE = auto()
     TOP_LEFT_TRIANGLE = auto()
     LEFT_HALF_RECTANGLE = auto()
+    BOTTOM_LEFT_TRIANGLE = auto()
+    TOP_RIGHT_TRIANGLE = auto()
 
 
 class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
@@ -46,7 +49,7 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
         self,
         plaquette_type: ExtendedPlaquetteType,
         position: ExtendedPlaquettePosition,
-        basis: Basis,
+        basis: Basis | PauliBasis | None,
         schedule: tuple[int, int, int, int],
         reset: Basis | None = None,
         measurement: Basis | None = None,
@@ -173,8 +176,17 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
         side_length = configuration.plaquette_overflow_lerp_coefficient
 
         vs = [bl, bl - side_length * 1j, tr - side_length, tr, br]
-        if plaquette_type == ExtendedPlaquetteType.TOP_LEFT_TRIANGLE:
-            vs = [2 * center - v for v in vs]
+        match plaquette_type:
+            case ExtendedPlaquetteType.BOTTOM_RIGHT_TRIANGLE:
+                pass
+            case ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE:
+                vs = [complex(1 - v.real, v.imag) for v in vs]
+            case ExtendedPlaquetteType.TOP_LEFT_TRIANGLE:
+                vs = [2 * center - v for v in vs]
+            case ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE:
+                vs = [complex(1 - v.real, v.imag) for v in (2 * center - v for v in vs)]
+            case _:
+                raise ValueError("Unsupported triangle plaquette type provided.")
         return svg_path_enclosing_points(vs, fill, configuration)
 
     def get_plaquette_shape_path(
@@ -191,7 +203,7 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
             the value of ``self._basis``.
 
         """
-        fill = SVGPlaquetteDrawer.get_colour(self._basis)
+        fill = "none" if self._basis is None else SVGPlaquetteDrawer.get_colour(self._basis)
         match self._plaquette_type:
             case (
                 ExtendedPlaquetteType.BULK
@@ -204,6 +216,8 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
             case (
                 ExtendedPlaquetteType.BOTTOM_RIGHT_TRIANGLE
                 | ExtendedPlaquetteType.TOP_LEFT_TRIANGLE
+                | ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE
+                | ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE
             ):
                 return ExtendedPlaquetteDrawer._get_weight_three_extended_plaquette_shape(
                     self._position, self._plaquette_type, fill, configuration
@@ -247,6 +261,12 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
             case ExtendedPlaquetteType.TOP_LEFT_TRIANGLE:
                 data_corners = [tl, tr] if self._position == ExtendedPlaquettePosition.UP else [bl]
                 schedules = [s1, s2] if self._position == ExtendedPlaquettePosition.UP else [s1]
+            case ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE:
+                data_corners = [tl] if self._position == ExtendedPlaquettePosition.UP else [bl, br]
+                schedules = [s1] if self._position == ExtendedPlaquettePosition.UP else [s1, s2]
+            case ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE:
+                data_corners = [tl, tr] if self._position == ExtendedPlaquettePosition.UP else [br]
+                schedules = [s1, s2] if self._position == ExtendedPlaquettePosition.UP else [s2]
             case ExtendedPlaquetteType.RIGHT_HALF_RECTANGLE:
                 data_corners = [tr] if self._position == ExtendedPlaquettePosition.UP else [br]
                 schedules = [s2]
@@ -294,11 +314,22 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
         ]:
             return None
         if (
-            self._plaquette_type == ExtendedPlaquetteType.BOTTOM_RIGHT_TRIANGLE
-            and self._position == ExtendedPlaquettePosition.UP
-        ) or (
-            self._plaquette_type == ExtendedPlaquetteType.TOP_LEFT_TRIANGLE
-            and self._position == ExtendedPlaquettePosition.DOWN
+            (
+                self._plaquette_type == ExtendedPlaquetteType.BOTTOM_RIGHT_TRIANGLE
+                and self._position == ExtendedPlaquettePosition.UP
+            )
+            or (
+                self._plaquette_type == ExtendedPlaquetteType.TOP_LEFT_TRIANGLE
+                and self._position == ExtendedPlaquettePosition.DOWN
+            )
+            or (
+                self._plaquette_type == ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE
+                and self._position == ExtendedPlaquettePosition.UP
+            )
+            or (
+                self._plaquette_type == ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE
+                and self._position == ExtendedPlaquettePosition.DOWN
+            )
         ):
             return None
 
@@ -360,6 +391,18 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
                     [PlaquetteCorner.TOP_LEFT, PlaquetteCorner.TOP_RIGHT]
                     if self._position == ExtendedPlaquettePosition.UP
                     else [PlaquetteCorner.BOTTOM_LEFT]
+                )
+            case ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE:
+                places = (
+                    [PlaquetteCorner.TOP_LEFT]
+                    if self._position == ExtendedPlaquettePosition.UP
+                    else [PlaquetteCorner.BOTTOM_LEFT, PlaquetteCorner.BOTTOM_RIGHT]
+                )
+            case ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE:
+                places = (
+                    [PlaquetteCorner.TOP_LEFT, PlaquetteCorner.TOP_RIGHT]
+                    if self._position == ExtendedPlaquettePosition.UP
+                    else [PlaquetteCorner.BOTTOM_RIGHT]
                 )
             case ExtendedPlaquetteType.RIGHT_HALF_RECTANGLE:
                 places = (

--- a/tests/compile/specs/library/generators/extended_stabilizers_test.py
+++ b/tests/compile/specs/library/generators/extended_stabilizers_test.py
@@ -1,6 +1,7 @@
 import numpy
 import pytest
 import stim
+import svg
 
 from tqec.compile.generation import generate_circuit_from_instantiation
 from tqec.compile.specs.library.generators.constants import EXTENDED_PLAQUETTE_SCHEDULES
@@ -22,6 +23,16 @@ from tqec.visualisation.computation.plaquette.extended import (
     ExtendedPlaquettePosition,
     ExtendedPlaquetteType,
 )
+
+
+def _path_points(path: svg.Path) -> set[tuple[float, float]]:
+    points: set[tuple[float, float]] = set()
+    for element in path.d or []:
+        x = getattr(element, "x", None)
+        y = getattr(element, "y", None)
+        if x is not None and y is not None:
+            points.add((round(float(x), 10), round(float(y), 10)))
+    return points
 
 
 @pytest.mark.parametrize(
@@ -88,6 +99,39 @@ def test_extended_plaquette_drawer_preserves_existing_debug_information() -> Non
     assert decorated_plaquette.debug_information.rpng == description
     assert decorated_plaquette.debug_information.draw_polygons == debug_information.draw_polygons
     assert isinstance(decorated_plaquette.debug_information.drawer, ExtendedPlaquetteDrawer)
+
+
+@pytest.mark.parametrize(
+    "plaquette_type,expected_points",
+    [
+        (
+            ExtendedPlaquetteType.BOTTOM_RIGHT_TRIANGLE,
+            {(0.8, 0.0), (1.0, 0.0), (1.0, 2.0), (0.0, 2.0), (0.0, 1.8)},
+        ),
+        (
+            ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE,
+            {(0.0, 0.0), (0.2, 0.0), (1.0, 1.8), (1.0, 2.0), (0.0, 2.0)},
+        ),
+        (
+            ExtendedPlaquetteType.TOP_LEFT_TRIANGLE,
+            {(0.0, 0.0), (1.0, 0.0), (1.0, 0.2), (0.2, 2.0), (0.0, 2.0)},
+        ),
+        (
+            ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE,
+            {(0.0, 0.2), (0.0, 0.0), (1.0, 0.0), (1.0, 2.0), (0.8, 2.0)},
+        ),
+    ],
+)
+def test_weight_three_extended_plaquette_shapes_match_corner_orientation(
+    plaquette_type: ExtendedPlaquetteType,
+    expected_points: set[tuple[float, float]],
+) -> None:
+    shape = ExtendedPlaquetteDrawer._get_weight_three_extended_plaquette_shape(
+        ExtendedPlaquettePosition.UP, plaquette_type
+    )
+
+    assert isinstance(shape, svg.Path)
+    assert _path_points(shape) == expected_points
 
 
 @pytest.mark.parametrize("reset,measurement", [(None, None), (Basis.X, None), (None, Basis.Z)])

--- a/tests/compile/specs/library/generators/extended_stabilizers_test.py
+++ b/tests/compile/specs/library/generators/extended_stabilizers_test.py
@@ -12,6 +12,7 @@ from tqec.compile.specs.library.generators.extended_stabilizers import (
 from tqec.plaquette.plaquette import Plaquettes
 from tqec.plaquette.rpng.rpng import RPNGDescription
 from tqec.utils.enums import Basis
+from tqec.utils.exceptions import TQECError
 from tqec.utils.frozendefaultdict import FrozenDefaultDict
 from tqec.utils.position import Shift2D
 from tqec.visualisation.computation.plaquette.extended import (
@@ -40,6 +41,25 @@ def test_extended_plaquette(basis: Basis, is_reversed: bool) -> None:
     lf, rf = ("", "_") if is_reversed else ("_", "")
     assert circuit.has_flow(stim.Flow(f"1 -> {b}{lf}{b}__{b}{rf}{b} xor rec[0]"))
     assert circuit.has_flow(stim.Flow(f"{b}{lf}{b}__{b}{rf}{b} -> rec[0]"))
+
+
+@pytest.mark.parametrize(
+    "description",
+    [
+        RPNGDescription.empty(),
+        RPNGDescription.from_string("-x2- ---- ---- -x5-"),
+    ],
+)
+def test_extended_plaquette_collection_rejects_undefined_corners(
+    description: RPNGDescription,
+) -> None:
+    with pytest.raises(TQECError, match="must define all four data-qubit interactions"):
+        ExtendedPlaquetteCollection.from_description(
+            description,
+            reset=None,
+            measurement=None,
+            is_reversed=False,
+        )
 
 
 @pytest.mark.parametrize("reset,measurement", [(None, None), (Basis.X, None), (None, Basis.Z)])

--- a/tests/compile/specs/library/generators/extended_stabilizers_test.py
+++ b/tests/compile/specs/library/generators/extended_stabilizers_test.py
@@ -4,12 +4,21 @@ import stim
 
 from tqec.compile.generation import generate_circuit_from_instantiation
 from tqec.compile.specs.library.generators.constants import EXTENDED_PLAQUETTE_SCHEDULES
-from tqec.compile.specs.library.generators.extended_stabilizers import get_extended_plaquette
+from tqec.compile.specs.library.generators.extended_stabilizers import (
+    ExtendedPlaquette,
+    ExtendedPlaquetteCollection,
+    get_extended_plaquette,
+)
 from tqec.plaquette.plaquette import Plaquettes
 from tqec.plaquette.rpng.rpng import RPNGDescription
 from tqec.utils.enums import Basis
 from tqec.utils.frozendefaultdict import FrozenDefaultDict
 from tqec.utils.position import Shift2D
+from tqec.visualisation.computation.plaquette.extended import (
+    ExtendedPlaquetteDrawer,
+    ExtendedPlaquettePosition,
+    ExtendedPlaquetteType,
+)
 
 
 @pytest.mark.parametrize(
@@ -31,3 +40,42 @@ def test_extended_plaquette(basis: Basis, is_reversed: bool) -> None:
     lf, rf = ("", "_") if is_reversed else ("_", "")
     assert circuit.has_flow(stim.Flow(f"1 -> {b}{lf}{b}__{b}{rf}{b} xor rec[0]"))
     assert circuit.has_flow(stim.Flow(f"{b}{lf}{b}__{b}{rf}{b} -> rec[0]"))
+
+
+@pytest.mark.parametrize("reset,measurement", [(None, None), (Basis.X, None), (None, Basis.Z)])
+@pytest.mark.parametrize(
+    "collection_name,expected_type",
+    [
+        ("bulk", ExtendedPlaquetteType.BULK),
+        ("bottom_right_triangle", ExtendedPlaquetteType.BOTTOM_RIGHT_TRIANGLE),
+        ("right_half_rectangle", ExtendedPlaquetteType.RIGHT_HALF_RECTANGLE),
+        ("top_left_triangle", ExtendedPlaquetteType.TOP_LEFT_TRIANGLE),
+        ("left_half_rectangle", ExtendedPlaquetteType.LEFT_HALF_RECTANGLE),
+        ("bottom_left_triangle", ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE),
+        ("top_right_triangle", ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE),
+    ],
+)
+def test_extended_plaquettes_have_svg_drawers(
+    collection_name: str,
+    expected_type: ExtendedPlaquetteType,
+    reset: Basis | None,
+    measurement: Basis | None,
+) -> None:
+    collection = ExtendedPlaquetteCollection.from_basis(
+        Basis.X,
+        reset=reset,
+        measurement=measurement,
+        is_reversed=False,
+    )
+    plaquette = getattr(collection, collection_name)
+    assert isinstance(plaquette, ExtendedPlaquette)
+
+    for position, part in [
+        (ExtendedPlaquettePosition.UP, plaquette.top),
+        (ExtendedPlaquettePosition.DOWN, plaquette.bottom),
+    ]:
+        drawer = part.debug_information.drawer
+        assert isinstance(drawer, ExtendedPlaquetteDrawer)
+        assert drawer._plaquette_type is expected_type
+        assert drawer._position is position
+        assert drawer.draw("extended-plaquette")

--- a/tests/compile/specs/library/generators/extended_stabilizers_test.py
+++ b/tests/compile/specs/library/generators/extended_stabilizers_test.py
@@ -7,10 +7,12 @@ from tqec.compile.specs.library.generators.constants import EXTENDED_PLAQUETTE_S
 from tqec.compile.specs.library.generators.extended_stabilizers import (
     ExtendedPlaquette,
     ExtendedPlaquetteCollection,
+    _with_extended_plaquette_drawer,
     get_extended_plaquette,
 )
+from tqec.plaquette.debug import DrawPolygon, PlaquetteDebugInformation
 from tqec.plaquette.plaquette import Plaquettes
-from tqec.plaquette.rpng.rpng import RPNGDescription
+from tqec.plaquette.rpng.rpng import PauliBasis, RPNGDescription
 from tqec.utils.enums import Basis
 from tqec.utils.exceptions import TQECError
 from tqec.utils.frozendefaultdict import FrozenDefaultDict
@@ -60,6 +62,32 @@ def test_extended_plaquette_collection_rejects_undefined_corners(
             measurement=None,
             is_reversed=False,
         )
+
+
+def test_extended_plaquette_drawer_preserves_existing_debug_information() -> None:
+    description = RPNGDescription.from_basis_and_schedule(
+        Basis.X, EXTENDED_PLAQUETTE_SCHEDULES[False]
+    )
+    up, _ = get_extended_plaquette(description, is_reversed=False)
+    debug_information = PlaquetteDebugInformation(
+        rpng=description,
+        draw_polygons=DrawPolygon(PauliBasis.X),
+    )
+    plaquette = up.with_debug_information(debug_information)
+
+    decorated_plaquette = _with_extended_plaquette_drawer(
+        plaquette,
+        ExtendedPlaquetteType.BULK,
+        ExtendedPlaquettePosition.UP,
+        PauliBasis.X,
+        (2, 3, 4, 5),
+        reset=None,
+        measurement=None,
+    )
+
+    assert decorated_plaquette.debug_information.rpng == description
+    assert decorated_plaquette.debug_information.draw_polygons == debug_information.draw_polygons
+    assert isinstance(decorated_plaquette.debug_information.drawer, ExtendedPlaquetteDrawer)
 
 
 @pytest.mark.parametrize("reset,measurement", [(None, None), (Basis.X, None), (None, Basis.Z)])


### PR DESCRIPTION
# Description

Re-introduces extended plaquette drawers so generated vertical extended plaquettes can be rendered by the computation SVG visualization path again.

Fixes #657.

Generated with the issue's `move_rotation(Basis.Z)` snippet on this branch (`move_rotation_fixed_boundary_7.svg`):

![Rendered fixed-boundary move-rotation layer with extended plaquettes](https://raw.githubusercontent.com/Samfresh-ai/tqec/b8a3f40f1e9519cdbb8fa16bafd88173167cb542/docs/assets/unitaryhack-950/move_rotation_fixed_boundary_7.png)

This PR:
- attaches `ExtendedPlaquetteDrawer` debug metadata to every generated extended plaquette shape
- adds the missing bottom-left and top-right triangle drawer types
- covers all seven extended plaquette collection shapes, with reset and measurement drawing paths exercised

AI assistance disclosure: OpenAI Codex assisted with this PR. The changed code path was reviewed against the issue requirements and validated locally before submission.

# How Has This Been Tested?

- `uv run pytest tests/compile/specs/library/generators/extended_stabilizers_test.py`
- `uv run pytest tests/compile/specs/library/generators/fixed_bulk_test.py tests/compile/specs/library/generators/fixed_boundary_test.py`
- `uv run ruff check src/tqec/visualisation/computation/plaquette/extended.py src/tqec/compile/specs/library/generators/extended_stabilizers.py tests/compile/specs/library/generators/extended_stabilizers_test.py`
- `uv run ruff format --check src/tqec/visualisation/computation/plaquette/extended.py src/tqec/compile/specs/library/generators/extended_stabilizers.py tests/compile/specs/library/generators/extended_stabilizers_test.py`
- `uv run ty check src/tqec/visualisation/computation/plaquette/extended.py src/tqec/compile/specs/library/generators/extended_stabilizers.py tests/compile/specs/library/generators/extended_stabilizers_test.py`
- `python3 -m compileall -q src/tqec/visualisation/computation/plaquette/extended.py src/tqec/compile/specs/library/generators/extended_stabilizers.py tests/compile/specs/library/generators/extended_stabilizers_test.py`
- `git diff --check`
- Full CI-shaped coverage run over all tracked `*_test.py` files passed: `uv run pytest --cov=tqec --cov-report=xml:coverage.xml --cov-report term-missing:skip-covered ... -m "not slow"` (`772 passed`, `257 deselected`, total line coverage `93%`)
- `uv run python <issue snippet>` generated 42 SVGs under `/tmp/tqec-950-svg`, including `move_rotation_fixed_boundary_7.svg`


**Test Configuration**:
* Python version: 3.13.7
* Operating system and system architecture: Linux x86_64

# Checklist:

* &nbsp; [x] My code follows the style guidelines of this project
* &nbsp; [x] I have performed a self-review of my own code
* &nbsp; [x] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation, where applicable
* &nbsp; [x] My changes generate no new errors or warnings from the changed code
* &nbsp; [x] My code and tests pass locally and have at least 80% line coverage
* &nbsp; [x] Any dependent changes have been merged and published in downstream modules, where applicable
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked


