### PR TITLE
Issue578 extended stabilizers

### DIFF
--- a/src/tqec/compile/convention.py
+++ b/src/tqec/compile/convention.py
@@ -9,7 +9,9 @@ from tqec.compile.observables.fixed_boundary_builder import (
 from tqec.compile.observables.fixed_bulk_builder import FIXED_BULK_OBSERVABLE_BUILDER
 from tqec.compile.specs.library.fixed_boundary import (
     FIXED_BOUNDARY_CUBE_BUILDER,
+    FIXED_BOUNDARY_CUBE_BUILDER_FLIPPING,
     FIXED_BOUNDARY_PIPE_BUILDER,
+    FIXED_BOUNDARY_PIPE_BUILDER_FLIPPING,
 )
 from tqec.compile.specs.library.fixed_bulk import (
     FIXED_BULK_CUBE_BUILDER,
@@ -63,4 +65,19 @@ FIXED_BOUNDARY_CONVENTION = Convention(
     ),
 )
 
-ALL_CONVENTIONS = {conv.name: conv for conv in [FIXED_BULK_CONVENTION, FIXED_BOUNDARY_CONVENTION]}
+FIXED_BOUNDARY_FLIPPING_CONVENTION = Convention(
+    "fixed_boundary_flipping",
+    ConventionTriplet(
+        FIXED_BOUNDARY_CUBE_BUILDER_FLIPPING,
+        FIXED_BOUNDARY_PIPE_BUILDER_FLIPPING,
+        FIXED_BOUNDARY_OBSERVABLE_BUILDER,
+    ),
+)
+ALL_CONVENTIONS = {
+    conv.name: conv
+    for conv in [
+        FIXED_BULK_CONVENTION,
+        FIXED_BOUNDARY_CONVENTION,
+        FIXED_BOUNDARY_FLIPPING_CONVENTION,
+    ]
+}

--- a/src/tqec/compile/specs/library/fixed_boundary.py
+++ b/src/tqec/compile/specs/library/fixed_boundary.py
@@ -110,7 +110,10 @@ def _get_block(
 
 class FixedBoundaryCubeBuilder(CubeBuilder):
     def __init__(
-        self, compiler: PlaquetteCompiler, translator: RPNGTranslator = DefaultRPNGTranslator()
+        self,
+        compiler: PlaquetteCompiler,
+        translator: RPNGTranslator = DefaultRPNGTranslator(),
+        flipping: bool = True,
     ) -> None:
         """Implement the :class:`.CubeBuilder` interface for the fixed boundary convention.
 
@@ -123,9 +126,12 @@ class FixedBoundaryCubeBuilder(CubeBuilder):
             compiler: compiler used to compile :class:`.Plaquette` instances returned from the
                 provided ``translator``.
             translator: translator to obtain :class:`.Plaquette` instances from a RPNG description.
+            flipping: flag controlling whether the plaquette schedule reversal should use
+                the flipping approach (i.e. scheduled moments are flipped along the vertical axis)
+                or the legacy approach (i.e. scheduled moments are completely reversed).
 
         """
-        self._generator = FixedBoundaryConventionGenerator(translator, compiler)
+        self._generator = FixedBoundaryConventionGenerator(translator, compiler, flipping)
 
     def _get_template_and_plaquettes_generator(
         self, spec: CubeSpec
@@ -182,7 +188,10 @@ class FixedBoundaryCubeBuilder(CubeBuilder):
 
 class FixedBoundaryPipeBuilder(PipeBuilder):
     def __init__(
-        self, compiler: PlaquetteCompiler, translator: RPNGTranslator = DefaultRPNGTranslator()
+        self,
+        compiler: PlaquetteCompiler,
+        translator: RPNGTranslator = DefaultRPNGTranslator(),
+        flipping: bool = True,
     ) -> None:
         """Implement the :class:`.PipeBuilder` interface for the fixed boundary convention.
 
@@ -195,9 +204,12 @@ class FixedBoundaryPipeBuilder(PipeBuilder):
             compiler: compiler used to compile :class:`.Plaquette` instances returned from the
                 provided ``translator``.
             translator: translator to obtain :class:`.Plaquette` instances from a RPNG description.
+            flipping: flag controlling whether the plaquette schedule reversal should use
+                the flipping approach (i.e. scheduled moments are flipped along the vertical axis)
+                or the legacy approach (i.e. scheduled moments are completely reversed).
 
         """
-        self._generator = FixedBoundaryConventionGenerator(translator, compiler)
+        self._generator = FixedBoundaryConventionGenerator(translator, compiler, flipping)
 
     @override
     def __call__(self, spec: PipeSpec, block_temporal_height: LinearFunction) -> Block:
@@ -402,5 +414,11 @@ class FixedBoundaryPipeBuilder(PipeBuilder):
         return self._get_spatial_regular_pipe_block(spec, block_temporal_height)
 
 
-FIXED_BOUNDARY_CUBE_BUILDER = FixedBoundaryCubeBuilder(IdentityPlaquetteCompiler)
-FIXED_BOUNDARY_PIPE_BUILDER = FixedBoundaryPipeBuilder(IdentityPlaquetteCompiler)
+FIXED_BOUNDARY_CUBE_BUILDER = FixedBoundaryCubeBuilder(IdentityPlaquetteCompiler, flipping=False)
+FIXED_BOUNDARY_PIPE_BUILDER = FixedBoundaryPipeBuilder(IdentityPlaquetteCompiler, flipping=False)
+FIXED_BOUNDARY_CUBE_BUILDER_FLIPPING = FixedBoundaryCubeBuilder(
+    IdentityPlaquetteCompiler, flipping=True
+)
+FIXED_BOUNDARY_PIPE_BUILDER_FLIPPING = FixedBoundaryPipeBuilder(
+    IdentityPlaquetteCompiler, flipping=True
+)

--- a/src/tqec/compile/specs/library/fixed_boundary.py
+++ b/src/tqec/compile/specs/library/fixed_boundary.py
@@ -113,7 +113,7 @@ class FixedBoundaryCubeBuilder(CubeBuilder):
         self,
         compiler: PlaquetteCompiler,
         translator: RPNGTranslator = DefaultRPNGTranslator(),
-        flipping: bool = True,
+        flipping: bool = False,
     ) -> None:
         """Implement the :class:`.CubeBuilder` interface for the fixed boundary convention.
 

--- a/src/tqec/compile/specs/library/generators/constants.py
+++ b/src/tqec/compile/specs/library/generators/constants.py
@@ -1,14 +1,38 @@
 from typing import Final
 
-EXTENDED_PLAQUETTE_SCHEDULES: Final[dict[bool, tuple[int, int, int, int]]] = {
-    False: (2, 4, 3, 5),
-    True: (5, 3, 4, 2),
+EXTENDED_PLAQUETTE_SCHEDULES: Final[dict[bool, dict[bool, tuple[int, int, int, int]]]] = {
+    # Flipping-style schedules along the vertical axis of the plaquettes.
+    True: {
+        False: (2, 4, 3, 5),
+        True: (4, 2, 5, 3),
+    },
+    # Legacy schedules with complete time-reversal.
+    False: {
+        False: (2, 4, 3, 5),
+        True: (5, 3, 4, 2),
+    },
 }
-VERTICAL_HOOK_SCHEDULES: Final[dict[bool, tuple[int, int, int, int]]] = {
-    False: (1, 4, 3, 5),
-    True: (5, 3, 4, 1),
+VERTICAL_HOOK_SCHEDULES: Final[dict[bool, dict[bool, tuple[int, int, int, int]]]] = {
+    # Flipping-style schedules along the vertical axis of the plaquettes.
+    True: {
+        False: (1, 4, 3, 5),
+        True: (4, 1, 5, 3),
+    },
+    # Legacy schedules with complete time-reversal.
+    False: {
+        False: (1, 4, 3, 5),
+        True: (5, 3, 4, 1),
+    },
 }
-HORIZONTAL_HOOK_SCHEDULES: Final[dict[bool, tuple[int, int, int, int]]] = {
-    False: (1, 2, 3, 5),
-    True: (5, 3, 2, 1),
+HORIZONTAL_HOOK_SCHEDULES: Final[dict[bool, dict[bool, tuple[int, int, int, int]]]] = {
+    # Flipping-style schedules along the vertical axis of the plaquettes.
+    True: {
+        False: (1, 2, 3, 5),
+        True: (2, 1, 5, 3),
+    },
+    # Legacy schedules with complete time-reversal.
+    False: {
+        False: (1, 2, 3, 5),
+        True: (5, 3, 2, 1),
+    },
 }

--- a/src/tqec/compile/specs/library/generators/extended_stabilizers.py
+++ b/src/tqec/compile/specs/library/generators/extended_stabilizers.py
@@ -91,31 +91,31 @@ def _make_spatial_cube_arm_memory_plaquette_up(
     s1, s2 = tuple(qubits.syndrome_qubits_indices)
     # Define the base moments, only containing the reset on s2 as that is the
     # only operation that does not depend on the parameters of this function.
-    base_moments = [
-        Moment(stim.Circuit(f"RZ {s2}")),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-    ]
-    # Add the GHZ state creation and measurement.
+    base_moments = [Moment(stim.Circuit()) for _ in range(8)]
+
+    # Prepare the extra syndrome qubit to form the GHZ state
+    base_moments[0].append("RZ", [s2], [])
+
     if is_flipping or not is_reversed:
+        # Handle the GHZ state preparation and deconstruction.
         base_moments[0].append("RX", [s1], [])
         base_moments[1].append("CX", [s1, s2], [])
         base_moments[5].append("CX", [s2, s1], [])
     else:
+        # Prepare the syndrome qubit
         base_moments[1].append("RZ", [s1], [])
+        # Handle the GHZ state preparation and deconstruction.
         base_moments[2].append("CX", [s2, s1], [])
         base_moments[6].append("CX", [s1, s2], [])
+        # Make the syndrome measurement
         base_moments[7].append("MX", [s1], [])
+
     # Add controlled gates
     if left_qubit.p is not None and left_qubit.n is not None:
         base_moments[left_qubit.n].append(f"C{left_qubit.p.name.upper()}", [s1, dl], [])
     if right_qubit.p is not None and right_qubit.n is not None:
         base_moments[right_qubit.n].append(f"C{right_qubit.p.name.upper()}", [s1, dr], [])
+
     # Add data-qubit reset/measurement if needed
     # Note about resets: data-qubits (i.e., the 4 corners) are already in a
     # correct state and we should not reset them. Internal qubits are also
@@ -163,16 +163,7 @@ def _make_spatial_cube_arm_memory_plaquette_down(
     s1, s2 = tuple(qubits.syndrome_qubits_indices)
     # Define the base moments, only containing the reset on s2 as that is the
     # only operation that does not depend on the parameters of this function.
-    base_moments = [
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-    ]
+    base_moments = [Moment(stim.Circuit()) for _ in range(8)]
 
     if not is_flipping:
         base_moments[0].append("RZ", [s2], [])
@@ -187,18 +178,20 @@ def _make_spatial_cube_arm_memory_plaquette_down(
         base_moments[2].append("CX", [s2, s1], [])
         base_moments[6].append("CX", [s1, s2], [])
         base_moments[7].append("MX", [s1], [])
+
     # Add controlled gates
     if left_qubit.p is not None and left_qubit.n is not None:
         base_moments[left_qubit.n].append(f"C{left_qubit.p.name.upper()}", [s1, dl], [])
     if right_qubit.p is not None and right_qubit.n is not None:
         base_moments[right_qubit.n].append(f"C{right_qubit.p.name.upper()}", [s1, dr], [])
+
     # Add data-qubit reset/measurement if needed
     # Note about resets: data-qubits (i.e., the 4 corners) are already in a
     # correct state and we should not reset them. Internal qubits are also
     # already reset individually by the circuit constructed above. That means
     # that we should NOT reset anything here. Nevertheless, the reset argument
     # is kept because the plaquette naming should be adapted.
-    # Note: when the flipping schedules are used, the measurement is taken care
+    # Note: when the flipping schedules are used, that measurement is taken care
     # of by the upper plaquette.
     if measurement and not is_flipping:
         # Add ancilla measurements if data-qubits are measured.

--- a/src/tqec/compile/specs/library/generators/extended_stabilizers.py
+++ b/src/tqec/compile/specs/library/generators/extended_stabilizers.py
@@ -69,11 +69,12 @@ def _make_spatial_cube_arm_memory_plaquette_up(
     right_qubit: RPNG,
     reset: Basis | None = None,
     measurement: Basis | None = None,
+    is_flipping: bool = False,
     is_reversed: bool = False,
 ) -> Plaquette:
     # Checking the validity of the provided schedules
-    first_available_schedule = 2 if not is_reversed else 3
-    last_available_schedule = 4 if not is_reversed else 5
+    first_available_schedule = 2 if is_flipping or not is_reversed else 3
+    last_available_schedule = 4 if is_flipping or not is_reversed else 5
     _check_schedules(
         [left_qubit.n, right_qubit.n], first_available_schedule, last_available_schedule
     )
@@ -84,7 +85,7 @@ def _make_spatial_cube_arm_memory_plaquette_up(
     # s2 ---- s2
     qubits = PlaquetteQubits(
         [GridQubit(-1, -1), GridQubit(1, -1)],
-        [GridQubit(0, 0), GridQubit(1 if is_reversed else -1, 1)],
+        [GridQubit(0, 0), GridQubit(1 if not is_flipping and is_reversed else -1, 1)],
     )
     dl, dr = tuple(qubits.data_qubits_indices)
     s1, s2 = tuple(qubits.syndrome_qubits_indices)
@@ -101,7 +102,7 @@ def _make_spatial_cube_arm_memory_plaquette_up(
         Moment(stim.Circuit()),
     ]
     # Add the GHZ state creation and measurement.
-    if not is_reversed:
+    if is_flipping or not is_reversed:
         base_moments[0].append("RX", [s1], [])
         base_moments[1].append("CX", [s1, s2], [])
         base_moments[5].append("CX", [s2, s1], [])
@@ -123,7 +124,7 @@ def _make_spatial_cube_arm_memory_plaquette_up(
     # is kept because the plaquette naming should be adapted.
     if measurement:
         # Add ancilla measurements if data-qubits are measured.
-        base_moments[-1].append("M", [s2] if is_reversed else [s1, s2], [])
+        base_moments[-1].append("M", [s2] if not is_flipping and is_reversed else [s1, s2], [])
     # Finally, return the plaquette
     return Plaquette(
         _get_spatial_cube_arm_name(
@@ -140,11 +141,12 @@ def _make_spatial_cube_arm_memory_plaquette_down(
     right_qubit: RPNG,
     reset: Basis | None = None,
     measurement: Basis | None = None,
+    is_flipping: bool = False,
     is_reversed: bool = False,
 ) -> Plaquette:
     # Checking the validity of the provided schedules
-    first_available_schedule = 3 if not is_reversed else 2
-    last_available_schedule = 5 if not is_reversed else 4
+    first_available_schedule = 3 if is_flipping or not is_reversed else 2
+    last_available_schedule = 5 if is_flipping or not is_reversed else 4
     _check_schedules(
         [left_qubit.n, right_qubit.n], first_available_schedule, last_available_schedule
     )
@@ -155,14 +157,14 @@ def _make_spatial_cube_arm_memory_plaquette_down(
     # dl ---- dr
     qubits = PlaquetteQubits(
         [GridQubit(-1, 1), GridQubit(1, 1)],
-        [GridQubit(0, 0), GridQubit(1 if is_reversed else -1, -1)],
+        [GridQubit(0, 0), GridQubit(1 if not is_flipping and is_reversed else -1, -1)],
     )
     dl, dr = tuple(qubits.data_qubits_indices)
     s1, s2 = tuple(qubits.syndrome_qubits_indices)
     # Define the base moments, only containing the reset on s2 as that is the
     # only operation that does not depend on the parameters of this function.
     base_moments = [
-        Moment(stim.Circuit(f"RZ {s2}")),
+        Moment(stim.Circuit()),
         Moment(stim.Circuit()),
         Moment(stim.Circuit()),
         Moment(stim.Circuit()),
@@ -171,8 +173,12 @@ def _make_spatial_cube_arm_memory_plaquette_down(
         Moment(stim.Circuit()),
         Moment(stim.Circuit()),
     ]
+
+    if not is_flipping:
+        base_moments[0].append("RZ", [s2], [])
+
     # Add the GHZ state creation and measurement.
-    if is_reversed:
+    if not is_flipping and is_reversed:
         base_moments[0].append("RX", [s1], [])
         base_moments[1].append("CX", [s1, s2], [])
         base_moments[5].append("CX", [s2, s1], [])
@@ -192,7 +198,9 @@ def _make_spatial_cube_arm_memory_plaquette_down(
     # already reset individually by the circuit constructed above. That means
     # that we should NOT reset anything here. Nevertheless, the reset argument
     # is kept because the plaquette naming should be adapted.
-    if measurement:
+    # Note: when the flipping schedules are used, the measurement is taken care
+    # of by the upper plaquette.
+    if measurement and not is_flipping:
         # Add ancilla measurements if data-qubits are measured.
         base_moments[-1].append("M", [s1, s2] if is_reversed else [s2], [])
     # Finally, return the plaquette
@@ -210,6 +218,7 @@ def get_extended_plaquette(
     rpng: RPNGDescription,
     reset: Basis | None = None,
     measurement: Basis | None = None,
+    is_flipping: bool = False,
     is_reversed: bool = False,
 ) -> tuple[Plaquette, Plaquette]:
     """Create an extended plaquette from the provided RPNG description.
@@ -221,6 +230,9 @@ def get_extended_plaquette(
         measurement: basis of the measurement operation performed on internal data-qubits (used as
             syndrome qubits). Defaults to ``None`` that translates to no measurement being applied
             on data-qubits.
+        is_flipping: flag controlling whether the plaquette schedule reversal should use
+            the flipping approach (i.e. scheduled moments are flipped along the vertical axis)
+            or the legacy approach (i.e. scheduled moments are completely reversed).
         is_reversed: flag indicating if the plaquette schedule should be reversed or not. Useful to
             limit the loss of code distance when hook errors are not correctly oriented by
             alternating regular and reversed plaquettes.
@@ -231,8 +243,12 @@ def get_extended_plaquette(
     """
     tl, tr, bl, br = rpng.corners
     return (
-        _make_spatial_cube_arm_memory_plaquette_up(tl, tr, reset, measurement, is_reversed),
-        _make_spatial_cube_arm_memory_plaquette_down(bl, br, reset, measurement, is_reversed),
+        _make_spatial_cube_arm_memory_plaquette_up(
+            tl, tr, reset, measurement, is_flipping, is_reversed
+        ),
+        _make_spatial_cube_arm_memory_plaquette_down(
+            bl, br, reset, measurement, is_flipping, is_reversed
+        ),
     )
 
 
@@ -332,11 +348,12 @@ class ExtendedPlaquetteCollection:
         description: RPNGDescription,
         reset: Basis | None,
         measurement: Basis | None,
+        is_flipping: bool,
         is_reversed: bool,
     ) -> ExtendedPlaquetteCollection:
         """Build an instance from the provided ``RPNGDescription``."""
         _raise_if_undefined_corners(description)
-        up, down = get_extended_plaquette(description, reset, measurement, is_reversed)
+        up, down = get_extended_plaquette(description, reset, measurement, is_flipping, is_reversed)
         drawer_basis = _get_drawer_basis(description)
         drawer_schedule = _get_drawer_schedule(description)
         # In the calls to project_on_data_qubit_indices, it is important to remember
@@ -429,6 +446,7 @@ class ExtendedPlaquetteCollection:
         basis: Basis,
         reset: Basis | None,
         measurement: Basis | None,
+        is_flipping: bool,
         is_reversed: bool,
         schedule: Sequence[int] | Schedule | None = None,
     ) -> ExtendedPlaquetteCollection:
@@ -448,6 +466,9 @@ class ExtendedPlaquetteCollection:
             measurement: basis of the measurement operation performed on internal data-qubits (used
                 as syndrome qubits). Defaults to ``None`` that translates to no measurement being
                 applied on data-qubits.
+            is_flipping: flag controlling whether the plaquette schedule reversal should use
+                the flipping approach (i.e. scheduled moments are flipped along the vertical axis)
+                or the legacy approach (i.e. scheduled moments are completely reversed).
             is_reversed: flag indicating if the plaquette schedule should be reversed or not. Useful
                 to limit the loss of code distance when hook errors are not correctly oriented by
                 alternating regular and reversed plaquettes.
@@ -462,10 +483,10 @@ class ExtendedPlaquetteCollection:
 
         """
         if schedule is None:
-            schedule = EXTENDED_PLAQUETTE_SCHEDULES[is_reversed]
+            schedule = EXTENDED_PLAQUETTE_SCHEDULES[is_flipping][is_reversed]
         # Not including reset and measurement in the RPNG description as these are specially placed
         # for an extended plaquette
         description = RPNGDescription.from_basis_and_schedule(basis, schedule)
         return ExtendedPlaquetteCollection.from_description(
-            description, reset, measurement, is_reversed
+            description, reset, measurement, is_flipping, is_reversed
         )

--- a/src/tqec/compile/specs/library/generators/fixed_boundary.py
+++ b/src/tqec/compile/specs/library/generators/fixed_boundary.py
@@ -36,7 +36,7 @@ from tqec.utils.position import Direction3D
 
 
 class FixedBoundaryConventionGenerator:
-    def __init__(self, translator: RPNGTranslator, compiler: PlaquetteCompiler):
+    def __init__(self, translator: RPNGTranslator, compiler: PlaquetteCompiler, flipping: bool):
         """Low-level helper class centralising all the plaquette creation for the fixed boundary
         convention.
 
@@ -45,6 +45,7 @@ class FixedBoundaryConventionGenerator:
 
         """
         self._mapper = PlaquetteMapper(translator, compiler)
+        self._is_flipping = flipping
 
     def get_bulk_rpng_descriptions(
         self,
@@ -84,8 +85,8 @@ class FixedBoundaryConventionGenerator:
         rs = [r if i in reset_and_measured_indices else "-" for i in range(4)]
         ms = [m if i in reset_and_measured_indices else "-" for i in range(4)]
         # 2-qubit gate schedules
-        vsched = VERTICAL_HOOK_SCHEDULES[is_reversed]
-        hsched = HORIZONTAL_HOOK_SCHEDULES[is_reversed]
+        vsched = VERTICAL_HOOK_SCHEDULES[self._is_flipping][is_reversed]
+        hsched = HORIZONTAL_HOOK_SCHEDULES[self._is_flipping][is_reversed]
         return {
             basis: {
                 Orientation.VERTICAL: RPNGDescription.from_string(
@@ -132,7 +133,7 @@ class FixedBoundaryConventionGenerator:
         # Note: the schedule of CNOT gates in corner plaquettes is less important
         # because hook errors do not exist on 3-body stabilizers. We arbitrarily
         # pick the vertical schedule.
-        s = VERTICAL_HOOK_SCHEDULES[is_reversed]
+        s = VERTICAL_HOOK_SCHEDULES[self._is_flipping][is_reversed]
         # Note that we include resets and measurements on all the used data-qubits.
         # That should be fine because this plaquette only touches cubes and pipes
         # that are related to the spatial junction being implemented, and it is not
@@ -195,7 +196,7 @@ class FixedBoundaryConventionGenerator:
         # Note: the schedule of CNOT gates in weight-2 plaquettes is less
         # important because hook errors do not exist. We arbitrarily chose the
         # vertical schedule.
-        s = VERTICAL_HOOK_SCHEDULES[is_reversed]
+        s = VERTICAL_HOOK_SCHEDULES[self._is_flipping][is_reversed]
         for basis in Basis:
             b = basis.value.lower()
             ret[basis] = {
@@ -217,7 +218,9 @@ class FixedBoundaryConventionGenerator:
 
         """
         return {
-            b: (ExtendedPlaquetteCollection.from_basis(b, reset, measurement, is_reversed))
+            b: ExtendedPlaquetteCollection.from_basis(
+                b, reset, measurement, self._is_flipping, is_reversed
+            )
             for b in Basis
         }
 
@@ -232,8 +235,8 @@ class FixedBoundaryConventionGenerator:
 
         """
         # 2-qubit gate schedules
-        vsched = VERTICAL_HOOK_SCHEDULES[is_reversed]
-        hsched = HORIZONTAL_HOOK_SCHEDULES[is_reversed]
+        vsched = VERTICAL_HOOK_SCHEDULES[self._is_flipping][is_reversed]
+        hsched = HORIZONTAL_HOOK_SCHEDULES[self._is_flipping][is_reversed]
         return {
             basis: {
                 orientation: RPNGDescription.from_basis_and_schedule(
@@ -288,8 +291,8 @@ class FixedBoundaryConventionGenerator:
         r = reset.value.lower() if reset is not None else "-"
         m = measurement.value.lower() if measurement is not None else "-"
         # 2-qubit gate schedules
-        vs = VERTICAL_HOOK_SCHEDULES[is_reversed]
-        hs = HORIZONTAL_HOOK_SCHEDULES[is_reversed]
+        vs = VERTICAL_HOOK_SCHEDULES[self._is_flipping][is_reversed]
+        hs = HORIZONTAL_HOOK_SCHEDULES[self._is_flipping][is_reversed]
         return (
             RPNGDescription.from_string(
                 f"-{b}{hs[0]}- {r}{o}{hs[1]}{m} -{b}{hs[2]}- {r}{o}{hs[3]}{m}"
@@ -349,8 +352,8 @@ class FixedBoundaryConventionGenerator:
         r = reset.value.lower() if reset is not None else "-"
         m = measurement.value.lower() if measurement is not None else "-"
         # 2-qubit gate schedules
-        vs = VERTICAL_HOOK_SCHEDULES[is_reversed]
-        hs = HORIZONTAL_HOOK_SCHEDULES[is_reversed]
+        vs = VERTICAL_HOOK_SCHEDULES[self._is_flipping][is_reversed]
+        hs = HORIZONTAL_HOOK_SCHEDULES[self._is_flipping][is_reversed]
         return (
             RPNGDescription.from_string(
                 f"-{o}{hs[0]}- -{o}{hs[1]}- {r}{b}{hs[2]}{m} {r}{b}{hs[3]}{m}"

--- a/src/tqec/compile/specs/library/generators/fixed_bulk.py
+++ b/src/tqec/compile/specs/library/generators/fixed_bulk.py
@@ -251,7 +251,12 @@ class FixedBulkConventionGenerator:
 
         """
         return {
-            b: (ExtendedPlaquetteCollection.from_basis(b, reset, measurement, False)) for b in Basis
+            b: (
+                ExtendedPlaquetteCollection.from_basis(
+                    b, reset, measurement, is_flipping=False, is_reversed=False
+                )
+            )
+            for b in Basis
         }
 
     ############################################################

--- a/tests/compile/specs/library/generators/extended_stabilizers_test.py
+++ b/tests/compile/specs/library/generators/extended_stabilizers_test.py
@@ -41,7 +41,9 @@ def _path_points(path: svg.Path) -> set[tuple[float, float]]:
 )
 def test_extended_plaquette(basis: Basis, is_reversed: bool) -> None:
     up, down = get_extended_plaquette(
-        RPNGDescription.from_basis_and_schedule(basis, EXTENDED_PLAQUETTE_SCHEDULES[is_reversed]),
+        RPNGDescription.from_basis_and_schedule(
+            basis, EXTENDED_PLAQUETTE_SCHEDULES[False][is_reversed]
+        ),
         is_reversed=is_reversed,
     )
     scheduled_circuit = generate_circuit_from_instantiation(
@@ -71,13 +73,14 @@ def test_extended_plaquette_collection_rejects_undefined_corners(
             description,
             reset=None,
             measurement=None,
+            is_flipping=False,
             is_reversed=False,
         )
 
 
 def test_extended_plaquette_drawer_preserves_existing_debug_information() -> None:
     description = RPNGDescription.from_basis_and_schedule(
-        Basis.X, EXTENDED_PLAQUETTE_SCHEDULES[False]
+        Basis.X, EXTENDED_PLAQUETTE_SCHEDULES[False][False]
     )
     up, _ = get_extended_plaquette(description, is_reversed=False)
     debug_information = PlaquetteDebugInformation(
@@ -157,6 +160,7 @@ def test_extended_plaquettes_have_svg_drawers(
         Basis.X,
         reset=reset,
         measurement=measurement,
+        is_flipping=False,
         is_reversed=False,
     )
     plaquette = getattr(collection, collection_name)

--- a/tests/compile/specs/library/generators/fixed_boundary_test.py
+++ b/tests/compile/specs/library/generators/fixed_boundary_test.py
@@ -16,7 +16,7 @@ def fixture_rpng_translator():
 @pytest.fixture(scope="session", name="generator")
 def fixture_generator(translator):
     compiler = IdentityPlaquetteCompiler
-    return FixedBoundaryConventionGenerator(translator, compiler)
+    return FixedBoundaryConventionGenerator(translator, compiler, flipping=False)
 
 
 def _assert_result_contains_bases_and_orientations(


### PR DESCRIPTION
# Description

I've implemented the extended stabilizers in a different way to enable a complete meshing as originally described in the review paper. The idea is that the forward direction operates as documented in the review paper and the reverse direction simply flips all the schedules along the vertical axis of the plaquettes. Using the (TL, TR, BL, BR) convention, the schedules are transformed as follows:

- (1, 2, 3, 5) <-> (2, 1, 5, 3)
- (1, 4, 3, 5) <-> (4, 1, 5, 3)
- (2, 3, 4, 5) <-> (3, 2, 5, 4)

This new implementation exists side-by-side with the current implementation and a new convention has been added called "fixed_boundary_flipping".

Partially adresses issue #578.

# How Has This Been Tested?

Originally, by adapting the run-example subcommand to use a spatial junction computation with red/blue tips to generate both cases of the layout (with complete plaquettes or trimmed plaquettes in the corners)

Following my addition of the TQEC simulate subcommand (see PR #1037), I've used the commands

$ tqec simulate -c fixed_boundary -k 2 3 4 5 -s 1e8 -- assets/spatial-junction-x-basis-blue-boundaries.dae
$ tqec simulate -c fixed_boundary_flipping -k 2 3 4 5 -s 1e8 -- assets/spatial-junction-x-basis-blue-boundaries.dae

And compared visually the graphs to see that the new implementation falls in same ballpark as the existing one.

<img width="370" height="278" alt="spatial-junction-x-basis-blue-boundaries_fixed_boundary_results_observable_0" src="https://github.com/user-attachments/assets/55d36a82-717d-444f-9752-963bae642dfd" />
<img width="370" height="278" alt="spatial-junction-x-basis-blue-boundaries_fixed_boundary_flipping_results_observable_0" src="https://github.com/user-attachments/assets/3314a306-e565-4c42-85cf-592949f9d14a" />


This implementation lays out the gates in a way that can be fully meshed to achieve its full potential. However, TQECD is unable to find all the detectors when there is an RX/MX at the same moment which limits my ability to thoroughly simulate this construction. The performance of this new implementation should improve once PR [tqec/tqecd#69](https://github.com/tqec/tqecd/pull/69) is completed. I have manually completed the annotation for distance d=5 and observed a very slight improvement on the performance but not significant enough to be conclusive (see https://github.com/tqec/tqec/issues/578#issuecomment-5326419315).

**Test Configuration**:
* Python version: 3.13
* Operating system and system architecture: MacOS (Apple MacMini M2)

# Checklist:

- The existing tests all run successfully