### PR TITLE
Address typing error in original_greedy_color invocation

### DIFF
--- a/tests/computation/open_graph_test.py
+++ b/tests/computation/open_graph_test.py
@@ -1,4 +1,5 @@
 import hashlib
+from typing import Literal
 
 import networkx as nx
 import pytest
@@ -17,11 +18,17 @@ OPEN_PORT_EXAMPLES = {
 
 # networkx's documented coloring strategy names (passed as strings to
 # greedy_color). "largest_first" is the production default; the others probe ordering drift.
-COLORING_STRATEGIES = [
+GreedyColorStrategy = Literal[
     "largest_first",
     "smallest_last",
     "saturation_largest_first",
 ]
+# Repeating this since python 3.10 doesn't allow unpacking inside subscripts.
+GREEDY_COLOR_STRATEGIES: tuple[GreedyColorStrategy, ...] = (
+    "largest_first",
+    "smallest_last",
+    "saturation_largest_first",
+)
 
 
 def _circuit_sha(filled: FilledGraph) -> str:
@@ -71,14 +78,14 @@ def test_fill_ports_deterministic_across_coloring_strategies(
     graph_fn = OPEN_PORT_EXAMPLES[example]
     original_greedy_color = nx.algorithms.coloring.greedy_color
 
-    def make_patched(strategy: str):
+    def make_patched(strategy: GreedyColorStrategy):
         def patched(g: nx.Graph, *args: object, **kwargs: object) -> dict[int, int]:
             return original_greedy_color(g, strategy=strategy)
 
         return patched
 
     fingerprints = {}
-    for strategy in COLORING_STRATEGIES:
+    for strategy in GREEDY_COLOR_STRATEGIES:
         monkeypatch.setattr(nx.algorithms.coloring, "greedy_color", make_patched(strategy))
         filled = fill_ports_for_minimal_simulation(graph_fn(), False)
         fingerprints[strategy] = _fingerprint(filled)


### PR DESCRIPTION
# Description

Address breaking type checks found in PR #1018

`original_greedy_color` expects one of several possible literal values, which is what was being provided, but the type checker didn't examine the list it was iterating over. Add a new custom type `GreedyColorStrategy` just to make it a little clearer.

# How Has This Been Tested?

`uv run ty check`
`uv run pytest tests/computation/open_graph_test.py`

**Test Configuration**:
* Python version: 3.12.9 
* Operating system and system architecture: macOS 26.5.2 / Apple Silicon

# Checklist:

* &nbsp; [x] My code follows the style guidelines of this project
* &nbsp; [x] I have performed a self-review of my own code
* &nbsp; [x] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation
* &nbsp; [x] My changes generate no new errors or warnings
* &nbsp; [x] My code and tests pass locally and have at least 80% line coverage
* &nbsp; [x] Any dependent changes have been merged and published in downstream modules
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked
