### PR TITLE
docs: fix typos, broken cross-references, and terminology figure template

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ For more tutorials like this one, refer to our [user guide](https://tqec.github.
 
 Pull requests and issues are more than welcome!
 
-See the [contributor guide](https://tqec.github.io/tqec/contributor_guide.html) for for specific instructions to start contributing.
+See the [contributor guide](https://tqec.github.io/tqec/contributor_guide.html) for specific instructions to start contributing.
 
 ## Attribution
 
@@ -131,7 +131,7 @@ Please join the [Google group](https://groups.google.com/g/tqec-design-automatio
 >
 > It is made freely and publicly available without access restrictions, in the interest of advancing **open scientific and academic collaboration**.
 >
-> Therefore, the maintainers request that users and contributors **refrain from using the TQEC library to engage in, support, or facilite military, surveillance, or dual-use applications**.
+> Therefore, the maintainers request that users and contributors **refrain from using the TQEC library to engage in, support, or facilitate military, surveillance, or dual-use applications**.
 >
 > Please review the full [`ETHICAL_NOTICE.md`](https://github.com/tqec/tqec/blob/main/ETHICAL_NOTICE.md) for important terms regarding **export control**, **ethical use**, and **contributor responsibilities**.
 ---

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -53,9 +53,9 @@ such that the input is transformed into a topologically quantum error corrected 
 
 Allows a user to provide a ``.dae`` file or a ``pyzx`` graph as an input to ``tqec``.
 
-* A :class:`.BlockGraph` can be constructed through a Collada ``.dae`` file through :func:`.read_block_graph_from_dae_file`
+* A :class:`.BlockGraph` can be constructed from a Collada ``.dae`` file via :func:`.read_block_graph_from_dae_file`
   and vice versa through :func:`.write_block_graph_to_dae_file`.
-* A ZX graph can be mapped to a :class:`.BlockGraph` through :func:`.block_synthesis`.
+* A ZX graph can be mapped to a :class:`.BlockGraph` by using :func:`.block_synthesis`.
 
 Standard color representations as described in :ref:`terminology` are predefined in :class:`.TQECColor`.
 
@@ -72,7 +72,7 @@ The ``3D`` structures discussed in detail in :ref:`terminology` are defined in t
 * A :class:`.Cube` is a fundamental building block constituting of a block of quantum operations that occupy a specific spacetime volume.
   Quantum information encoded in the logical qubits can be preserved or manipulated by these blocks.
 * A :class:`.Pipe` is a block that connects :class:`.Cube` objects in a :class:`.BlockGraph` but does not occupy spacetime volume on its own. The exception
-  here are temporal hadamard pipes that have a volume when compiled using the fixed bulk convention.
+  here are temporal Hadamard pipes that have a volume when compiled using the fixed bulk convention.
 * :class:`.PipeKind` helps determine the kind of a pipe in a  :class:`.BlockGraph` based on the wall bases at the head of the pipe in
   addition to a Hadamard transition.
 * :class:`.Port` depicts the open ports in a :class:`.BlockGraph`.
@@ -125,7 +125,7 @@ A plaquette is the representation of a local quantum circuit. A surface code pat
 :mod:`.circuit`
 ^^^^^^^^^^^^^^^
 
-Implementation of :class:`.ScheduledCircuit`, a quantum circuit representation in tqec, where each and every gate of a regular quantum circuit is associated with the time of execution. This module
+Implementation of :class:`.ScheduledCircuit`, a quantum circuit representation in ``tqec``, where each and every gate of a regular quantum circuit is associated with the time of execution. This module
 maps from the numbered templates to some plaquettes that implement small local circuits to measure a stabilizer as a :class:`.ScheduledCircuit` instance.
 
 :class:`.NoiseModel`

--- a/docs/user_guide/bgraph.rst
+++ b/docs/user_guide/bgraph.rst
@@ -4,7 +4,7 @@ BGRAPH is a work-in-progress file format (`.bgraph`) that can be used to facilit
 
 While only a preliminary minimum baseline in need of improvement, the current BGRAPH specification already enjoys the following advantages:
 
-- Common format both `Topologiq <https://github.com/tqec/topologiq>`_ and `TopoLS <https://github.com/tqec/TopoLS>`_ can produce.
+- Common format that `Topologiq <https://github.com/tqec/topologiq>`_ and `TopoLS <https://github.com/tqec/TopoLS>`_ can produce.
 - Human-readable (QASM-like) format that is easy to inspect.
 - Clear structure that allows parsing using.
 - Sufficiently complete as to enable read/write of any arbitrary block graph :code:`tqec` can currently handle.
@@ -99,12 +99,21 @@ Contains the information needed to translate each line of this section into a :c
 
 The information in this section is meant to be parsed and must contain, at a minimum:
 
-- ``src``: the ID of the cube at which the pipe starts (the source for the edge represented by the pipe).
-- ``tgt``: the ID of the cube at which the pipe ends (the target for the edge represented by the pipe).
+- ``src``: the ID of one of the pipe's two endpoints.
+- ``tgt``: the ID of the other endpoint.
 - ``kind``: the kind of the pipe (see :ref:`Pipe <pipe>` for all possibilities.).
 
 Each Pipe item should be given as a CSV-separated sequence.
 All separating semi-colons should be included and all fields should be given.
+
+.. note::
+
+    The block graph is **undirected**.
+    The ``src`` and ``tgt`` labels are only a writing convention for the two endpoints of a pipe;
+    swapping them describes the same edge, and no ordering or flow is implied.
+    Pipes represent spacetime volumes between two cubes and are not inherently directional.
+    The one exception is Hadamard pipes, whose *head* and *tail* ends carry a visualisation-only meaning
+    inherited from the DAE importer (which end is the rotated one).
 
 .. admonition:: Example
 
@@ -145,7 +154,6 @@ For instance, it is not allowed to use the word ``source`` as the name of the gr
 .. warning::
 
     This constraint is part of the BGRAPH specification but is not yet enforced by the :code:`tqec` parser.
-    Using a reserved term as a value will currently parse without error, but the result is undefined.
 
 Lastly, while probably obvious due to the nature of lattice surgery and the use of semi-colon-separated-values:
 

--- a/docs/user_guide/bgraph.rst
+++ b/docs/user_guide/bgraph.rst
@@ -1,26 +1,27 @@
 BGRAPH Schema
-========================
-
+=============
 BGRAPH is a work-in-progress file format (`.bgraph`) that can be used to facilitate interoperability between external lattice surgery (LS) tools.
 
 While only a preliminary minimum baseline in need of improvement, the current BGRAPH specification already enjoys the following advantages:
 
-- Common format both `Topologiq <https://github.com/tqec/topologiq>`_ and `TopoLS <https://github.com/tqec/TopoLS>`_ can produce
-- Human-readable (QASM-like) format that is easy to inspect
-- Clear structure that allows parsing using
-- Sufficiently complete as to enable read/write of any arbitrary blockgraph :code:`tqec` can currently handle.
+- Common format both `Topologiq <https://github.com/tqec/topologiq>`_ and `TopoLS <https://github.com/tqec/TopoLS>`_ can produce.
+- Human-readable (QASM-like) format that is easy to inspect.
+- Clear structure that allows parsing using.
+- Sufficiently complete as to enable read/write of any arbitrary block graph :code:`tqec` can currently handle.
 
-We welcome proposals for improved specifications that expand upon these minimum advantages. In the ideal scenario, we foresee future versions of BGRAPH being flexible enough as to enable interoperability *at any stage* of the LS process, which the current version cannot yet do.
+We welcome proposals for improved specifications that expand upon these minimum advantages.
+In the ideal scenario, we foresee future versions of BGRAPH being flexible enough as to enable interoperability *at any stage* of the LS process, which the current version cannot yet do.
 
 Schema
--------
+------
 A BGRAPH file can be conceived as a QASM-like representation of a lattice surgery.
 
 Any BGRAPH file should be divided into four main sections:
-- HEADER: The title of the document, with information about the source tool used to produce it.
-- METADATA: A short section with meta information on top
-- CUBES: A subsequent section with detailed information about the cubes in the blockgraph
-- PIPES: A final section with detailed information about the pipes in the blockgraph.
+
+- ``Header``: the title of the document, with information about the source tool used to produce it.
+- ``Metadata``: a short section with meta information on top.
+- ``Cubes``: a subsequent section with detailed information about the cubes in the block graph.
+- ``Pipes``: a final section with detailed information about the pipes in the block graph.
 
 An example BGRAPH file is available from :code:`tqec.assets`.
 
@@ -38,14 +39,15 @@ The information in this section is for identification purposes and is not meant 
 
 Metadata
 ~~~~~~~~
-Contains the information needed to produce a blockgraph using the information available in other sections.
+Contains the information needed to produce a block graph using the information available in the other sections.
 
 The information in this section is parseable, but the specific fields are optional:
-- source: The tool used to create the BGRAPH.
-- name of the circuit: used to give the blockgraph a reference name.
-- length of pipes used in the source tool: The length of the pipes between any two adjacent cubes (see note at the end of this section).
 
-Each METADATA item should be given as a CSV-separated pair. If a field is not included, TQEC will assign default values.
+- ``source``: the tool used to create the BGRAPH.
+- ``circuit_name``: used to give the block graph a reference name.
+- ``pipe_length``: the length of the pipes between any two adjacent cubes (see note at the end of this section).
+
+Each Metadata item should be given as a CSV-separated pair. If a field is not included, ``tqec`` will assign default values.
 
 .. admonition:: Example
 
@@ -58,19 +60,23 @@ Each METADATA item should be given as a CSV-separated pair. If a field is not in
 
 .. note::
 
-    Fields in this section are optional. Note, in particular, that if `pipe_length` is not given, the TQEC parser will default to `pipe_length = 0.0`.
+    Fields in this section are optional. Note, in particular, that if `pipe_length` is not given, the ``tqec`` parser will default to `pipe_length = 0.0`.
 
 Cubes
 ~~~~~
-Contains the information needed to translate each line of this section into a :code:`tqec` `cube <./terminology.rst>`.
+Contains the information needed to translate each line of this section into a :code:`tqec` :ref:`Cube <cube>`.
 
 The information in this section is meant to be parsed and must contain, at a minimum:
-- index: the ID of the cube, ideally an integer but alphanumeric IDs also possible.
-- position: The (x, y, z) position of the cube, a tuple of integers.
-- kind: The kind of the cube, as a string (see `Terminology <https://tqec.github.io/tqec/user_guide/terminology.html>`_, as well as the note below).
-- label (optional): An optional annotation that is typically used to denote when a cube is a PORT.
 
-Each CUBE item should be given as a CSV-separated sequence. All separating semi-colons should be included even if the (optional) label field is blank. This helps communicating explicitly to the parser that there is no label (for robustness, the parses *will* fail if an incorrect number of semi-colons is used).
+- ``index``: the ID of the cube, ideally an integer but alphanumeric IDs also possible.
+- ``x``, ``y``, ``z``: the position of the cube, a tuple of integers.
+- ``kind``: the kind of the cube, as a string (see :ref:`Cube <cube>`, as well as the note below).
+
+Optionally, it may also contain a ``label``, an annotation that is typically used to denote when a cube is a :ref:`Port <port>`.
+
+Each Cube item should be given as a CSV-separated sequence.
+All separating semi-colons should be included even if the (optional) label field is blank.
+This helps communicating explicitly to the parser that there is no label (for robustness, the parses *will* fail if an incorrect number of semi-colons is used).
 
 .. admonition:: Example
 
@@ -82,22 +88,23 @@ Each CUBE item should be given as a CSV-separated sequence. All separating semi-
         0;6;0;0;ooo;in_0;
         8;-6;0;0;ooo;out_0;
 
-
 .. note::
 
-    There is no fully-agreed denomination for open boundaries/ports or Y-cubes. For the time being, it is possible to use "ooo" or "P" for ports and "Y", "yi", "ym" to denote a Y-cube.
+    There is no fully-agreed denomination for open boundaries/ports or Y-cubes.
+    For the time being, it is possible to use ``ooo`` or ``P`` for ports and ``Y``, ``yi``, ``ym`` to denote a Y-cube.
 
 Pipes
 ~~~~~
-Contains the information needed to translate each line of this section into a :code:`tqec` `pipe <./terminology.rst>`.
+Contains the information needed to translate each line of this section into a :code:`tqec` :ref:`Pipe <pipe>`.
 
 The information in this section is meant to be parsed and must contain, at a minimum:
-- index: the ID of the cube, typically an integer.
-- u: The ID of the cube at which the pipe starts (the source for the edge represented by the pipe).
-- v: The ID of the cube at which the pipe ends (the target for the edge represented by the pipe).
-- kind: The kind of the pipe (see `Terminology <https://tqec.github.io/tqec/user_guide/terminology.html>`_ for all possibilities.).
 
-Each PIPE item should be given as a CSV-separated sequence. All separating semi-colons should be included and all fields should be given.
+- ``src``: the ID of the cube at which the pipe starts (the source for the edge represented by the pipe).
+- ``tgt``: the ID of the cube at which the pipe ends (the target for the edge represented by the pipe).
+- ``kind``: the kind of the pipe (see :ref:`Pipe <pipe>` for all possibilities.).
+
+Each Pipe item should be given as a CSV-separated sequence.
+All separating semi-colons should be included and all fields should be given.
 
 .. admonition:: Example
 
@@ -113,24 +120,41 @@ General
 -------
 There are also a number of general practices to consider across sections.
 
-Each section must include the header for the respective section, including the micro-schema for the section. In other words, the following lines should appear exactly as in the examples given above.
-- METADATA: attr_name; value;
-- CUBES: index;x;y;z;kind;label;
-- PIPES: src;tgt;kind;
+Each section must include the header for the respective section, including the micro-schema for the section.
+In other words, the following lines should appear exactly as in the examples given above.
 
-Additionally, the following terms are reserved for usage only as first item in the respective metadata section. In other words, they cannot be used in other fields. So, for instance, it is not allowed use the word *"source"* as :code:`graph_name`.
-- graph_name
-- source
-- pipe_length.
+- ``METADATA: attr_name; value;``
+- ``CUBES: index;x;y;z;kind;label;``
+- ``PIPES: src;tgt;kind;``
 
-Additionally, while probably obvious due to the nature of lattice surgery and the use of semi-colon-separated-values:
-- the strings used as kinds for either cubes or pipes (e.g. zxz, xxz, oxz, ozxh, etc) should not be used for any other purpose.
+Additionally, the following terms are reserved for usage only as first item in the Metadata section.
+
+- ``source``
+- ``circuit_name``
+- ``pipe_length``
+
+For instance, it is not allowed to use the word ``source`` as the name of the graph in ``circuit_name``:
+
+.. admonition:: Example
+
+    .. code-block:: text
+
+        METADATA: attr_name; value;
+        circuit_name; source;
+
+.. warning::
+
+    This constraint is part of the BGRAPH specification but is not yet enforced by the :code:`tqec` parser.
+    Using a reserved term as a value will currently parse without error, but the result is undefined.
+
+Lastly, while probably obvious due to the nature of lattice surgery and the use of semi-colon-separated-values:
+
+- the strings used as kinds for either cubes or pipes (e.g. ``zxz``, ``xxz``, ``oxz``, ``ozxh``, etc) should not be used for any other purpose.
 - no additional semi-colons can be used anywhere in the field except as separators for the specific fields in each of the lines in metadata, cubes, or pipes sections.
 
 Parsing a BGRAPH
 ----------------
-
-If you have a BGRAPH file, you can easily convert it into a blockgraph using :code:`tqec`'s :code:`tqec.computation.block_graph.from_bgraph`.
+If you have a BGRAPH file, you can easily convert it into a :code:`BlockGraph` using :code:`tqec`'s :code:`tqec.computation.block_graph.from_bgraph`.
 
 .. jupyter-execute::
 
@@ -139,13 +163,21 @@ If you have a BGRAPH file, you can easily convert it into a blockgraph using :co
     filepath = "../assets/cnots.bgraph"
     graph = BlockGraph.from_bgraph(filepath)
 
-You can then display and use the resulting blockgraph using other TQEC methods.
+.. raw:: html
 
-For instance, you can call :code:`BlockGraph.view_as_html` to visualize the blockgraph.
+   <br>
+
+You can then display and use the resulting :code:`BlockGraph` using other ``tqec`` methods.
+
+For instance, you can call :code:`BlockGraph.view_as_html` to visualize the :code:`BlockGraph`.
 
 .. jupyter-execute::
 
     graph.view_as_html()
+
+.. raw:: html
+
+   <br>
 
 Additionally, you can attach the correlation surface to the model to visualize what the logical observable looks like:
 
@@ -157,13 +189,16 @@ Additionally, you can attach the correlation surface to the model to visualize w
         show_correlation_surface=correlation_surfaces[0],
     )
 
-And, of course, you can follow the same instructions available in several gallery docs (for instance, this `Steane code example <https://tqec.github.io/tqec/gallery/steane_encoding.html>`_) to produce circuits and simulate the blockgraph.
+.. raw:: html
+
+   <br>
+
+And, of course, you can follow the same instructions available in several gallery docs (for instance, this :doc:`Steane code example </gallery/steane_encoding>`) to produce circuits and simulate the :code:`BlockGraph`.
 
 
 Producing a BGRAPH
 ------------------
-
-It is also possible to produce a BGRAPH of any TQEC blockgraph.
+It is also possible to produce a BGRAPH of any ``tqec`` :code:`BlockGraph`.
 
 In the example below, we print the BGRAPH string. To produce a `.bgraph` file with the contents of the string, simply change :code:`path_to_output_file=None` to Path (pathlib.Path or string).
 
@@ -173,7 +208,7 @@ In the example below, we print the BGRAPH string. To produce a `.bgraph` file wi
     from tqec.gallery import cnot
     from tqec.utils.enums import Basis
 
-    # Import blockgraph from gallery
+    # Import BlockGraph from gallery
     graph = cnot(Basis.X)
 
     # Write to BGRAPH
@@ -184,3 +219,7 @@ In the example below, we print the BGRAPH string. To produce a `.bgraph` file wi
 
     # Inspect BGRAPH string
     print(bgraph_out_str)
+
+.. note::
+
+     It is not allowed to use the reserved terms (``source``, ``circuit_name`` and ``pipe_length``) as the name of the graph in ``graph_name``.

--- a/docs/user_guide/bgraph.rst
+++ b/docs/user_guide/bgraph.rst
@@ -10,7 +10,7 @@ While only a preliminary minimum baseline in need of improvement, the current BG
 - Sufficiently complete as to enable read/write of any arbitrary block graph :code:`tqec` can currently handle.
 
 We welcome proposals for improved specifications that expand upon these minimum advantages.
-In the ideal scenario, we foresee future versions of BGRAPH being flexible enough as to enable interoperability *at any stage* of the LS process, which the current version cannot yet do.
+We foresee future versions of BGRAPH being flexible enough as to enable interoperability *at any stage* of the LS process, which the current version cannot yet do.
 
 Schema
 ------
@@ -75,7 +75,7 @@ The information in this section is meant to be parsed and must contain, at a min
 Optionally, it may also contain a ``label``, an annotation that is typically used to denote when a cube is a :ref:`Port <port>`.
 
 Each Cube item should be given as a CSV-separated sequence.
-All separating semi-colons should be included even if the (optional) label field is blank.
+All separating semicolons should be included even if the (optional) label field is blank.
 This helps communicating explicitly to the parser that there is no label (for robustness, the parses *will* fail if an incorrect number of semi-colons is used).
 
 .. admonition:: Example

--- a/docs/user_guide/bgraph.rst
+++ b/docs/user_guide/bgraph.rst
@@ -76,7 +76,7 @@ Optionally, it may also contain a ``label``, an annotation that is typically use
 
 Each Cube item should be given as a CSV-separated sequence.
 All separating semicolons should be included even if the (optional) label field is blank.
-This helps communicating explicitly to the parser that there is no label (for robustness, the parses *will* fail if an incorrect number of semi-colons is used).
+This helps communicating explicitly to the parser that there is no label (for robustness, the parses *will* fail if an incorrect number of semicolons is used).
 
 .. admonition:: Example
 
@@ -104,7 +104,7 @@ The information in this section is meant to be parsed and must contain, at a min
 - ``kind``: the kind of the pipe (see :ref:`Pipe <pipe>` for all possibilities.).
 
 Each Pipe item should be given as a CSV-separated sequence.
-All separating semi-colons should be included and all fields should be given.
+All separating semicolons should be included and all fields should be given.
 
 .. note::
 
@@ -158,7 +158,7 @@ For instance, it is not allowed to use the word ``source`` as the name of the gr
 Lastly, while probably obvious due to the nature of lattice surgery and the use of semi-colon-separated-values:
 
 - the strings used as kinds for either cubes or pipes (e.g. ``zxz``, ``xxz``, ``oxz``, ``ozxh``, etc) should not be used for any other purpose.
-- no additional semi-colons can be used anywhere in the field except as separators for the specific fields in each of the lines in metadata, cubes, or pipes sections.
+- no additional semicolons can be used anywhere in the field except as separators for the specific fields in each of the lines in metadata, cubes, or pipes sections.
 
 Parsing a BGRAPH
 ----------------

--- a/docs/user_guide/build_computation.rst
+++ b/docs/user_guide/build_computation.rst
@@ -10,7 +10,7 @@ In :code:`tqec`, a logical computation is represented as a :code:`BlockGraph`. T
 In this notebook, we will guide you through all the methods.
 
 1. Use SketchUp
-----------------
+---------------
 
 `SketchUp <https://en.wikipedia.org/wiki/SketchUp>`_ is a 3D modeling tool widely used in QEC community to build the spacetime diagram for logical computations.
 Its user-friendly interface allows you to easily create and manipulate the computation blocks.
@@ -65,11 +65,11 @@ You can add blocks to a :code:`BlockGraph` by calling :code:`add_cube` and :code
 3. :code:`pyzx.GraphS` and synthesis
 ------------------------------------
 
-For large scale quantum computation, we might use :code:`pyzx` as a upstream compiler and take optimized ZX diagrams as inputs to :code:`tqec`. We need to synthesis the
-reduced ZX diagram to valid :code:`BlockGraph` realization.
+For large scale quantum computation, we might use :code:`pyzx` as a upstream compiler and take optimized ZX diagrams as inputs to :code:`tqec`.
+We need to synthesize the reduced ZX diagram to valid :code:`BlockGraph` realization.
 
-Currently, we only support very naive synthesis strategy that requires specifying positions of every vertex in the ZX diagram explicitly. Here we take logical
-S gate teleportation for example to show how to take a :code:`pyzx` graph as input and synthesis it to a :code:`BlockGraph`.
+Currently, we only support very naive synthesis strategy that requires specifying positions of every vertex in the ZX diagram explicitly.
+Here we take logical S gate teleportation for example to show how to take a :code:`pyzx` graph as input and synthesize it to a :code:`BlockGraph`.
 
 .. jupyter-execute::
 

--- a/docs/user_guide/terminology.rst
+++ b/docs/user_guide/terminology.rst
@@ -26,7 +26,6 @@ The naming convention for a cube or a pipe is as follows:
 - The axes used for labeling are as shown in the figure below. ``RGB`` axes are synonymous to ``XYZ`` axes.
 - We begin by labeling the boundary that is facing the X-axis first, then the one that is facing the Y-axis followed by the one facing the Z-axis.
 
-
 .. figure:: ../media/user_guide/terminology/axes_convention.png
    :width: 200px
    :align: center
@@ -52,7 +51,6 @@ The labels based on color of the boundaries are provided in the table below.
    * - Open/Hole (no color)
      - O
 
-
 .. _cube:
 
 Cube
@@ -68,7 +66,6 @@ quantum operations that are applied within the cube. Currently we have the follo
    Different kinds of cubes
 
 .. _zxcube:
-
 
 :py:class:`~tqec.computation.ZXCube`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -101,10 +98,12 @@ the hook errors from decreasing the circuit-level code distance.
 :py:class:`~tqec.computation.YHalfCube`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A green cube representing inplace Y-basis logical initialization or measurement as proposed in `this paper <https://quantum-journal.org/papers/q-2024-04-08-1310/>`_.
+A green cube representing in-place Y-basis logical initialization or measurement as proposed in `this paper <https://quantum-journal.org/papers/q-2024-04-08-1310/>`_.
 The cube's function, whether for initialization or measurement, is determined by its connection to other cubes, either upwards or downwards.
 
 A ``YHalfCube`` occupies :math:`\approx d^3 /2` spacetime volume, where :math:`d` is the code distance.
+
+.. _port:
 
 :py:class:`~tqec.computation.Port`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -166,8 +165,6 @@ Here we take the movement of a logical qubit for example:
 
    Movement of a logical qubit
 
-
-
 The movement operation maps :math:`Z_L, X_L` logical operators at input to :math:`Z_L^{\prime}, X_L^{\prime}` at output.
 Firstly, we show in detail why the structure and circuits above implement the movement of a logical qubit.
 
@@ -203,7 +200,7 @@ Template
 
 In ``tqec``, a template is an object that can, from an integer value representing the
 scaling factor $k$ (with the code distance $d$ checking $d = 2k + 1$ for the surface code),
-can generate a $2$-dimensional array of positive integers.
+generate a $2$-dimensional array of positive integers.
 
 .. _qubit_example:
 
@@ -235,14 +232,14 @@ by convention.
       Usual tiling of plaquettes to build a logical qubit using the surface code.
 
    To see the correspondence more clearly, one can map the indices ``1``, ``2``,
-   ``3``, ``4``, ``5``, ``8``, ``12`` and ``14`` to the "no plaquette" index ``0``
+   ``3``, ``4``, ``5``, ``8``, ``11`` and ``14`` to the "no plaquette" index ``0``
    and print ``0`` with ``.`` for visual clarity::
 
       .  .  6  .  6  .
-      7  9 10  9 10 11
-      . 10  9 10  9  .
-      7  9 10  9 10 11
-      . 10  9 10  9  .
+      7  9 10  9 10  .
+      . 10  9 10  9 12
+      7  9 10  9 10  .
+      . 10  9 10  9 12
       . 13  . 13  .  .
 
 Templates are the abstraction layer that allows most of ``tqec`` internals to be
@@ -264,7 +261,6 @@ systematically extracted from a contiguous portion of a larger template.
 
    is a valid sub-template of :ref:`the full example given in the Template <qubit_example>`
    section.
-
 
 .. important::
 
@@ -305,7 +301,7 @@ Temporal locality means that the quantum circuit depth should be constant and sh
 Explicit gate scheduling requires each and every gate in the circuit to be explicitly
 scheduled at a precise time (or moment) in the quantum circuit.
 
-These condition make plaquettes easily representable as visual $2$-dimensional pictures. It is worth noting that the
+These conditions make plaquettes easily representable as visual $2$-dimensional pictures. It is worth noting that the
 numbering of a plaquette represents the order in which the data qubits interact with the measure qubit. The interaction
 order resembles a ``Z`` or inverted ``N`` shape to ensure commutation relationships with the neighboring stabilizers :footcite:`Fowler_2012, Tomita_2014`.
 The examples below utilize the ``Z`` shape.
@@ -368,5 +364,5 @@ supposed to have a deterministic parity in the absence of errors.
 
 
 References
------------
+----------
 .. footbibliography::


### PR DESCRIPTION
# Description

A pass over the README and the user guide / architecture pages to fix small but real issues found while reading through the docs. No code or behavior changes: docs only.

- **README.md**: typo fixes: duplicate `for for`, and `facilite` to `facilitate`.
- **docs/architecture.rst**: minor wording (`through` to `via` / `by using`), `hadamard` to `Hadamard`, and inline-code formatting for `tqec`.
- **docs/user_guide/terminology.rst**: corrected the example template in the Template section so the figure (rows 2 to 5 with 5 plaquettes) matches the surface image. Also: `inplace` to `in-place`, duplicate `can` removed, `These condition` to `These conditions`, and added a `_port:` anchor so the Port section can be cross-referenced.
- **docs/user_guide/bgraph.rst**: replaced two broken links with proper Sphinx cross-references (`pipe <./terminology.rst>` to `:ref:Pipe <pipe>`, external `gallery/steane_encoding.html` URL to `:doc:/gallery/steane_encoding`), linked the bare `PORT` mention to the new `_port:` anchor, and added small `<br>` spacers so text doesn't render flush against the `view_as_html()` iframes.

No new dependencies.

Fixes # (no issue)

Please add the `documentation` label.

# How Has This Been Tested?

Docs built locally with sphinx-autobuild and visually inspected in a browser:

```
cd docs && uv run sphinx-autobuild . _build/html
```

Verified:

- The build produces no new warnings.
- The new "Port" link in `bgraph.rst` lands on the Port section in `terminology.rst`.
- The "Steane code example" link in `bgraph.rst` lands on the local gallery page, not the external URL.
- The figure-vs-template mismatch in `terminology.rst` is gone (visual check against the surface image).
- All the lists in `bgraph.rst` are displayed correctly.
- Text that follows the HTML figures (`view_as_html()` iframes) in `bgraph.rst` is now displayed with proper vertical separation.
- Inline `tqec` in `architecture.rst` renders as monospaced code, not plain text.

**Test Configuration**:
* Python version: 3.12.3
* Operating system and system architecture: Ubuntu 24.04 (Linux 6.17, x86_64)

# Checklist:

* &nbsp; [ ] My code follows the style guidelines of this project
* &nbsp; [x] I have performed a self-review of my own code
* &nbsp; [ ] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation
* &nbsp; [x] My changes generate no new errors or warnings
* &nbsp; [ ] My code and tests pass locally and have at least 80% line coverage
* &nbsp; [ ] Any dependent changes have been merged and published in downstream modules
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked