### PR TITLE
Remove redundant cast in FrozenDefaultDict::map_values

### DIFF
--- a/src/tqec/utils/frozendefaultdict.py
+++ b/src/tqec/utils/frozendefaultdict.py
@@ -106,9 +106,7 @@ class FrozenDefaultDict(Generic[K, V], Mapping[K, V]):
         if self.default_value is not None:
             default_value = callable(self.default_value)
         defined_type: dict[K, Vp] = {k: callable(v) for k, v in self.items()}
-        return cast(
-            FrozenDefaultDict[K, Vp], FrozenDefaultDict(defined_type, default_value=default_value)
-        )
+        return FrozenDefaultDict(defined_type, default_value=default_value)
 
     def map_keys_if_present(self, mapping: Mapping[K, K]) -> FrozenDefaultDict[K, V]:
         """Apply ``callable`` to each key and return a new instance with the modified keys."""


### PR DESCRIPTION
# Description

Fix type checker warning generated by #1039 

# How Has This Been Tested?

```
uv run ty check
uv run pytest
```

**Test Configuration**:
* Python version: 3.12.9
* Operating system and system architecture: macOS 26.6.1 / M1

# Checklist:

* &nbsp; [x] My code follows the style guidelines of this project
* &nbsp; [x] I have performed a self-review of my own code
* &nbsp; [x] I have commented my code, particularly in hard-to-understand areas
* &nbsp; [x] I have made corresponding changes to the documentation
* &nbsp; [x] My changes generate no new errors or warnings
* &nbsp; [x] My code and tests pass locally and have at least 80% line coverage
* &nbsp; [x] Any dependent changes have been merged and published in downstream modules
* &nbsp; [x] All AI-generated changes have been thoroughly human reviewed and checked
