### PR TITLE
fix: re-introduce extended plaquette drawers

### DIFF
--- a/src/tqec/compile/specs/library/generators/extended_stabilizers.py
+++ b/src/tqec/compile/specs/library/generators/extended_stabilizers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import stim
 
@@ -11,12 +11,20 @@ from tqec.circuit.qubit import GridQubit
 from tqec.circuit.schedule.circuit import ScheduledCircuit
 from tqec.circuit.schedule.schedule import Schedule
 from tqec.compile.specs.library.generators.constants import EXTENDED_PLAQUETTE_SCHEDULES
+from tqec.plaquette.debug import PlaquetteDebugInformation
 from tqec.plaquette.plaquette import Plaquette
 from tqec.plaquette.qubit import PlaquetteQubits
-from tqec.plaquette.rpng.rpng import RPNG, PauliBasis, RPNGDescription
+from tqec.plaquette.rpng.rpng import RPNG, ExtendedBasis, PauliBasis, RPNGDescription
 from tqec.utils.enums import Basis
 from tqec.utils.exceptions import TQECError
 from tqec.utils.instructions import MEASUREMENT_INSTRUCTION_NAMES, RESET_INSTRUCTION_NAMES
+
+if TYPE_CHECKING:
+    from tqec.visualisation.computation.plaquette.extended import (
+        ExtendedPlaquetteDrawer,
+        ExtendedPlaquettePosition,
+        ExtendedPlaquetteType,
+    )
 
 
 def _get_spatial_cube_arm_name(
@@ -280,19 +288,82 @@ class ExtendedPlaquetteCollection:
         # |   s2   |
         # |        |
         # d0 ---- d1
+
+        tl, tr, bl, br = description.corners
+        sched = (
+            tl.n or 0,
+            tr.n or 0,
+            bl.n or 0,
+            br.n or 0,
+        )
+        bases = {c.p for c in description.corners if c.p is not None}
+        if len(bases) == 1:
+            basis: Basis | ExtendedBasis = Basis(bases.pop().value.upper())
+        else:
+            basis = ExtendedBasis.H
+
+        def _with_drawer(
+            plaquette: Plaquette,
+            ptype: ExtendedPlaquetteType,
+            pos: ExtendedPlaquettePosition,
+        ) -> Plaquette:  # pragma: no cover
+            from tqec.visualisation.computation.plaquette.extended import (  # noqa: PLC0415
+                ExtendedPlaquetteDrawer,
+            )
+
+            drawer: ExtendedPlaquetteDrawer = ExtendedPlaquetteDrawer(
+                ptype, pos, basis, sched, reset, measurement
+            )
+            return plaquette.with_debug_information(
+                PlaquetteDebugInformation(drawer=drawer)
+            )
+
+        from tqec.visualisation.computation.plaquette.extended import (  # noqa: PLC0415
+            ExtendedPlaquettePosition as Pos,
+            ExtendedPlaquetteType as PType,
+        )
+
+        bulk_up = up
+        bulk_down = down
+        brt_up = up.project_on_data_qubit_indices([1])
+        rhr_up = up.project_on_data_qubit_indices([1])
+        rhr_down = down.project_on_data_qubit_indices([1])
+        tlt_up = up
+        tlt_down = down.project_on_data_qubit_indices([0])
+        lhr_up = up.project_on_data_qubit_indices([0])
+        lhr_down = down.project_on_data_qubit_indices([0])
+        blt_up = up.project_on_data_qubit_indices([0])
+        trt_down = down.project_on_data_qubit_indices([1])
+
         return ExtendedPlaquetteCollection(
-            bulk=ExtendedPlaquette(up, down),
-            bottom_right_triangle=ExtendedPlaquette(up.project_on_data_qubit_indices([1]), down),
+            bulk=ExtendedPlaquette(
+                _with_drawer(bulk_up, PType.BULK, Pos.UP),
+                _with_drawer(bulk_down, PType.BULK, Pos.DOWN),
+            ),
+            bottom_right_triangle=ExtendedPlaquette(
+                _with_drawer(brt_up, PType.BOTTOM_RIGHT_TRIANGLE, Pos.UP),
+                _with_drawer(down, PType.BOTTOM_RIGHT_TRIANGLE, Pos.DOWN),
+            ),
             right_half_rectangle=ExtendedPlaquette(
-                up.project_on_data_qubit_indices([1]), down.project_on_data_qubit_indices([1])
+                _with_drawer(rhr_up, PType.RIGHT_HALF_RECTANGLE, Pos.UP),
+                _with_drawer(rhr_down, PType.RIGHT_HALF_RECTANGLE, Pos.DOWN),
             ),
-            top_left_triangle=ExtendedPlaquette(up, down.project_on_data_qubit_indices([0])),
+            top_left_triangle=ExtendedPlaquette(
+                _with_drawer(tlt_up, PType.TOP_LEFT_TRIANGLE, Pos.UP),
+                _with_drawer(tlt_down, PType.TOP_LEFT_TRIANGLE, Pos.DOWN),
+            ),
             left_half_rectangle=ExtendedPlaquette(
-                up.project_on_data_qubit_indices([0]), down.project_on_data_qubit_indices([0])
+                _with_drawer(lhr_up, PType.LEFT_HALF_RECTANGLE, Pos.UP),
+                _with_drawer(lhr_down, PType.LEFT_HALF_RECTANGLE, Pos.DOWN),
             ),
-            bottom_left_triangle=ExtendedPlaquette(up.project_on_data_qubit_indices([0]), down),
-            # bottom left refers to where the right angle is.
-            top_right_triangle=ExtendedPlaquette(up, down.project_on_data_qubit_indices([1])),
+            bottom_left_triangle=ExtendedPlaquette(
+                _with_drawer(blt_up, PType.BOTTOM_LEFT_TRIANGLE, Pos.UP),
+                _with_drawer(down, PType.BOTTOM_LEFT_TRIANGLE, Pos.DOWN),
+            ),
+            top_right_triangle=ExtendedPlaquette(
+                _with_drawer(up, PType.TOP_RIGHT_TRIANGLE, Pos.UP),
+                _with_drawer(trt_down, PType.TOP_RIGHT_TRIANGLE, Pos.DOWN),
+            ),
         )
 
     @staticmethod

--- a/src/tqec/visualisation/computation/plaquette/base.py
+++ b/src/tqec/visualisation/computation/plaquette/base.py
@@ -241,6 +241,8 @@ class SVGPlaquetteDrawer(ABC):
                 return TQECColor.Y.rgba.to_hex()
             case "Z":
                 return TQECColor.Z.rgba.to_hex()
+            case "H":
+                return TQECColor.H.rgba.to_hex()
             case _:
                 return "none"
 

--- a/src/tqec/visualisation/computation/plaquette/extended.py
+++ b/src/tqec/visualisation/computation/plaquette/extended.py
@@ -6,6 +6,7 @@ from typing import cast
 import svg
 from typing_extensions import override
 
+from tqec.plaquette.rpng.rpng import ExtendedBasis, PauliBasis
 from tqec.utils.enums import Basis
 from tqec.visualisation.computation.plaquette.base import (
     PlaquetteCorner,
@@ -39,6 +40,13 @@ class ExtendedPlaquetteType(Enum):
     RIGHT_HALF_RECTANGLE = auto()
     TOP_LEFT_TRIANGLE = auto()
     LEFT_HALF_RECTANGLE = auto()
+    BOTTOM_LEFT_TRIANGLE = auto()
+    TOP_RIGHT_TRIANGLE = auto()
+
+
+def _flip_x(v: complex) -> complex:
+    """Mirror a point horizontally around x=0.5."""
+    return (1 - v.real) + v.imag * 1j
 
 
 class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
@@ -46,7 +54,7 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
         self,
         plaquette_type: ExtendedPlaquetteType,
         position: ExtendedPlaquettePosition,
-        basis: Basis,
+        basis: Basis | ExtendedBasis,
         schedule: tuple[int, int, int, int],
         reset: Basis | None = None,
         measurement: Basis | None = None,
@@ -172,9 +180,14 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
         center = 0.5 + 1j
         side_length = configuration.plaquette_overflow_lerp_coefficient
 
+        # Base vertices for BOTTOM_RIGHT_TRIANGLE shape
         vs = [bl, bl - side_length * 1j, tr - side_length, tr, br]
         if plaquette_type == ExtendedPlaquetteType.TOP_LEFT_TRIANGLE:
             vs = [2 * center - v for v in vs]
+        elif plaquette_type == ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE:
+            vs = [_flip_x(v) for v in vs]
+        elif plaquette_type == ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE:
+            vs = [2 * center - _flip_x(v) for v in vs]
         return svg_path_enclosing_points(vs, fill, configuration)
 
     def get_plaquette_shape_path(
@@ -204,6 +217,8 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
             case (
                 ExtendedPlaquetteType.BOTTOM_RIGHT_TRIANGLE
                 | ExtendedPlaquetteType.TOP_LEFT_TRIANGLE
+                | ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE
+                | ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE
             ):
                 return ExtendedPlaquetteDrawer._get_weight_three_extended_plaquette_shape(
                     self._position, self._plaquette_type, fill, configuration
@@ -253,6 +268,15 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
             case ExtendedPlaquetteType.LEFT_HALF_RECTANGLE:
                 data_corners = [tl] if self._position == ExtendedPlaquettePosition.UP else [bl]
                 schedules = [s1]
+            case ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE:
+                data_corners = [tl] if self._position == ExtendedPlaquettePosition.UP else [bl, br]
+                schedules = [s1] if self._position == ExtendedPlaquettePosition.UP else [s1, s2]
+            case ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE:
+                data_corners = [tl, tr] if self._position == ExtendedPlaquettePosition.UP else [br]
+                schedules = [s1, s2] if self._position == ExtendedPlaquettePosition.UP else [s2]
+            case _:
+                data_corners = []
+                schedules = []
 
         for corner, schedule in zip(data_corners, schedules):
             if not schedule:
@@ -298,6 +322,15 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
             and self._position == ExtendedPlaquettePosition.UP
         ) or (
             self._plaquette_type == ExtendedPlaquetteType.TOP_LEFT_TRIANGLE
+            and self._position == ExtendedPlaquettePosition.DOWN
+        ):
+            return None
+        # Mirrors of the above: no hook error for these single-qubit halves either
+        if (
+            self._plaquette_type == ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE
+            and self._position == ExtendedPlaquettePosition.UP
+        ) or (
+            self._plaquette_type == ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE
             and self._position == ExtendedPlaquettePosition.DOWN
         ):
             return None
@@ -373,6 +406,20 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
                     if self._position == ExtendedPlaquettePosition.UP
                     else [PlaquetteCorner.BOTTOM_LEFT]
                 )
+            case ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE:
+                places = (
+                    [PlaquetteCorner.TOP_LEFT]
+                    if self._position == ExtendedPlaquettePosition.UP
+                    else [PlaquetteCorner.BOTTOM_LEFT, PlaquetteCorner.BOTTOM_RIGHT]
+                )
+            case ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE:
+                places = (
+                    [PlaquetteCorner.TOP_LEFT, PlaquetteCorner.TOP_RIGHT]
+                    if self._position == ExtendedPlaquettePosition.UP
+                    else [PlaquetteCorner.BOTTOM_RIGHT]
+                )
+            case _:
+                places = []
         reset_measurement_svgs: list[svg.Element] = []
         for place in places:
             corner_coords = self.get_corner_coordinates(place)


### PR DESCRIPTION
Fixes #657

- Added `ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE` and `ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE` to support all generated shapes.
- Fixed shape geometry for the new triangles using horizontal mirroring and 180 degree rotation.
- Updated `ExtendedPlaquetteDrawer` to properly attach interaction orders, data qubit symbols, and hook errors for these shapes.
- Added support for Hadamard-colored extended plaquettes by supporting the `"H"` basis string in `SVGPlaquetteDrawer.get_colour`.
- Wired up the `ExtendedPlaquetteDrawer` correctly in `ExtendedPlaquetteCollection.from_description`, identifying Hadamard bases by checking if the source RPNG description contains mixed Pauli bases.