### PR TITLE
Subcommands tweaks

### DIFF
--- a/src/tqec/_cli/subcommands/dae2circuits.py
+++ b/src/tqec/_cli/subcommands/dae2circuits.py
@@ -72,6 +72,7 @@ class Dae2CircuitsTQECSubCommand(TQECSubCommand):
     @override
     def execute(args: argparse.Namespace) -> None:
         dae_absolute_path: Path = args.dae_file.resolve()
+        convention = ALL_CONVENTIONS[args.convention]
         out_dir: Path = args.out_dir.resolve()
         if not out_dir.exists():
             out_dir.mkdir(parents=True)
@@ -100,10 +101,10 @@ class Dae2CircuitsTQECSubCommand(TQECSubCommand):
             zx_graph,
             observable_out_dir,
             [correlation_surfaces[i] for i in obs_indices],
+            file_stem=dae_absolute_path.stem,
         )
 
         # Compile the block graph and generate stim circuits
-        convention = ALL_CONVENTIONS[args.convention]
         circuits_out_dir = out_dir / "circuits"
         circuits_out_dir.mkdir(exist_ok=True)
         compiled_graph = compile_block_graph(
@@ -113,9 +114,10 @@ class Dae2CircuitsTQECSubCommand(TQECSubCommand):
         )
         ks: list[int] = args.k
         add_detectors: bool = args.add_detectors
+        file_stem = f"{dae_absolute_path.stem}-{convention}"
         for k in ks:
             circuit = compiled_graph.generate_stim_circuit(k)
             if add_detectors:
                 circuit = annotate_detectors_automatically(circuit)
-            circuit.to_file(circuits_out_dir / f"{dae_absolute_path.stem}-{convention}-{k=}.stim")
+            circuit.to_file(circuits_out_dir / f"{file_stem}-{k=}.stim")
             print(f"Write circuit to {circuits_out_dir}.")

--- a/src/tqec/_cli/subcommands/dae2circuits.py
+++ b/src/tqec/_cli/subcommands/dae2circuits.py
@@ -9,7 +9,7 @@ from typing_extensions import override
 from tqec._cli.subcommands.base import TQECSubCommand
 from tqec._cli.subcommands.dae2observables import save_correlation_surfaces_to
 from tqec.compile.compile import compile_block_graph
-from tqec.compile.convention import FIXED_BULK_CONVENTION
+from tqec.compile.convention import ALL_CONVENTIONS
 from tqec.computation.block_graph import BlockGraph
 
 
@@ -30,6 +30,13 @@ class Dae2CircuitsTQECSubCommand(TQECSubCommand):
             "dae_file",
             help="A valid .dae file representing a computation.",
             type=Path,
+        )
+        parser.add_argument(
+            "-c",
+            "--convention",
+            help="Convention to use.",
+            choices=ALL_CONVENTIONS.keys(),
+            default="fixed_bulk",
         )
         parser.add_argument(
             "--out-dir",
@@ -96,11 +103,12 @@ class Dae2CircuitsTQECSubCommand(TQECSubCommand):
         )
 
         # Compile the block graph and generate stim circuits
+        convention = ALL_CONVENTIONS[args.convention]
         circuits_out_dir = out_dir / "circuits"
         circuits_out_dir.mkdir(exist_ok=True)
         compiled_graph = compile_block_graph(
             block_graph,
-            FIXED_BULK_CONVENTION,
+            convention,
             observables=[correlation_surfaces[i] for i in obs_indices],
         )
         ks: list[int] = args.k
@@ -109,5 +117,5 @@ class Dae2CircuitsTQECSubCommand(TQECSubCommand):
             circuit = compiled_graph.generate_stim_circuit(k)
             if add_detectors:
                 circuit = annotate_detectors_automatically(circuit)
-            circuit.to_file(circuits_out_dir / f"{k=}.stim")
+            circuit.to_file(circuits_out_dir / f"{dae_absolute_path.stem}-{convention}-{k=}.stim")
             print(f"Write circuit to {circuits_out_dir}.")

--- a/src/tqec/_cli/subcommands/dae2observables.py
+++ b/src/tqec/_cli/subcommands/dae2observables.py
@@ -54,13 +54,16 @@ class Dae2ObservablesTQECSubCommand(TQECSubCommand):
         else:
             if not args.out_dir.exists():
                 os.makedirs(args.out_dir)
-            save_correlation_surfaces_to(zx_graph, args.out_dir, correlation_surfaces)
+            save_correlation_surfaces_to(
+                zx_graph, args.out_dir, correlation_surfaces, file_stem=dae_absolute_path.stem
+            )
 
 
 def save_correlation_surfaces_to(
     zx_graph: PositionedZX,
     out_dir: Path,
     correlation_surfaces: list[CorrelationSurface],
+    file_stem: str = "",
 ) -> None:
     """Save the provided correlation surfaces to ``out_dir``.
 
@@ -69,6 +72,7 @@ def save_correlation_surfaces_to(
             so that correlation surfaces appear on the ZX-graph.
         out_dir: filepath to save the drawing to.
         correlation_surfaces: correlation surfaces to draw over ``zx_graph``.
+        file_stem: the filename prefix to use for naming the PNG files.
 
     """
     for i, correlation_surface in enumerate(correlation_surfaces):
@@ -77,7 +81,7 @@ def save_correlation_surfaces_to(
         draw_positioned_zx_graph_on(zx_graph, ax)
         draw_correlation_surface_on(correlation_surface, zx_graph, ax)
         fig.tight_layout()
-        save_path = (out_dir / f"{i}.png").resolve()
+        save_path = (out_dir / f"{file_stem}_observable_{i}.png").resolve()
         print(f"Saving correlation surface number {i} to '{save_path}'.")
         fig.savefig(save_path)
         fig.clear()


### PR DESCRIPTION
# Description

- Added the option to the DAE subcommand to select the convention (-c/--convention) for more convenience when compiling circuits.
- Corrected filename outputs for the STIM files to include the name of the DAE file that originated them.
- Corrected filename outputs for the PNG of the observables to include the name of the DAE file that originated them.

# How Has This Been Tested?

As these are ~10 line changes, I simply executed the commands

$ tqec dae2circuits -c fixed_bulk --out-dir . -k 2 -- assets/logical_cnot.dae
$ tqec dae2circuits -c fixed_boundary --out-dir . -k 2 -- assets/logical_cnot.dae

And checked the files generated in crumble.

**Test Configuration**:
* Python version: 3.13
* Operating system and system architecture: MacOS (Apple MacMini M2)