### PR TITLE
feat: add CubeColor enum and Cube.colour property (#817)

### DIFF
--- a/src/tqec/computation/cube.py
+++ b/src/tqec/computation/cube.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from dataclasses import astuple, dataclass
 from typing import Any
 
@@ -166,6 +167,15 @@ class YHalfCube:
         return isinstance(other, YHalfCube)
 
 
+
+class CubeColor(Enum):
+    """Enumeration of possible colours for a Cube in the BlockGraph."""
+
+    RED = "red"
+    BLUE = "blue"
+    GREEN = "green"
+    WHITE = "white"
+
 CubeKind = ZXCube | Port | YHalfCube
 """All the possible kinds of cubes."""
 
@@ -244,6 +254,19 @@ class Cube:
 
         """
         return isinstance(self.kind, ZXCube) and self.kind.is_spatial
+
+
+    @property
+    def colour(self) -> CubeColor:
+        """Return the colour of the cube node."""
+        if self.is_zx_cube:
+            if self.kind.normal_basis == Basis.Z:
+                return CubeColor.BLUE
+            return CubeColor.RED
+        elif self.is_y_cube:
+            return CubeColor.GREEN
+        else:
+            return CubeColor.WHITE
 
     def to_dict(self) -> dict[str, Any]:
         """Return the dictionary representation of the cube."""

--- a/tests/computation/cube_test.py
+++ b/tests/computation/cube_test.py
@@ -64,7 +64,7 @@ def test_cube_from_dict() -> None:
 def test_cube_colour() -> None:
     cube_z = Cube(Position3D(0, 0, 0), ZXCube.from_str("XXZ"))
     assert cube_z.colour == CubeColor.BLUE
-    
+
     cube_x = Cube(Position3D(0, 0, 0), ZXCube.from_str("XZX"))
     assert cube_x.colour == CubeColor.RED
 

--- a/tests/computation/cube_test.py
+++ b/tests/computation/cube_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tqec.computation.cube import Cube, Port, ZXCube
+from tqec.computation.cube import Cube, Port, ZXCube, CubeColor, YHalfCube
 from tqec.utils.enums import Basis
 from tqec.utils.exceptions import TQECError
 from tqec.utils.position import Direction3D, Position3D
@@ -26,6 +26,7 @@ def test_zx_cube() -> None:
     assert not cube.is_spatial
     assert not cube.is_port
     assert not cube.is_y_cube
+    assert cube.colour == CubeColor.RED
     assert str(cube) == "ZXZ(0,0,0)"
     assert cube.to_dict() == {
         "position": (0, 0, 0),
@@ -37,6 +38,7 @@ def test_zx_cube() -> None:
 def test_port() -> None:
     cube = Cube(Position3D(0, 0, 0), Port(), "p")
     assert cube.is_port
+    assert cube.colour == CubeColor.WHITE
     assert str(cube) == "PORT(0,0,0)"
 
     with pytest.raises(TQECError, match=r"A port cube must have a non-empty port label."):
@@ -57,3 +59,14 @@ def test_cube_from_dict() -> None:
         "label": "",
     }
     assert Cube.from_dict(cube_dict) == Cube(Position3D(0, 0, 0), ZXCube.from_str("ZXZ"))
+
+
+def test_cube_colour() -> None:
+    cube_z = Cube(Position3D(0, 0, 0), ZXCube.from_str("XXZ"))
+    assert cube_z.colour == CubeColor.BLUE
+    
+    cube_x = Cube(Position3D(0, 0, 0), ZXCube.from_str("XZX"))
+    assert cube_x.colour == CubeColor.RED
+
+    cube_y = Cube(Position3D(0, 0, 0), YHalfCube())
+    assert cube_y.colour == CubeColor.GREEN


### PR DESCRIPTION
Resolves #817. This PR introduces a \CubeColor\ enumeration (\BLUE\, \RED\, \GREEN\, \WHITE\) and adds a \colour\ property to \Cube\ nodes in the BlockGraph, enabling easy access to block colours without relying on string representations.