### PR TITLE
Remove redundant tuple casting in RPNGDescription builder methods

### DIFF
--- a/src/tqec/plaquette/rpng/rpng.py
+++ b/src/tqec/plaquette/rpng/rpng.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, cast
+from typing import Any
 
 from tqec.circuit.schedule.schedule import Schedule
 from tqec.utils.enums import Basis
@@ -216,7 +216,7 @@ class RPNGDescription:
         rpng_objs = tuple([RPNG.from_string(s) for s in corners_rpng_string.split(" ")])
         if len(rpng_objs) != 4:
             raise ValueError("There must be 4 corners in the RPNG description.")
-        return cls(cast(tuple[RPNG, RPNG, RPNG, RPNG], rpng_objs))
+        return cls(rpng_objs)
 
     @classmethod
     def from_extended_string(cls, ancilla_and_corners_rpng_string: str) -> RPNGDescription:
@@ -226,7 +226,7 @@ class RPNGDescription:
         rpng_objs = tuple([RPNG.from_string(s) for s in values[1:]])
         if len(rpng_objs) != 4:
             raise ValueError("There must be 4 corners in the RPNG description.")
-        return cls(cast(tuple[RPNG, RPNG, RPNG, RPNG], rpng_objs), ancilla_rg)
+        return cls(rpng_objs, ancilla_rg)
 
     @classmethod
     def from_basis_and_schedule(
@@ -242,7 +242,7 @@ class RPNGDescription:
         rpng_objs = tuple([RPNG.from_string(f"{r}{basis.value.lower()}{s}{m}") for s in schedule])
         if len(rpng_objs) != 4:
             raise ValueError("There must be 4 corners in the RPNG description.")
-        return cls(cast(tuple[RPNG, RPNG, RPNG, RPNG], rpng_objs))
+        return cls(rpng_objs)
 
     @staticmethod
     def empty() -> RPNGDescription:


### PR DESCRIPTION
# Description

RPNGDescriptor constructor invocations were flagged by the type checker because of a (now) redundant casting as a tuple, which it can now infer from the previous code, including the size requirement of 4.

Fixes #970 

# How Has This Been Tested?

```
uv run ty check
uv run pytest
```

**Test Configuration**:
* Python version: 3.12.9
* Operating system and system architecture: macOS 26.5/M1 chip

# Checklist:

* &nbsp; [x] My code follows the style guidelines of this project
* &nbsp; [x] I have performed a self-review of my own code
* &nbsp; [x] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation
* &nbsp; [x] My changes generate no new errors or warnings
* &nbsp; [x] My code and tests pass locally and have at least 80% line coverage
* &nbsp; [x] Any dependent changes have been merged and published in downstream modules
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked (**No AI used.**)
