### PR TITLE
Cast pytest arguments into tuple

### DIFF
--- a/src/tqec/utils/paths.py
+++ b/src/tqec/utils/paths.py
@@ -6,11 +6,10 @@ from platformdirs import user_data_path
 
 USER_DATA_PATH: Final[Path] = user_data_path(appname="TQEC")
 
+
 # Get the detector database path.
 # This path can be provided through the TQEC_DETECTOR_DATABASE_PATH environment variable, or it
 # defaults to a user-controlled directory.
-
-
 def _get_database_path() -> Path:
     if (env_db_path := os.getenv("TQEC_DETECTOR_DATABASE_PATH")) is not None:
         return Path(env_db_path)  # pragma: no cover

--- a/src/tqec/utils/paths.py
+++ b/src/tqec/utils/paths.py
@@ -6,10 +6,11 @@ from platformdirs import user_data_path
 
 USER_DATA_PATH: Final[Path] = user_data_path(appname="TQEC")
 
-
 # Get the detector database path.
 # This path can be provided through the TQEC_DETECTOR_DATABASE_PATH environment variable, or it
 # defaults to a user-controlled directory.
+
+
 def _get_database_path() -> Path:
     if (env_db_path := os.getenv("TQEC_DETECTOR_DATABASE_PATH")) is not None:
         return Path(env_db_path)  # pragma: no cover

--- a/tests/compile/compile_test.py
+++ b/tests/compile/compile_test.py
@@ -47,7 +47,7 @@ def generate_inputs(
     *args: Unpack[Ts],
     small_ks: Sequence[int] = (1,),
     larger_ks: Sequence[int] = (2,),
-) -> Iterable[int, Unpack[Ts]] | Any:
+) -> Iterable[tuple[int, Unpack[Ts]]] | Any:
     # Currently not possible to return the correct type with typing. See
     # https://github.com/python/typing/issues/1216 for example.
     yield from itertools.product(small_ks, *args)

--- a/tests/compile/compile_test.py
+++ b/tests/compile/compile_test.py
@@ -47,7 +47,7 @@ def generate_inputs(
     *args: Unpack[Ts],
     small_ks: Sequence[int] = (1,),
     larger_ks: Sequence[int] = (2,),
-) -> Iterable[tuple[int, Unpack[Ts]]] | Any:
+) -> Iterable[tuple[int, Unpack[Ts]] | Any]:
     # Currently not possible to return the correct type with typing. See
     # https://github.com/python/typing/issues/1216 for example.
     yield from itertools.product(small_ks, *args)

--- a/tests/compile/compile_test.py
+++ b/tests/compile/compile_test.py
@@ -13,7 +13,7 @@ Warning:
 """
 
 import itertools
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -47,7 +47,7 @@ def generate_inputs(
     *args: Unpack[Ts],
     small_ks: Sequence[int] = (1,),
     larger_ks: Sequence[int] = (2,),
-) -> Iterable[tuple[int, Unpack[Ts]] | Any]:
+) -> tuple[int, Unpack[Ts]] | Any:
     # Currently not possible to return the correct type with typing. See
     # https://github.com/python/typing/issues/1216 for example.
     yield from itertools.product(small_ks, *args)
@@ -154,7 +154,7 @@ def detector_db(filepath: Path):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def save_to_db(filepath, detector_db):
+def save_to_db(filepath: Path, detector_db: DetectorDatabase):
     yield
     detector_db.to_file(filepath)
 

--- a/tests/compile/compile_test.py
+++ b/tests/compile/compile_test.py
@@ -13,7 +13,7 @@ Warning:
 """
 
 import itertools
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -47,7 +47,7 @@ def generate_inputs(
     *args: Unpack[Ts],
     small_ks: Sequence[int] = (1,),
     larger_ks: Sequence[int] = (2,),
-) -> tuple[int, Unpack[Ts]] | Any:
+) -> Iterable[int, Unpack[Ts]] | Any:
     # Currently not possible to return the correct type with typing. See
     # https://github.com/python/typing/issues/1216 for example.
     yield from itertools.product(small_ks, *args)
