### PR TITLE
docs: clarify merge permissions for external contributors

### DIFF
--- a/docs/contributor_guide.rst
+++ b/docs/contributor_guide.rst
@@ -179,7 +179,8 @@ by other people, you can
 on the ``main`` branch of the tqec repository. In the PR message, try to
 provide as much information as possible to help other people understanding your code.
 
-Once your code has been reviewed and accepted by at least one of the developers, you
-will be able to merge it to the ``main`` branch.
-You (the PR owner) are responsible to click on the "Merge" button. If you prefer someone
-else to do it, you should send a clear comment asking for it.
+Once your code has been reviewed and accepted by at least one of the developers, the PR can be merged to the ``main`` branch.
+
+**For contributors with write access:** you can merge the PR yourself by clicking the "Merge" button.
+
+**For external contributors (no write access):** please add a comment on the PR indicating it is ready to merge (e.g., "Ready to merge" or "@maintainers ready to merge"), and a maintainer will merge it for you.


### PR DESCRIPTION
Fixes #987

Updates the contributor guide to clarify the merge process for external contributors vs. contributors with write access.

## Changes
- Distinguishes between contributors with write access (can merge directly) and external contributors (should comment when ready to merge)
- Adds clear instruction for external contributors to use comments like "Ready to merge" or "@maintainers ready to merge"

This resolves the confusion reported in #987 where the documentation stated contributors could merge themselves, but external contributors do not have write access to do so.