### PR TITLE
fix: stabilize filled graph circuit ordering

### DIFF
--- a/src/tqec/computation/open_graph.py
+++ b/src/tqec/computation/open_graph.py
@@ -96,9 +96,12 @@ def fill_ports_for_minimal_simulation(
         )
 
     correlation_surfaces = graph.find_correlation_surfaces()
-    stab_to_surface: dict[str, CorrelationSurface] = {
-        s.external_stabilizer_on_graph(graph): s for s in correlation_surfaces
-    }
+    stab_to_surface: dict[str, CorrelationSurface] = dict(
+        sorted(
+            (surface.external_stabilizer_on_graph(graph), surface)
+            for surface in correlation_surfaces
+        )
+    )
     generators = list(stab_to_surface.keys())
 
     if search_small_area_observables:
@@ -132,9 +135,17 @@ def fill_ports_for_minimal_simulation(
             g.add_edge(i, j)
     # Solve with heuristic greedy coloring
     coloring = nx.algorithms.coloring.greedy_color(g)  # type: ignore[invalid-argument-type]
-    cliques: dict[int, list[str]] = {}
+    clique_map: dict[int, list[str]] = {}
     for node, color in coloring.items():
-        cliques.setdefault(color, []).append(generators[node])
+        clique_map.setdefault(color, []).append(generators[node])
+    pauli_order = {"X": 0, "Y": 1, "Z": 2}
+    cliques = sorted(
+        (sorted(clique) for clique in clique_map.values()),
+        key=lambda clique: (
+            min(pauli_order[p] for stabilizer in clique for p in stabilizer if p != "I"),
+            clique,
+        ),
+    )
 
     def ports_basis_for_clique(
         supported_stabilizers: list[str],
@@ -151,7 +162,7 @@ def fill_ports_for_minimal_simulation(
     # Fill in the ports and create the filled graphs
     ports = graph.ordered_ports
     filled_graphs: list[FilledGraph] = []
-    for clique in cliques.values():
+    for clique in cliques:
         fg = graph.clone()
         port_basis = ports_basis_for_clique(clique)
         for port, basis in zip(ports, port_basis):

--- a/tests/computation/open_graph_test.py
+++ b/tests/computation/open_graph_test.py
@@ -1,7 +1,14 @@
-import pytest
+from collections.abc import Callable
 
+import pytest
+import stim
+
+from tqec.compile.compile import compile_block_graph
+from tqec.computation.block_graph import BlockGraph
+from tqec.computation.correlation import CorrelationSurface
 from tqec.computation.open_graph import fill_ports_for_minimal_simulation
 from tqec.gallery.cnot import cnot
+from tqec.gallery.three_cnots import three_cnots
 
 
 @pytest.mark.parametrize("search_small_area_observables", [True, False])
@@ -20,3 +27,42 @@ def test_fill_ports_for_minimal_simulation(search_small_area_observables: bool) 
     else:
         assert set(g1.stabilizers) == {"XXXI", "XIXX"}
         assert set(g1.get_external_stabilizers()) == {"XXXI", "XXIX"}
+
+
+@pytest.mark.parametrize("graph_factory", [cnot, three_cnots])
+def test_fill_ports_is_independent_of_correlation_surface_order(
+    graph_factory: Callable[[], BlockGraph],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    find_correlation_surfaces = BlockGraph.find_correlation_surfaces
+
+    def generated_circuits() -> list[tuple[list[str], stim.Circuit]]:
+        return [
+            (
+                filled_graph.stabilizers,
+                compile_block_graph(
+                    filled_graph.graph,
+                    observables=filled_graph.observables,
+                ).generate_stim_circuit(
+                    1,
+                    manhattan_radius=-1,
+                    database_path=None,
+                ),
+            )
+            for filled_graph in fill_ports_for_minimal_simulation(graph_factory())
+        ]
+
+    expected = generated_circuits()
+
+    def find_reversed_correlation_surfaces(
+        self: BlockGraph,
+    ) -> list[CorrelationSurface]:
+        return list(reversed(find_correlation_surfaces(self)))
+
+    monkeypatch.setattr(
+        BlockGraph,
+        "find_correlation_surfaces",
+        find_reversed_correlation_surfaces,
+    )
+
+    assert generated_circuits() == expected


### PR DESCRIPTION
## Summary

- canonicalize correlation surfaces before NetworkX greedy coloring
- canonicalize stabilizers within each clique and preserve stable X/Y/Z output ordering
- add a regression test that reverses correlation-surface iteration and compares the generated Stim circuits structurally

## Why

Sorting only after coloring is too late: unordered surface iteration can change graph node insertion order and therefore the greedy-color result. That produces different circuit strong IDs for equivalent gallery circuits and leaves duplicate points in the error-rate curves.

This takes the pre-coloring canonicalization approach discussed in #825 and avoids string or hash snapshots in the regression test.

## Checks

- `uv run pytest tests -q` (758 passed, 257 deselected)
- `uv run ruff check src/tqec/computation/open_graph.py tests/computation/open_graph_test.py` (passed)
- `uv run ty check src/tqec/computation/open_graph.py tests/computation/open_graph_test.py` (passed)
- `git diff --check` (passed)

Closes #825.

## AI disclosure

I used an LLM as a collaborative tool for repository triage, test design, and reviewing the ordering edge cases. I reproduced the nondeterminism before the fix, implemented and reviewed the patch locally, and ran the checks listed above.