@@ -161,7 +161,7 @@ def save_to_db(filepath: Path, detector_db: DetectorDatabase):
 
 @pytest.mark.parametrize(
     ("k", "convention", "kind"),
-    generate_inputs(CONVENTIONS, ("ZXZ", "ZXX", "XZX", "XZZ")),
+    tuple(generate_inputs(CONVENTIONS, ("ZXZ", "ZXX", "XZX", "XZZ"))),
 )
 def test_compile_memory(
     convention: Convention, kind: str, k: int, detector_db: DetectorDatabase
@@ -183,7 +183,11 @@ def test_compile_memory(
 
 @pytest.mark.parametrize(
     ("k", "convention", "kind", "xy"),
-    generate_inputs(CONVENTIONS, ("ZXZ", "ZXX", "XZX", "XZZ"), ((0, 0), (1, 1), (2, 2), (-1, -1))),
+    tuple(
+        generate_inputs(
+            CONVENTIONS, ("ZXZ", "ZXX", "XZX", "XZZ"), ((0, 0), (1, 1), (2, 2), (-1, -1))
+        )
+    ),
 )
 def test_compile_two_same_blocks_connected_in_time(
     convention: Convention, kind: str, k: int, xy: tuple[int, int], detector_db: DetectorDatabase
@@ -209,7 +213,11 @@ def test_compile_two_same_blocks_connected_in_time(
 
 @pytest.mark.parametrize(
     ("k", "convention", "kinds"),
-    generate_inputs(CONVENTIONS, (("ZXZ", "OXZ"), ("ZXX", "ZOX"), ("XZX", "OZX"), ("XZZ", "XOZ"))),
+    tuple(
+        generate_inputs(
+            CONVENTIONS, (("ZXZ", "OXZ"), ("ZXX", "ZOX"), ("XZX", "OZX"), ("XZZ", "XOZ"))
+        )
+    ),
 )
 def test_compile_two_same_blocks_connected_in_space(
     convention: Convention, kinds: tuple[str, str], k: int, detector_db: DetectorDatabase
@@ -238,7 +246,11 @@ def test_compile_two_same_blocks_connected_in_space(
 
 @pytest.mark.parametrize(
     ("k", "convention", "kinds"),
-    generate_inputs(CONVENTIONS, (("ZXZ", "OXZ"), ("ZXX", "ZOX"), ("XZX", "OZX"), ("XZZ", "XOZ"))),
+    tuple(
+        generate_inputs(
+            CONVENTIONS, (("ZXZ", "OXZ"), ("ZXX", "ZOX"), ("XZX", "OZX"), ("XZZ", "XOZ"))
+        )
+    ),
 )
 def test_compile_L_shape_in_space_time(
     convention: Convention, kinds: tuple[str, str], k: int, detector_db: DetectorDatabase
@@ -271,7 +283,7 @@ def test_compile_L_shape_in_space_time(
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    ("k", "convention", "obs_basis"), generate_inputs(CONVENTIONS, (Basis.X, Basis.Z))
+    ("k", "convention", "obs_basis"), tuple(generate_inputs(CONVENTIONS, (Basis.X, Basis.Z)))
 )
 def test_compile_logical_cnot(
     convention: Convention, obs_basis: Basis, k: int, detector_db: DetectorDatabase
@@ -285,7 +297,7 @@ def test_compile_logical_cnot(
 
 
 @pytest.mark.parametrize(
-    ("k", "convention", "obs_basis"), generate_inputs(CONVENTIONS, (Basis.X, Basis.Z))
+    ("k", "convention", "obs_basis"), tuple(generate_inputs(CONVENTIONS, (Basis.X, Basis.Z)))
 )
 def test_compile_stability(
     convention: Convention, obs_basis: Basis, k: int, detector_db: DetectorDatabase
@@ -309,7 +321,7 @@ def test_compile_stability(
     )
 
 
-@pytest.mark.parametrize(("k", "convention"), generate_inputs(CONVENTIONS))
+@pytest.mark.parametrize(("k", "convention"), tuple(generate_inputs(CONVENTIONS)))
 def test_compile_L_spatial_junction(
     convention: Convention, k: int, detector_db: DetectorDatabase
 ) -> None:
@@ -327,7 +339,7 @@ def test_compile_L_spatial_junction(
 
 
 @pytest.mark.parametrize(
-    ("k", "convention", "obs_basis"), generate_inputs(CONVENTIONS, (Basis.X, Basis.Z))
+    ("k", "convention", "obs_basis"), tuple(generate_inputs(CONVENTIONS, (Basis.X, Basis.Z)))
 )
 def test_compile_move_rotation(
     convention: Convention, obs_basis: Basis, k: int, detector_db: DetectorDatabase
@@ -351,7 +363,7 @@ def test_compile_move_rotation(
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    ("k", "convention", "in_future"), generate_inputs(CONVENTIONS, (False, True))
+    ("k", "convention", "in_future"), tuple(generate_inputs(CONVENTIONS, (False, True)))
 )
 def test_compile_L_spatial_junction_with_time_pipe(
     convention: Convention, k: int, in_future: bool, detector_db: DetectorDatabase
@@ -373,7 +385,7 @@ def test_compile_L_spatial_junction_with_time_pipe(
 
 @pytest.mark.parametrize(
     ("k", "convention", "in_obs_basis"),
-    generate_inputs(CONVENTIONS, (Basis.X, Basis.Z)),
+    tuple(generate_inputs(CONVENTIONS, (Basis.X, Basis.Z))),
 )
 def test_compile_temporal_hadamard(
     convention: Convention, in_obs_basis: Basis, k: int, detector_db: DetectorDatabase
@@ -391,7 +403,7 @@ def test_compile_temporal_hadamard(
 
 @pytest.mark.parametrize(
     ("k", "convention", "h_top_obs_basis"),
-    generate_inputs(CONVENTIONS, [Basis.X, Basis.Z]),
+    tuple(generate_inputs(CONVENTIONS, [Basis.X, Basis.Z])),
 )
 def test_compile_bell_state_with_single_temporal_hadamard(
     convention: Convention, h_top_obs_basis: Basis, k: int, detector_db: DetectorDatabase
@@ -413,7 +425,7 @@ def test_compile_bell_state_with_single_temporal_hadamard(
 
 @pytest.mark.parametrize(
     ("k", "convention", "direction"),
-    generate_inputs(CONVENTIONS, (Direction3D.X, Direction3D.Y)),
+    tuple(generate_inputs(CONVENTIONS, (Direction3D.X, Direction3D.Y))),
 )
 def test_compile_spatial_hadamard_vertical_correlation_surface(
     convention: Convention, direction: Direction3D, k: int, detector_db: DetectorDatabase
@@ -449,7 +461,7 @@ def test_compile_spatial_hadamard_vertical_correlation_surface(
 
 @pytest.mark.parametrize(
     ("k", "convention", "direction", "obs_basis"),
-    generate_inputs(CONVENTIONS, (Direction3D.X, Direction3D.Y), (Basis.X, Basis.Z)),
+    tuple(generate_inputs(CONVENTIONS, (Direction3D.X, Direction3D.Y), (Basis.X, Basis.Z))),
 )
 def test_compile_spatial_hadamard_horizontal_correlation_surface(
     convention: Convention,
@@ -500,7 +512,7 @@ def test_compile_spatial_hadamard_horizontal_correlation_surface(
 @pytest.mark.slow
 @pytest.mark.parametrize(
     ("k", "convention", "shape", "basis"),
-    generate_inputs(CONVENTIONS, ("⊣", "T", "⊥", "⊢"), (Basis.X, Basis.Z)),
+    tuple(generate_inputs(CONVENTIONS, ("⊣", "T", "⊥", "⊢"), (Basis.X, Basis.Z))),
 )
 def test_compile_three_way_junction_with_spatial_cube_endpoints(
     convention: Convention, shape: str, basis: Basis, k: int, detector_db: DetectorDatabase
@@ -537,7 +549,7 @@ def test_compile_three_way_junction_with_spatial_cube_endpoints(
 @pytest.mark.slow
 @pytest.mark.parametrize(
     ("k", "convention", "shape", "spatial_basis"),
-    generate_inputs(CONVENTIONS, ("⊣", "T", "⊥", "⊢"), (Basis.X, Basis.Z)),
+    tuple(generate_inputs(CONVENTIONS, ("⊣", "T", "⊥", "⊢"), (Basis.X, Basis.Z))),
 )
 def test_compile_three_way_junction_with_regular_cube_endpoints(
     convention: Convention, shape: str, spatial_basis: Basis, k: int, detector_db: DetectorDatabase
@@ -587,7 +599,7 @@ def test_compile_three_way_junction_with_regular_cube_endpoints(
 
 @pytest.mark.parametrize(
     ("k", "convention", "kind", "direction"),
-    generate_inputs(CONVENTIONS, ("ZZX", "XXZ"), (Direction3D.X, Direction3D.Y)),
+    tuple(generate_inputs(CONVENTIONS, ("ZZX", "XXZ"), (Direction3D.X, Direction3D.Y))),
 )
 def test_compile_I_shape_stability_experiment_composed_of_three_cubes(
     convention: Convention, kind: str, direction: Direction3D, k: int, detector_db: DetectorDatabase
@@ -609,7 +621,7 @@ def test_compile_I_shape_stability_experiment_composed_of_three_cubes(
 @pytest.mark.slow
 @pytest.mark.parametrize(
     ("k", "convention", "kind", "shape"),
-    generate_inputs(CONVENTIONS, ("ZZX", "XXZ"), ("H", "工")),
+    tuple(generate_inputs(CONVENTIONS, ("ZZX", "XXZ"), ("H", "工"))),
 )
 def test_compile_H_shape_stability_experiment(
     convention: Convention, kind: str, shape: str, k: int, detector_db: DetectorDatabase
@@ -658,7 +670,7 @@ def test_compile_H_shape_stability_experiment(
 @pytest.mark.slow
 @pytest.mark.parametrize(
     ("k", "convention", "shape", "spatial_basis"),
-    generate_inputs(CONVENTIONS, ("H", "工"), (Basis.X, Basis.Z)),
+    tuple(generate_inputs(CONVENTIONS, ("H", "工"), (Basis.X, Basis.Z))),
 )
 def test_compile_H_shape_junctions_with_regular_cube_endpoints(
     convention: Convention, shape: str, spatial_basis: Basis, k: int, detector_db: DetectorDatabase
@@ -715,7 +727,7 @@ def test_compile_H_shape_junctions_with_regular_cube_endpoints(
 @pytest.mark.slow
 @pytest.mark.parametrize(
     ("k", "convention", "observable_basis"),
-    generate_inputs(CONVENTIONS, (Basis.X, Basis.Z)),
+    tuple(generate_inputs(CONVENTIONS, (Basis.X, Basis.Z))),
 )
 def test_compile_three_cnots(
     convention: Convention, observable_basis: Basis, k: int, detector_db: DetectorDatabase
@@ -730,7 +742,7 @@ def test_compile_three_cnots(
 @pytest.mark.slow
 @pytest.mark.parametrize(
     ("k", "convention", "observable_basis"),
-    generate_inputs(CONVENTIONS, (Basis.X, Basis.Z)),
+    tuple(generate_inputs(CONVENTIONS, (Basis.X, Basis.Z))),
 )
 def test_compile_steane_encoding(
     convention: Convention, observable_basis: Basis, k: int, detector_db: DetectorDatabase
@@ -751,15 +763,17 @@ def test_compile_steane_encoding(
 
 @pytest.mark.parametrize(
     ("k", "convention", "kind", "block_temporal_height"),
-    generate_inputs(
-        CONVENTIONS,
-        ("ZXZ", "ZXX", "XZX", "XZZ"),
-        (
-            LinearFunction(2, -1),
-            LinearFunction(3, -1),
-            LinearFunction(5, -1),
-            LinearFunction(4, 3),
-        ),
+    tuple(
+        generate_inputs(
+            CONVENTIONS,
+            ("ZXZ", "ZXX", "XZX", "XZZ"),
+            (
+                LinearFunction(2, -1),
+                LinearFunction(3, -1),
+                LinearFunction(5, -1),
+                LinearFunction(4, 3),
+            ),
+        )
     ),
 )
 def test_compile_memory_custom_temporal_height(

--- a/tests/computation/correlation_test.py
+++ b/tests/computation/correlation_test.py
@@ -349,7 +349,9 @@ def test_correlation_four_node_circle() -> None:
     assert len(find_correlation_surfaces(pg)) == 2
 
 
-@pytest.mark.parametrize(["bg", "basis"], product([memory, steane_encoding], [Basis.X, Basis.Z]))
+@pytest.mark.parametrize(
+    ["bg", "basis"], tuple(product([memory, steane_encoding], [Basis.X, Basis.Z]))
+)
 def test_correlation_representations_conversion(
     bg: Callable[[Basis], BlockGraph], basis: Basis
 ) -> None:

--- a/tests/templates/subtemplates_test.py
+++ b/tests/templates/subtemplates_test.py
@@ -28,11 +28,13 @@ _VALUES_OF_MANHATTAN_RADIUS_TO_TEST = [0, 1, 3]
 @pytest.mark.filterwarnings("ignore:Instantiating Qubit4WayJunctionTemplate")
 @pytest.mark.parametrize(
     "template,k,r,avoid_zero_plaquettes",
-    itertools.product(
-        _TEMPLATES_TO_TEST,
-        _VALUES_OF_K_TO_TEST,
-        _VALUES_OF_MANHATTAN_RADIUS_TO_TEST,
-        [True, False],
+    tuple(
+        itertools.product(
+            _TEMPLATES_TO_TEST,
+            _VALUES_OF_K_TO_TEST,
+            _VALUES_OF_MANHATTAN_RADIUS_TO_TEST,
+            [True, False],
+        )
     ),
 )
 def test_get_spatially_distinct_subtemplates(
@@ -111,10 +113,12 @@ _TEMPLATE_PAIRS_TO_TEST = [
 @pytest.mark.filterwarnings("ignore:Instantiating Qubit4WayJunctionTemplate")
 @pytest.mark.parametrize(
     "templates,k,r",
-    itertools.product(
-        _TEMPLATE_PAIRS_TO_TEST,
-        _VALUES_OF_K_TO_TEST,
-        _VALUES_OF_MANHATTAN_RADIUS_TO_TEST,
+    tuple(
+        itertools.product(
+            _TEMPLATE_PAIRS_TO_TEST,
+            _VALUES_OF_K_TO_TEST,
+            _VALUES_OF_MANHATTAN_RADIUS_TO_TEST,
+        )
     ),
 )
 def test_get_spatially_distinct_3d_subtemplates(


### PR DESCRIPTION
# Description

Passing iterables into pytests is now [deprecated](https://github.com/pytest-dev/pytest/issues/13409). Casting them into tuples where appropriate.

Fixes #972 

# How Has This Been Tested?

```
uv run pytest
uv run ty check
```

**Test Configuration**:
* Python version: 3.12.9
* Operating system and system architecture: macOS 26.5/M1

# Checklist:

* &nbsp; [x] My code follows the style guidelines of this project
* &nbsp; [x] I have performed a self-review of my own code
* &nbsp; [x] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation
* &nbsp; [x] My changes generate no new errors or warnings
* &nbsp; [x] My code and tests pass locally and have at least 80% line coverage
* &nbsp; [x] Any dependent changes have been merged and published in downstream modules
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked
