### PR TITLE
Remove redundant cast to FrozenDefaultDict[K,V]

### DIFF
--- a/src/tqec/utils/frozendefaultdict.py
+++ b/src/tqec/utils/frozendefaultdict.py
@@ -73,10 +73,7 @@ class FrozenDefaultDict(Generic[K, V], Mapping[K, V]):
     def __or__(self, other: Mapping[K, V]) -> FrozenDefaultDict[K, V]:
         mapping = deepcopy(self._dict)
         mapping.update(other)
-        return cast(
-            FrozenDefaultDict[K, V],
-            FrozenDefaultDict(mapping, default_value=self._default_value),
-        )
+        return FrozenDefaultDict(mapping, default_value=self._default_value)
 
     def __hash__(self) -> int:
         return hash(tuple(sorted(self.items())))  # pragma: no cover


### PR DESCRIPTION
# Description

Minor type checking fix.

# How Has This Been Tested?

`uv run pytest tests/utils`

**Test Configuration**:
* Python version: 3.12.9
* Operating system and system architecture: macOS 26.6.1 / M1

# Checklist:

* &nbsp; [x] My code follows the style guidelines of this project
* &nbsp; [x] I have performed a self-review of my own code
* &nbsp; [x] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation
* &nbsp; [x] My changes generate no new errors or warnings
* &nbsp; [x] My code and tests pass locally and have at least 80% line coverage
* &nbsp; [x] Any dependent changes have been merged and published in downstream modules
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked
