### PR TITLE
Remove extraneous trailing line from quick_start.rst

### DIFF
--- a/docs/user_guide/quick_start.rst
+++ b/docs/user_guide/quick_start.rst
@@ -214,4 +214,3 @@ The process can be repeated through the cli using
 .. code-block:: bash
 
     tqec run-example --out-dir ./results
-test change


### PR DESCRIPTION
# Description

I think this extra line was added as a mistake/initial test for #981 that slipped through the cracks, which is also breaking the docs build.

# How Has This Been Tested?

`uv run --group all make html`

**Test Configuration**:
* Python version: 3.12.9
* Operating system and system architecture: macOS 26.5.2 / M1

# Checklist:

* &nbsp; [x] My code follows the style guidelines of this project
* &nbsp; [x] I have performed a self-review of my own code
* &nbsp; [x] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation
* &nbsp; [x] My changes generate no new errors or warnings
* &nbsp; [x] My code and tests pass locally and have at least 80% line coverage
* &nbsp; [x] Any dependent changes have been merged and published in downstream modules
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked
