### PR TITLE
docs: Added documentation explaining temporal alternation of stabiliser schedules

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -106,6 +106,14 @@
 # Last Name Starts With R
 
 # Last Name Starts With S
+@misc{Shaw_Terhal_2026,
+   title={Optimising Quantum Error Correction Using Morphing Circuits},
+   author={Shaw, Mackenzie H. and Terhal, Barbara M.},
+   year={2026},
+   eprint={2604.09797},
+   archivePrefix={arXiv},
+   url={https://arxiv.org/abs/2604.09797} }
+
 @article{Steane_1996,
    title={Multiple Particle Interference and Quantum Error Correction},
    volume={452},

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -64,7 +64,14 @@
    publisher={Verein zur Forderung des Open Access Publizierens in den Quantenwissenschaften},
    author={Gidney, Craig and Newman, Michael and Fowler, Austin and Broughton, Michael},
    year={2021},
-   month=dec, pages={605} }
+    month=dec, pages={605} }
+
+@misc{Gidney_alternating_2025,
+   title={Preserving distance during stabilizer measurements by alternating interaction order from round to round},
+   author={Gidney, Craig},
+   year={2025},
+   howpublished={Quantum Computing Stack Exchange},
+   url={https://quantumcomputing.stackexchange.com/q/41263} }
 
 # Last Name Starts With H
 @article{Horsman_2012,

--- a/docs/user_guide/extended_stabilizers_implementation.rst
+++ b/docs/user_guide/extended_stabilizers_implementation.rst
@@ -10,6 +10,25 @@ Extended plaquettes are used in fixed boundary convention when implementing some
 
 These plaquettes are needed to keep the fixed boundary convention.
 
+What is temporal alternation?
+-----------------------------
+
+Extended plaquettes have hook errors that would significantly reduce the
+effective code distance if left completely uncontrolled. Fully controlling
+them would require even more moments, which would increase the number of
+idle moments for regular plaquettes and introduce more errors.
+
+Instead, the fixed boundary convention uses **temporal alternation**:
+consecutive QEC rounds alternate between a forward and a backward plaquette
+schedule. The backward schedule reverses the order of CNOT gates, flipping
+the orientation of hook errors from one round to the next. This prevents
+low-weight hook errors from lining up across rounds to form undetectable
+logical errors.
+
+When a spatial junction is present, the usual ``Init → Rep(memory) → Meas``
+pattern is replaced by a sequence that alternates backward and forward memory
+plaquettes, with the total number of repetitions unchanged.
+
 What are the implications of using extended plaquettes?
 --------------------------------------------------------
 

--- a/docs/user_guide/extended_stabilizers_implementation.rst
+++ b/docs/user_guide/extended_stabilizers_implementation.rst
@@ -29,6 +29,10 @@ schedule. The backward schedule reverses the order of CNOT gates, flipping
 the orientation of hook errors from one round to the next. This prevents
 low-weight hook errors from lining up across rounds to form undetectable
 logical errors :footcite:`Gidney_alternating_2025, Shaw_Terhal_2026`.
+With temporal alternation, undetectable logical errors require at least
+**d−1** physical errors, being a strict improvement over ⌈d/2⌉ with a
+fixed bad schedule.
+
 
 When a spatial junction is present, the usual ``Init -> Rep(memory) -> Meas``
 pattern is replaced by a sequence that alternates backward and forward memory
@@ -41,7 +45,8 @@ and the forward/backward schedule alternation in
 
 Note that while temporal alternation preserves the circuit-level
 distance, this does not guarantee better logical performance at all physical
-error rates, as the number of minimum-weight error mechanisms also matters
+error rates, since the logical performance also depends on the number of
+minimum-weight and near-minimum-weight error mechanisms that can occur
 :footcite:`Shaw_Terhal_2026`.
 
 What are the implications of using extended plaquettes?

--- a/docs/user_guide/extended_stabilizers_implementation.rst
+++ b/docs/user_guide/extended_stabilizers_implementation.rst
@@ -14,7 +14,7 @@ What is temporal alternation?
 -----------------------------
 
 Extended plaquettes are vulnerable to **hook errors**: a single fault on an ancilla
-qubit that propagates to multiple data qubits through the stabiliser
+qubit that propagates to multiple data qubits through the stabilizer
 measurement circuit. In the surface code, this occurs when a fault on a
 measurement qubit spreads to two data qubits via a CNOT gate, creating a
 weight-2 error that can match a detector pair. If these hook
@@ -39,7 +39,7 @@ For the implementation, see the ``is_reversed`` parameter in
 and the forward/backward schedule alternation in
 ``src/tqec/compile/specs/library/fixed_boundary.py``.
 
-Note that while temporal alternation preserves the circuit-level code
+Note that while temporal alternation preserves the circuit-level
 distance, this does not guarantee better logical performance at all physical
 error rates, as the number of minimum-weight error mechanisms also matters
 :footcite:`Shaw_Terhal_2026`.

--- a/docs/user_guide/extended_stabilizers_implementation.rst
+++ b/docs/user_guide/extended_stabilizers_implementation.rst
@@ -13,7 +13,7 @@ These plaquettes are needed to keep the fixed boundary convention.
 What is temporal alternation?
 -----------------------------
 
-Extended plaquettes contain **hook errors**: a single fault on an ancilla
+Extended plaquettes are vulnerable to **hook errors**: a single fault on an ancilla
 qubit that propagates to multiple data qubits through the stabiliser
 measurement circuit. In the surface code, this occurs when a fault on a
 measurement qubit spreads to two data qubits via a CNOT gate, creating a
@@ -28,11 +28,21 @@ consecutive QEC rounds alternate between a forward and a backward plaquette
 schedule. The backward schedule reverses the order of CNOT gates, flipping
 the orientation of hook errors from one round to the next. This prevents
 low-weight hook errors from lining up across rounds to form undetectable
-logical errors :footcite:`Gidney_alternating_2025`.
+logical errors :footcite:`Gidney_alternating_2025, Shaw_Terhal_2026`.
 
 When a spatial junction is present, the usual ``Init -> Rep(memory) -> Meas``
 pattern is replaced by a sequence that alternates backward and forward memory
 plaquettes, with the total number of repetitions unchanged.
+
+For the implementation, see the ``is_reversed`` parameter in
+``src/tqec/compile/specs/library/generators/extended_stabilizers.py``
+and the forward/backward schedule alternation in
+``src/tqec/compile/specs/library/fixed_boundary.py``.
+
+Note that while temporal alternation preserves the circuit-level code
+distance, this does not guarantee better logical performance at all physical
+error rates, as the number of minimum-weight error mechanisms also matters
+:footcite:`Shaw_Terhal_2026`.
 
 What are the implications of using extended plaquettes?
 --------------------------------------------------------

--- a/docs/user_guide/extended_stabilizers_implementation.rst
+++ b/docs/user_guide/extended_stabilizers_implementation.rst
@@ -13,8 +13,11 @@ These plaquettes are needed to keep the fixed boundary convention.
 What is temporal alternation?
 -----------------------------
 
-Extended plaquettes have hook errors that would significantly reduce the
-effective code distance if left completely uncontrolled. Fully controlling
+Extended plaquettes contain **hook errors**: faults on a single
+measurement qubit that propagate to two data qubits via a CNOT gate,
+creating a weight-2 error that can match a detector pair. If these hook
+errors are left uncontrolled, they can form undetectable logical errors
+and significantly reduce the effective code distance. Fully controlling
 them would require even more moments, which would increase the number of
 idle moments for regular plaquettes and introduce more errors.
 
@@ -25,7 +28,7 @@ the orientation of hook errors from one round to the next. This prevents
 low-weight hook errors from lining up across rounds to form undetectable
 logical errors.
 
-When a spatial junction is present, the usual ``Init → Rep(memory) → Meas``
+When a spatial junction is present, the usual ``Init -> Rep(memory) -> Meas``
 pattern is replaced by a sequence that alternates backward and forward memory
 plaquettes, with the total number of repetitions unchanged.
 

--- a/docs/user_guide/extended_stabilizers_implementation.rst
+++ b/docs/user_guide/extended_stabilizers_implementation.rst
@@ -29,9 +29,11 @@ schedule. The backward schedule reverses the order of CNOT gates, flipping
 the orientation of hook errors from one round to the next. This prevents
 low-weight hook errors from lining up across rounds to form undetectable
 logical errors :footcite:`Gidney_alternating_2025, Shaw_Terhal_2026`.
-With temporal alternation, undetectable logical errors require at least
-**d−1** physical errors, being a strict improvement over ⌈d/2⌉ with a
-fixed bad schedule.
+Temporal alternation requires undetectable logical errors to come from a
+length **d-1** Pauli error chain. This is an increase in circuit distance
+compared to a non-alternating extended plaquette measurement schedule,
+which can corrupt the logical qubit via a hook error mechanism created by
+Pauli errors on as low as ⌈d/2⌉ physical qubits.
 
 
 When a spatial junction is present, the usual ``Init -> Rep(memory) -> Meas``

--- a/docs/user_guide/extended_stabilizers_implementation.rst
+++ b/docs/user_guide/extended_stabilizers_implementation.rst
@@ -13,9 +13,11 @@ These plaquettes are needed to keep the fixed boundary convention.
 What is temporal alternation?
 -----------------------------
 
-Extended plaquettes contain **hook errors**: faults on a single
-measurement qubit that propagate to two data qubits via a CNOT gate,
-creating a weight-2 error that can match a detector pair. If these hook
+Extended plaquettes contain **hook errors**: a single fault on an ancilla
+qubit that propagates to multiple data qubits through the stabiliser
+measurement circuit. In the surface code, this occurs when a fault on a
+measurement qubit spreads to two data qubits via a CNOT gate, creating a
+weight-2 error that can match a detector pair. If these hook
 errors are left uncontrolled, they can form undetectable logical errors
 and significantly reduce the effective code distance. Fully controlling
 them would require even more moments, which would increase the number of

--- a/docs/user_guide/extended_stabilizers_implementation.rst
+++ b/docs/user_guide/extended_stabilizers_implementation.rst
@@ -29,8 +29,8 @@ schedule. The backward schedule reverses the order of CNOT gates, flipping
 the orientation of hook errors from one round to the next. This prevents
 low-weight hook errors from lining up across rounds to form undetectable
 logical errors :footcite:`Gidney_alternating_2025, Shaw_Terhal_2026`.
-Temporal alternation requires undetectable logical errors to come from a
-length **d-1** Pauli error chain. This is an increase in circuit distance
+Temporal alternation requires undetectable logical errors to come from
+**at least** a length **d-1** Pauli error chain. This is an increase in circuit distance
 compared to a non-alternating extended plaquette measurement schedule,
 which can corrupt the logical qubit via a hook error mechanism created by
 Pauli errors on as low as ⌈d/2⌉ physical qubits.

--- a/docs/user_guide/extended_stabilizers_implementation.rst
+++ b/docs/user_guide/extended_stabilizers_implementation.rst
@@ -28,7 +28,7 @@ consecutive QEC rounds alternate between a forward and a backward plaquette
 schedule. The backward schedule reverses the order of CNOT gates, flipping
 the orientation of hook errors from one round to the next. This prevents
 low-weight hook errors from lining up across rounds to form undetectable
-logical errors.
+logical errors :footcite:`Gidney_alternating_2025`.
 
 When a spatial junction is present, the usual ``Init -> Rep(memory) -> Meas``
 pattern is replaced by a sequence that alternates backward and forward memory
@@ -137,3 +137,7 @@ rate is never higher than 3 times its temporal counterpart.
 That means that, in practice, using extended plaquettes have a noticeable effect on logical error
 rate **but** that effect is not as bad as it seems. In fact, the number of low-weight logical errors
 is small enough that the code still persists good performance in terms of logical error rate.
+
+References
+-----------
+.. footbibliography::


### PR DESCRIPTION
# Description

Added a "What is temporal alternation?" section to the extended stabilizers implementation user guide (docs/user_guide/extended_stabilizers_implementation.rst). The new section explains:
- Why hook errors in extended plaquettes cannot be fully controlled (too costly)
- How temporal alternation works: consecutive QEC rounds alternate between forward and backward plaquette schedules, reversing CNOT gate order to flip hook error orientation
- How the pattern changes from Init → Rep(memory) → Meas to an alternating sequence at spatial junctions
 
Fixes #865 

# How Has This Been Tested?

Documentation-only change — no code modified. Verified the RST renders correctly by checking section heading underline length matches the title.

Test Configuration: N/A

# Checklist:

* &nbsp; [ ] My code follows the style guidelines of this project
* &nbsp; [ ] I have performed a self-review of my own code
* &nbsp; [ ] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation
* &nbsp; [ ] My changes generate no new errors or warnings
* &nbsp; [ ] My code and tests pass locally and have at least 80% line coverage
* &nbsp; [ ] Any dependent changes have been merged and published in downstream modules
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked

## AI Notice

I used AI assistance to help refine the wording of the documentation. All changes were reviewed and verified by me before submission.
