### PR TITLE
Add quantum stack exchange to linkcheck-ignore

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -219,6 +219,8 @@ linkcheck_ignore = [
     r"https://drive\.google\.com/file/.*",
     # Returns a 404 error in CI while being accessible in practice
     r"https://github.com/tqec/tqec/stargazers",
+    # Returns 403's during documentation build
+    r"https://quantumcomputing\.stackexchange\.com/.*",
 ]
 linkcheck_timeout = 30
 linkcheck_retries = 2


### PR DESCRIPTION
# Description

This site causes 403's in out build process, [example run](https://github.com/tqec/tqec/actions/runs/30821907896/job/91713917160?pr=1018)

Please add the appropriate labels in the sidebar (e.g., bug fix, CI/CD, documentation).

# How Has This Been Tested?

`sphinx-build -b linkcheck . _build`

**Test Configuration**:
* Python version: 3.12.9
* Operating system and system architecture: macOS 26.5.2 / Apple Silicon

# Checklist:

* &nbsp; [x] My code follows the style guidelines of this project
* &nbsp; [x] I have performed a self-review of my own code
* &nbsp; [x] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation
* &nbsp; [x] My changes generate no new errors or warnings
* &nbsp; [x] My code and tests pass locally and have at least 80% line coverage
* &nbsp; [x] Any dependent changes have been merged and published in downstream modules
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked
