### PR TITLE
Restore kwargs parameter to DisableJupyterExecutionInFastMode::apply

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,7 +174,7 @@ class DisableJupyterExecutionInFastMode(SphinxTransform):
     # jupyter-sphinx executes cells at priority 400.
     default_priority = 399
 
-    def apply(self) -> None:
+    def apply(self, **kwargs) -> None:
         """Mark Jupyter cells as non-executable during fast builds."""
         if not SKIP_NOTEBOOK_BUILD:
             return


### PR DESCRIPTION
# Description

Add parameter that was present in the overriden method.

Fixes #1021 

# How Has This Been Tested?

`uv run ty check`

**Test Configuration**:
* Python version: 3.12.9
* Operating system and system architecture: macOS 26.5.2/M1

# Checklist:

* &nbsp; [x] My code follows the style guidelines of this project
* &nbsp; [x] I have performed a self-review of my own code
* &nbsp; [x] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation
* &nbsp; [x] My changes generate no new errors or warnings
* &nbsp; [x] My code and tests pass locally and have at least 80% line coverage
* &nbsp; [x] Any dependent changes have been merged and published in downstream modules
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked
