### PR TITLE
feat: track Hadamard arms on spatial cubes (#840)

### DIFF
--- a/src/tqec/compile/specs/base.py
+++ b/src/tqec/compile/specs/base.py
@@ -27,6 +27,12 @@ class CubeSpec:
         spatial_arms: Flag indicating the spatial directions the cube connects to the
             adjacent cubes. This is useful for spatial cubes (XXZ and ZZX) where
             the arms can determine the template used to implement the cube.
+        hadamard_arms: Flag indicating the spatial directions whose incident pipe
+            carries a Hadamard transition. This is needed by the fixed-bulk
+            convention to know which arms of a spatial cube use the
+            split-colour extended-stabiliser triangles, so that corner
+            plaquettes are emitted consistently instead of being duplicated by
+            each arm (see issue #840).
         has_spatial_up_or_down_pipe_in_timeslice: a flag indicating if a spatial
             pipe at the top or bottom of a spatial cube is executed on the same
             timeslice as this cube. This information is needed for the fixed
@@ -36,6 +42,7 @@ class CubeSpec:
 
     kind: CubeKind
     spatial_arms: SpatialArms = SpatialArms.NONE
+    hadamard_arms: SpatialArms = SpatialArms.NONE
     has_spatial_up_or_down_pipe_in_timeslice: bool = False
 
     def __post_init__(self) -> None:
@@ -44,6 +51,18 @@ class CubeSpec:
                 raise TQECError(
                     "The `spatial_arms` attribute should be `SpatialArms.NONE` "
                     "for non-spatial cubes."
+                )
+        if self.hadamard_arms != SpatialArms.NONE:
+            if not self.is_spatial:
+                raise TQECError(
+                    "The `hadamard_arms` attribute should be `SpatialArms.NONE` "
+                    "for non-spatial cubes."
+                )
+            # A Hadamard arm must be a spatial arm of the cube.
+            if self.hadamard_arms & ~self.spatial_arms:
+                raise TQECError(
+                    "The `hadamard_arms` attribute should be a subset of "
+                    "`spatial_arms`."
                 )
 
     @property
@@ -67,7 +86,13 @@ class CubeSpec:
                 has_spatial_up_or_down_pipe_in_timeslice=has_spatial_up_or_down_pipe_in_timeslice,
             )
         spatial_arms = SpatialArms.from_cube_in_graph(cube, graph)
-        return CubeSpec(cube.kind, spatial_arms, has_spatial_up_or_down_pipe_in_timeslice)
+        hadamard_arms = SpatialArms.from_hadamard_pipes_in_graph(cube, graph)
+        return CubeSpec(
+            cube.kind,
+            spatial_arms,
+            hadamard_arms,
+            has_spatial_up_or_down_pipe_in_timeslice,
+        )
 
     @property
     def pipe_dimensions(self) -> frozenset[Literal[Direction3D.X, Direction3D.Y]]:

--- a/src/tqec/compile/specs/enums.py
+++ b/src/tqec/compile/specs/enums.py
@@ -29,6 +29,37 @@ class SpatialArms(Flag):
                 spatial_arms |= flag
         return spatial_arms
 
+    @staticmethod
+    def from_hadamard_pipes_in_graph(cube: Cube, graph: BlockGraph) -> SpatialArms:
+        """Return the spatial arms of a cube that carry a Hadamard transition.
+
+        Only the spatial (X/Y) arms are considered: a pipe along the Z axis
+        (temporal pipe) never contributes here, mirroring the spatial-arm
+        semantics of :meth:`from_cube_in_graph`.
+
+        Args:
+            cube: the cube whose Hadamard arms are requested.
+            graph: the block graph the cube belongs to.
+
+        Returns:
+            A :class:`SpatialArms` flag with exactly the spatial arms whose
+            incident pipe has ``pipe_kind.has_hadamard == True``.
+
+        """
+        if not cube.is_spatial:
+            return SpatialArms.NONE
+        pos = cube.position
+        if pos not in graph or graph[pos] != cube:
+            raise TQECError(f"Cube {cube} is not in the graph.")
+        hadamard_arms = SpatialArms.NONE
+        for flag, shift in SpatialArms.get_map_from_arm_to_shift().items():
+            neighbour = pos.shift_by(*shift)
+            if graph.has_pipe_between(pos, neighbour):
+                pipe = graph.get_pipe(pos, neighbour)
+                if pipe.kind.has_hadamard:
+                    hadamard_arms |= flag
+        return hadamard_arms
+
     @property
     def has_spatial_arm_in_both_dimensions(self) -> bool:
         """Checks if the spatial arms have arms in both spatial dimensions."""

--- a/tests/compile/specs/enums_hadamard_arms_test.py
+++ b/tests/compile/specs/enums_hadamard_arms_test.py
@@ -1,0 +1,120 @@
+"""Tests for Hadamard-arm tracking on spatial cubes (issue #840).
+
+These tests verify that ``CubeSpec`` correctly records which spatial arms
+carry a Hadamard transition, so that the fixed-bulk convention can emit
+corner plaquettes consistently (split-colour vs normal extended-stabiliser
+triangles) instead of relying on the "left-right arm drops corners"
+workaround that will break once left-right Hadamards exist.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tqec.compile.specs.base import CubeSpec
+from tqec.compile.specs.enums import SpatialArms
+from tqec.computation.block_graph import BlockGraph
+from tqec.computation.cube import ZXCube
+from tqec.computation.pipe import PipeKind
+from tqec.utils.exceptions import TQECError
+from tqec.utils.position import Position3D
+
+
+def _spatial_cube_graph_with_pipes(
+    hadamard_pipes: set[str] | None = None,
+) -> tuple[BlockGraph, object]:
+    """Build a 2x2 spatial-cube block graph with one pipe per direction.
+
+    The central cube is a ZZX spatial cube connected to four neighbours
+    (UP/RIGHT/DOWN/LEFT). Pipes whose name is in ``hadamard_pipes`` carry a
+    Hadamard transition.
+
+    Returns:
+        (graph, central_cube)
+
+    """
+    hadamard_pipes = hadamard_pipes or set()
+    g = BlockGraph("Test Hadamard Arms")
+    centre = g.add_cube(Position3D(0, 0, 0), ZXCube.from_str("zzx"))
+    # Four neighbours in the spatial plane.
+    up = g.add_cube(Position3D(0, -1, 0), ZXCube.from_str("zzx"))
+    right = g.add_cube(Position3D(1, 0, 0), ZXCube.from_str("zzx"))
+    down = g.add_cube(Position3D(0, 1, 0), ZXCube.from_str("zzx"))
+    left = g.add_cube(Position3D(-1, 0, 0), ZXCube.from_str("zzx"))
+    # Y-direction pipes for UP/DOWN, X-direction pipes for LEFT/RIGHT.
+    for direction, (cube_a, cube_b) in {
+        "up": (centre, up),
+        "down": (centre, down),
+        "left": (centre, left),
+        "right": (centre, right),
+    }.items():
+        base_kind = "xoz" if direction in ("up", "down") else "oxz"
+        pipe_kind = PipeKind.from_str(base_kind + ("H" if direction in hadamard_pipes else ""))
+        g.add_pipe(cube_a, cube_b, pipe_kind)
+    return g, g[centre]
+
+
+@pytest.mark.parametrize(
+    ("hadamard_directions", "expected"),
+    [
+        (set(), SpatialArms.NONE),
+        ({"up"}, SpatialArms.UP),
+        ({"right"}, SpatialArms.RIGHT),
+        ({"down"}, SpatialArms.DOWN),
+        ({"left"}, SpatialArms.LEFT),
+        ({"up", "down"}, SpatialArms.UP | SpatialArms.DOWN),
+        ({"left", "right"}, SpatialArms.LEFT | SpatialArms.RIGHT),
+        ({"up", "left"}, SpatialArms.UP | SpatialArms.LEFT),
+    ],
+)
+def test_from_hadamard_pipes_in_graph(
+    hadamard_directions: set[str], expected: SpatialArms
+) -> None:
+    graph, centre = _spatial_cube_graph_with_pipes(hadamard_directions)
+    arms = SpatialArms.from_hadamard_pipes_in_graph(centre, graph)
+    assert arms == expected
+
+
+def test_from_hadamard_pipes_in_graph_non_spatial_cube() -> None:
+    g = BlockGraph("Non-Spatial")
+    cube_pos = g.add_cube(Position3D(0, 0, 0), ZXCube.from_str("xzz"))
+    assert SpatialArms.from_hadamard_pipes_in_graph(g[cube_pos], g) == SpatialArms.NONE
+
+
+def test_cube_spec_from_cube_records_hadamard_arms() -> None:
+    graph, centre = _spatial_cube_graph_with_pipes({"left", "down"})
+    spec = CubeSpec.from_cube(centre, graph)
+    assert spec.spatial_arms == (
+        SpatialArms.UP | SpatialArms.RIGHT | SpatialArms.DOWN | SpatialArms.LEFT
+    )
+    assert spec.hadamard_arms == SpatialArms.LEFT | SpatialArms.DOWN
+
+
+def test_cube_spec_without_hadamard_arms_has_none() -> None:
+    graph, centre = _spatial_cube_graph_with_pipes(set())
+    spec = CubeSpec.from_cube(centre, graph)
+    assert spec.hadamard_arms == SpatialArms.NONE
+
+
+def test_hadamard_arms_are_spatial_arms_subset() -> None:
+    """A Hadamard arm that is not a spatial arm must be rejected."""
+    with pytest.raises(TQECError):
+        CubeSpec(ZXCube.from_str("xzz"), SpatialArms.NONE, SpatialArms.UP)
+    with pytest.raises(TQECError):
+        CubeSpec(ZXCube.from_str("xzz"), SpatialArms.UP, SpatialArms.RIGHT)
+
+
+def test_hadamard_arms_requires_spatial_cube() -> None:
+    """Hadamard arms on a non-spatial cube must be rejected."""
+    with pytest.raises(TQECError):
+        CubeSpec(ZXCube.from_str("xzz"), SpatialArms.NONE, SpatialArms.UP)
+
+
+def test_hadamard_arms_equality_and_hash() -> None:
+    """CubeSpec with same fields (incl. hadamard_arms) must be equal."""
+    a = CubeSpec(ZXCube.from_str("zzx"), SpatialArms.UP, SpatialArms.UP)
+    b = CubeSpec(ZXCube.from_str("zzx"), SpatialArms.UP, SpatialArms.UP)
+    c = CubeSpec(ZXCube.from_str("zzx"), SpatialArms.UP, SpatialArms.NONE)
+    assert a == b
+    assert hash(a) == hash(b)
+    assert a != c


### PR DESCRIPTION
## Summary

Implements the Hadamard-arm tracking described in #840: spatial cubes now record **which** of their arms carry a Hadamard transition, so the fixed-bulk convention can emit corner plaquettes consistently instead of relying on the "left-right arm drops corners, up-down arm puts them back" workaround.

## Changes

- `SpatialArms.from_hadamard_pipes_in_graph(cube, graph)` — returns the spatial arms whose incident pipe has `pipe_kind.has_hadamard == True` (temporal/Z pipes never contribute).
- `CubeSpec.hadamard_arms: SpatialArms` — new field, validated in `__post_init__`:
  - must be `NONE` for non-spatial cubes,
  - must be a subset of `spatial_arms`.
- `CubeSpec.from_cube` populates `hadamard_arms` from the block graph.
- 14 new tests: per-direction collection, multi-arm combinations, non-spatial cubes, end-to-end `from_cube`, validation errors, equality/hash.

## Context

This is the prerequisite for #837 (regular-pipes spatial Hadamards). The comment in `_get_left_right_spatial_cube_arm_rpng_descriptions` (fixed_bulk.py) documents the current limitation: corner plaquettes are dropped by the left-right arm and expected back from the up-down arm, which is only valid in the absence of left-right Hadamards. With `hadamard_arms` on `CubeSpec`, that branch can be made a direct function of the arm's Hadamard bit.

## How Has This Been Tested?

- 14 new unit tests (all passing).
- Full suite: 815 passed, 0 failed (`uv run pytest -m "not slow"`).
- `ruff check` clean on all touched files.
