### PR TITLE
fix: ignore stargazer list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -217,6 +217,8 @@ linkcheck_ignore = [
     r"https://quantum-journal\.org/.*",
     # Fowler review paper
     r"https://drive\.google\.com/file/.*",
+    # Returns a 404 error in CI while being accessible in practice
+    r"https://github.com/tqec/tqec/stargazers",
 ]
 linkcheck_timeout = 30
 linkcheck_retries = 2


### PR DESCRIPTION
# Description

Fixes an issue in CI that shows   https://github.com/tqec/tqec/stargazers as 404 (see https://github.com/tqec/tqec/actions/runs/28803996319/job/85433198556 for an example).

# How Has This Been Tested?

CI should work. I verified locally that I could access   https://github.com/tqec/tqec/stargazers without having a 404.

# Checklist:

* &nbsp; [x] My code follows the style guidelines of this project
* &nbsp; [x] I have performed a self-review of my own code
* &nbsp; [x] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation
* &nbsp; [x] My changes generate no new errors or warnings
* &nbsp; [x] My code and tests pass locally and have at least 80% line coverage
* &nbsp; [x] Any dependent changes have been merged and published in downstream modules
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked
