### PR TITLE
Invoke FrozenDefaultDict constructor explicitly

### DIFF
--- a/src/tqec/utils/frozendefaultdict.py
+++ b/src/tqec/utils/frozendefaultdict.py
@@ -95,7 +95,7 @@ class FrozenDefaultDict(Generic[K, V], Mapping[K, V]):
 
     def map_keys(self, callable: Callable[[K], K]) -> FrozenDefaultDict[K, V]:
         """Apply ``callable`` to each key and return a new instance with the modified keys."""
-        return self.__class__(
+        return FrozenDefaultDict(
             {callable(k): v for k, v in self.items()},
             default_value=self._default_value,
         )
@@ -112,7 +112,7 @@ class FrozenDefaultDict(Generic[K, V], Mapping[K, V]):
 
     def map_keys_if_present(self, mapping: Mapping[K, K]) -> FrozenDefaultDict[K, V]:
         """Apply ``callable`` to each key and return a new instance with the modified keys."""
-        return self.__class__(  # pragma: no cover
+        return FrozenDefaultDict(  # pragma: no cover
             {mapping[k]: v for k, v in self.items() if k in mapping},
             default_value=self._default_value,
         )


### PR DESCRIPTION
# Description

Invoke constructor explicitly to indicate to type checker what is intended. Applying to lockfile maintenance PR #1032.

# How Has This Been Tested?

```
uv run ty check
uv run pytest test/utils
```

**Test Configuration**:
* Python version: 3.12.9
* Operating system and system architecture: macOS 26.6.1 / M1

# Checklist:

* &nbsp; [x] My code follows the style guidelines of this project
* &nbsp; [x] I have performed a self-review of my own code
* &nbsp; [x] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation
* &nbsp; [x] My changes generate no new errors or warnings
* &nbsp; [x] My code and tests pass locally and have at least 80% line coverage
* &nbsp; [x] Any dependent changes have been merged and published in downstream modules
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked
