### PR TITLE
Replace StackOverflow link with pandoc installation guide

### DIFF
--- a/docs/contributor_guide.rst
+++ b/docs/contributor_guide.rst
@@ -84,8 +84,8 @@ of ``tqec`` through ``pip`` or ``uv``.
 
 
 .. warning::
-    You might have to install ``pandoc`` separately as the instructions above only install a ``pandoc`` wrapper.
-    See https://stackoverflow.com/a/71585691 for more info.
+    You might have to install ``pandoc`` separately as the instructions above only install a ``pandoc`` wrapper, not
+    the executable. See https://pandoc.org/installing.html for instructions.
 
 If you encounter any issue during the installation, please refer to :ref:`installation` for more information.
 


### PR DESCRIPTION
# Description

StackOverflow is now returning 403's in doc build, so, replacing that link to the pandoc installation guide, which is the salient link from the answer.

# How Has This Been Tested?

`make html`

**Test Configuration**:
* Python version: 3.12.9
* Operating system and system architecture: macOS 26.5.2/Apple Silicon

# Checklist:

* &nbsp; [x] My code follows the style guidelines of this project
* &nbsp; [x] I have performed a self-review of my own code
* &nbsp; [x] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation
* &nbsp; [x] My changes generate no new errors or warnings
* &nbsp; [x] My code and tests pass locally and have at least 80% line coverage
* &nbsp; [x] Any dependent changes have been merged and published in downstream modules
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked
