### PR TITLE
feat: add horizontal extended stabilisers

### DIFF
--- a/src/tqec/compile/specs/library/generators/extended_stabilizers.py
+++ b/src/tqec/compile/specs/library/generators/extended_stabilizers.py
@@ -494,6 +494,11 @@ class ExtendedPlaquetteCollection:
     left_half_rectangle is the left half of the full rectangle.
     bottom_right_triangle: the right angle of the triangle is
     in the bottom right corner.
+
+    In ``LEFT_RIGHT`` orientation the names keep the vertical shapes:
+    the geometry is the transposition ``T(x, y) = (y/2, 2x)`` of the
+    ``UP_DOWN`` one, so e.g. ``left_half_rectangle`` selects the top row
+    (the transposed left half) and ``right_half_rectangle`` the bottom row.
     """
 
     bulk: ExtendedPlaquette

--- a/src/tqec/compile/specs/library/generators/extended_stabilizers.py
+++ b/src/tqec/compile/specs/library/generators/extended_stabilizers.py
@@ -27,7 +27,7 @@ from tqec.visualisation.computation.plaquette.extended import (
 def _get_spatial_cube_arm_name(
     basis_left: PauliBasis | None,
     basis_right: PauliBasis | None,
-    position: Literal["UP", "DOWN"],
+    position: Literal["UP", "DOWN", "LEFT", "RIGHT"],
     reset: Basis | None,
     measurement: Basis | None,
     is_reverse: bool,
@@ -206,6 +206,148 @@ def _make_spatial_cube_arm_memory_plaquette_down(
     )
 
 
+def _make_spatial_cube_arm_memory_plaquette_left(
+    top_qubit: RPNG,
+    bottom_qubit: RPNG,
+    reset: Basis | None = None,
+    measurement: Basis | None = None,
+    is_reversed: bool = False,
+) -> Plaquette:
+    # Checking the validity of the provided schedules
+    first_available_schedule = 2 if not is_reversed else 3
+    last_available_schedule = 4 if not is_reversed else 5
+    _check_schedules(
+        [top_qubit.n, bottom_qubit.n], first_available_schedule, last_available_schedule
+    )
+    # dl ---- s2
+    # |        |
+    # |   s1   |
+    # |        |
+    # dr ---- s2
+    qubits = PlaquetteQubits(
+        [GridQubit(-1, -1), GridQubit(-1, 1)],
+        [GridQubit(0, 0), GridQubit(1, -1 if not is_reversed else 1)],
+    )
+    dl, dr = tuple(qubits.data_qubits_indices)
+    s1, s2 = tuple(qubits.syndrome_qubits_indices)
+    # Define the base moments, only containing the reset on s2 as that is the
+    # only operation that does not depend on the parameters of this function.
+    base_moments = [
+        Moment(stim.Circuit(f"RZ {s2}")),
+        Moment(stim.Circuit()),
+        Moment(stim.Circuit()),
+        Moment(stim.Circuit()),
+        Moment(stim.Circuit()),
+        Moment(stim.Circuit()),
+        Moment(stim.Circuit()),
+        Moment(stim.Circuit()),
+    ]
+    # Add the GHZ state creation and measurement.
+    if not is_reversed:
+        base_moments[0].append("RX", [s1], [])
+        base_moments[1].append("CX", [s1, s2], [])
+        base_moments[5].append("CX", [s2, s1], [])
+    else:
+        base_moments[1].append("RZ", [s1], [])
+        base_moments[2].append("CX", [s2, s1], [])
+        base_moments[6].append("CX", [s1, s2], [])
+        base_moments[7].append("MX", [s1], [])
+    # Add controlled gates
+    if top_qubit.p is not None and top_qubit.n is not None:
+        base_moments[top_qubit.n].append(f"C{top_qubit.p.name.upper()}", [s1, dl], [])
+    if bottom_qubit.p is not None and bottom_qubit.n is not None:
+        base_moments[bottom_qubit.n].append(f"C{bottom_qubit.p.name.upper()}", [s1, dr], [])
+    # Add data-qubit reset/measurement if needed
+    # Note about resets: data-qubits (i.e., the 4 corners) are already in a
+    # correct state and we should not reset them. Internal qubits are also
+    # already reset individually by the circuit constructed above. That means
+    # that we should NOT reset anything here. Nevertheless, the reset argument
+    # is kept because the plaquette naming should be adapted.
+    if measurement:
+        # Add ancilla measurements if data-qubits are measured.
+        base_moments[-1].append("M", [s2] if is_reversed else [s1, s2], [])
+    # Finally, return the plaquette
+    return Plaquette(
+        _get_spatial_cube_arm_name(
+            top_qubit.p, bottom_qubit.p, "LEFT", reset, measurement, is_reversed
+        ),
+        qubits,
+        ScheduledCircuit(base_moments, 0, qubits.qubit_map),
+        MEASUREMENT_INSTRUCTION_NAMES | RESET_INSTRUCTION_NAMES,
+    )
+
+
+def _make_spatial_cube_arm_memory_plaquette_right(
+    top_qubit: RPNG,
+    bottom_qubit: RPNG,
+    reset: Basis | None = None,
+    measurement: Basis | None = None,
+    is_reversed: bool = False,
+) -> Plaquette:
+    # Checking the validity of the provided schedules
+    first_available_schedule = 3 if not is_reversed else 2
+    last_available_schedule = 5 if not is_reversed else 4
+    _check_schedules(
+        [top_qubit.n, bottom_qubit.n], first_available_schedule, last_available_schedule
+    )
+    # s2 ---- dl
+    # |        |
+    # |   s1   |
+    # |        |
+    # s2 ---- dr
+    qubits = PlaquetteQubits(
+        [GridQubit(1, -1), GridQubit(1, 1)],
+        [GridQubit(0, 0), GridQubit(-1, -1 if not is_reversed else 1)],
+    )
+    dl, dr = tuple(qubits.data_qubits_indices)
+    s1, s2 = tuple(qubits.syndrome_qubits_indices)
+    # Define the base moments, only containing the reset on s2 as that is the
+    # only operation that does not depend on the parameters of this function.
+    base_moments = [
+        Moment(stim.Circuit(f"RZ {s2}")),
+        Moment(stim.Circuit()),
+        Moment(stim.Circuit()),
+        Moment(stim.Circuit()),
+        Moment(stim.Circuit()),
+        Moment(stim.Circuit()),
+        Moment(stim.Circuit()),
+        Moment(stim.Circuit()),
+    ]
+    # Add the GHZ state creation and measurement.
+    if is_reversed:
+        base_moments[0].append("RX", [s1], [])
+        base_moments[1].append("CX", [s1, s2], [])
+        base_moments[5].append("CX", [s2, s1], [])
+    else:
+        base_moments[1].append("RZ", [s1], [])
+        base_moments[2].append("CX", [s2, s1], [])
+        base_moments[6].append("CX", [s1, s2], [])
+        base_moments[7].append("MX", [s1], [])
+    # Add controlled gates
+    if top_qubit.p is not None and top_qubit.n is not None:
+        base_moments[top_qubit.n].append(f"C{top_qubit.p.name.upper()}", [s1, dl], [])
+    if bottom_qubit.p is not None and bottom_qubit.n is not None:
+        base_moments[bottom_qubit.n].append(f"C{bottom_qubit.p.name.upper()}", [s1, dr], [])
+    # Add data-qubit reset/measurement if needed
+    # Note about resets: data-qubits (i.e., the 4 corners) are already in a
+    # correct state and we should not reset them. Internal qubits are also
+    # already reset individually by the circuit constructed above. That means
+    # that we should NOT reset anything here. Nevertheless, the reset argument
+    # is kept because the plaquette naming should be adapted.
+    if measurement:
+        # Add ancilla measurements if data-qubits are measured.
+        base_moments[-1].append("M", [s1, s2] if is_reversed else [s2], [])
+    # Finally, return the plaquette
+    return Plaquette(
+        _get_spatial_cube_arm_name(
+            top_qubit.p, bottom_qubit.p, "RIGHT", reset, measurement, is_reversed
+        ),
+        qubits,
+        ScheduledCircuit(base_moments, 0, qubits.qubit_map),
+        MEASUREMENT_INSTRUCTION_NAMES | RESET_INSTRUCTION_NAMES,
+    )
+
+
 def get_extended_plaquette(
     rpng: RPNGDescription,
     reset: Basis | None = None,
@@ -233,6 +375,40 @@ def get_extended_plaquette(
     return (
         _make_spatial_cube_arm_memory_plaquette_up(tl, tr, reset, measurement, is_reversed),
         _make_spatial_cube_arm_memory_plaquette_down(bl, br, reset, measurement, is_reversed),
+    )
+
+
+def get_horizontal_extended_plaquette(
+    rpng: RPNGDescription,
+    reset: Basis | None = None,
+    measurement: Basis | None = None,
+    is_reversed: bool = False,
+) -> tuple[Plaquette, Plaquette]:
+    """Create a horizontal extended plaquette from the provided RPNG description.
+
+    Args:
+        rpng: description of the 4 corners of the extended plaquette.
+        reset: basis of the reset operation performed on internal data-qubits (used as syndrome
+            qubits). Defaults to ``None`` that translates to no reset being applied on data-qubits.
+        measurement: basis of the measurement operation performed on internal data-qubits (used as
+            syndrome qubits). Defaults to ``None`` that translates to no measurement being applied
+            on data-qubits.
+        is_reversed: flag indicating if the plaquette schedule should be reversed or not. Useful to
+            limit the loss of code distance when hook errors are not correctly oriented by
+            alternating regular and reversed plaquettes.
+
+    Returns:
+        a pair of plaquettes ``(LEFT, RIGHT)`` implementing the extended stabilizer.
+
+    """
+    tl, tr, bl, br = rpng.corners
+    return (
+        _make_spatial_cube_arm_memory_plaquette_left(
+            tl, bl, reset, measurement, is_reversed
+        ),
+        _make_spatial_cube_arm_memory_plaquette_right(
+            tr, br, reset, measurement, is_reversed
+        ),
     )
 
 
@@ -288,12 +464,13 @@ def _make_extended_plaquette(
     schedule: tuple[int, int, int, int],
     reset: Basis | None,
     measurement: Basis | None,
+    first_position: ExtendedPlaquettePosition = ExtendedPlaquettePosition.UP,
 ) -> ExtendedPlaquette:
     return ExtendedPlaquette(
         _with_extended_plaquette_drawer(
             top,
             plaquette_type,
-            ExtendedPlaquettePosition.UP,
+            first_position,
             basis,
             schedule,
             reset,
@@ -302,7 +479,7 @@ def _make_extended_plaquette(
         _with_extended_plaquette_drawer(
             bottom,
             plaquette_type,
-            ExtendedPlaquettePosition.DOWN,
+            first_position.flip(),
             basis,
             schedule,
             reset,
@@ -333,10 +510,39 @@ class ExtendedPlaquetteCollection:
         reset: Basis | None,
         measurement: Basis | None,
         is_reversed: bool,
+        orientation: Literal["UP_DOWN", "LEFT_RIGHT"] = "UP_DOWN",
     ) -> ExtendedPlaquetteCollection:
-        """Build an instance from the provided ``RPNGDescription``."""
+        """Build an instance from the provided ``RPNGDescription``.
+
+        Args:
+            description: description of the 4 corners of the extended plaquette.
+            reset: basis of the reset operation performed on internal data-qubits (used as syndrome
+                qubits). Defaults to ``None`` that translates to no reset being applied on
+                data-qubits.
+            measurement: basis of the measurement operation performed on internal data-qubits
+                (used as syndrome qubits). Defaults to ``None`` that translates to no measurement
+                being applied on data-qubits.
+            is_reversed: flag indicating if the plaquette schedule should be reversed or not.
+            orientation: orientation of the extended stabilisers. ``"UP_DOWN"`` (the default)
+                builds vertical extended stabilisers with a long direction along the y axis,
+                ``"LEFT_RIGHT"`` builds horizontal extended stabilisers with a long direction
+                along the x axis.
+
+        Returns:
+            a collection of extended plaquettes in the requested orientation.
+
+        """
         _raise_if_undefined_corners(description)
-        up, down = get_extended_plaquette(description, reset, measurement, is_reversed)
+        if orientation == "LEFT_RIGHT":
+            first, second = get_horizontal_extended_plaquette(
+                description, reset, measurement, is_reversed
+            )
+            first_position = ExtendedPlaquettePosition.LEFT
+        else:
+            first, second = get_extended_plaquette(
+                description, reset, measurement, is_reversed
+            )
+            first_position = ExtendedPlaquettePosition.UP
         drawer_basis = _get_drawer_basis(description)
         drawer_schedule = _get_drawer_schedule(description)
         # In the calls to project_on_data_qubit_indices, it is important to remember
@@ -359,68 +565,75 @@ class ExtendedPlaquetteCollection:
         # d0 ---- d1
         return ExtendedPlaquetteCollection(
             bulk=_make_extended_plaquette(
-                up,
-                down,
+                first,
+                second,
                 ExtendedPlaquetteType.BULK,
                 drawer_basis,
                 drawer_schedule,
                 reset,
                 measurement,
+                first_position,
             ),
             bottom_right_triangle=_make_extended_plaquette(
-                up.project_on_data_qubit_indices([1]),
-                down,
+                first.project_on_data_qubit_indices([1]),
+                second,
                 ExtendedPlaquetteType.BOTTOM_RIGHT_TRIANGLE,
                 drawer_basis,
                 drawer_schedule,
                 reset,
                 measurement,
+                first_position,
             ),
             right_half_rectangle=_make_extended_plaquette(
-                up.project_on_data_qubit_indices([1]),
-                down.project_on_data_qubit_indices([1]),
+                first.project_on_data_qubit_indices([1]),
+                second.project_on_data_qubit_indices([1]),
                 ExtendedPlaquetteType.RIGHT_HALF_RECTANGLE,
                 drawer_basis,
                 drawer_schedule,
                 reset,
                 measurement,
+                first_position,
             ),
             top_left_triangle=_make_extended_plaquette(
-                up,
-                down.project_on_data_qubit_indices([0]),
+                first,
+                second.project_on_data_qubit_indices([0]),
                 ExtendedPlaquetteType.TOP_LEFT_TRIANGLE,
                 drawer_basis,
                 drawer_schedule,
                 reset,
                 measurement,
+                first_position,
             ),
             left_half_rectangle=_make_extended_plaquette(
-                up.project_on_data_qubit_indices([0]),
-                down.project_on_data_qubit_indices([0]),
+                first.project_on_data_qubit_indices([0]),
+                second.project_on_data_qubit_indices([0]),
                 ExtendedPlaquetteType.LEFT_HALF_RECTANGLE,
                 drawer_basis,
                 drawer_schedule,
                 reset,
                 measurement,
+                first_position,
             ),
             bottom_left_triangle=_make_extended_plaquette(
-                up.project_on_data_qubit_indices([0]),
-                down,
+                first.project_on_data_qubit_indices([0]),
+                second,
                 ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE,
                 drawer_basis,
                 drawer_schedule,
                 reset,
                 measurement,
+                first_position,
             ),
             # top right refers to where the right angle is.
             top_right_triangle=_make_extended_plaquette(
-                up,
-                down.project_on_data_qubit_indices([1]),
+                first,
+                second.project_on_data_qubit_indices([1]),
                 ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE,
                 drawer_basis,
                 drawer_schedule,
                 reset,
                 measurement,
+                first_position,
             ),
         )
 
@@ -431,6 +644,7 @@ class ExtendedPlaquetteCollection:
         measurement: Basis | None,
         is_reversed: bool,
         schedule: Sequence[int] | Schedule | None = None,
+        orientation: Literal["UP_DOWN", "LEFT_RIGHT"] = "UP_DOWN",
     ) -> ExtendedPlaquetteCollection:
         """Create an instance from a basis and a schedule.
 
@@ -455,6 +669,9 @@ class ExtendedPlaquetteCollection:
                 this schedule (no matter the provided value of ``is_reversed``, it is up to the
                 caller to ensure the provided value is valid). If not provided, a default schedule
                 that depends on ``is_reversed`` is used. Needs to contain exactly 4 integer entries.
+            orientation: orientation of the pair of returned extended plaquettes. ``"UP_DOWN"``
+                returns the standard vertical extended plaquettes, while ``"LEFT_RIGHT"`` returns
+                the horizontal ones, with data-qubits on the left/right columns.
 
         Returns:
             a collection of extended plaquettes measuring the provided basis on data-qubits in the
@@ -467,5 +684,5 @@ class ExtendedPlaquetteCollection:
         # for an extended plaquette
         description = RPNGDescription.from_basis_and_schedule(basis, schedule)
         return ExtendedPlaquetteCollection.from_description(
-            description, reset, measurement, is_reversed
+            description, reset, measurement, is_reversed, orientation
         )

--- a/src/tqec/compile/specs/library/generators/extended_stabilizers.py
+++ b/src/tqec/compile/specs/library/generators/extended_stabilizers.py
@@ -14,7 +14,7 @@ from tqec.compile.specs.library.generators.constants import EXTENDED_PLAQUETTE_S
 from tqec.plaquette.plaquette import Plaquette
 from tqec.plaquette.qubit import PlaquetteQubits
 from tqec.plaquette.rpng.rpng import RPNG, PauliBasis, RPNGDescription
-from tqec.utils.enums import Basis
+from tqec.utils.enums import Basis, Orientation
 from tqec.utils.exceptions import TQECError
 from tqec.utils.instructions import MEASUREMENT_INSTRUCTION_NAMES, RESET_INSTRUCTION_NAMES
 from tqec.visualisation.computation.plaquette.extended import (
@@ -64,240 +64,63 @@ def _check_schedules(
         )
 
 
-def _make_spatial_cube_arm_memory_plaquette_up(
-    left_qubit: RPNG,
-    right_qubit: RPNG,
+def _make_spatial_cube_arm_memory_plaquette(
+    direction: ExtendedPlaquettePosition,
+    first_qubit: RPNG,
+    second_qubit: RPNG,
     reset: Basis | None = None,
     measurement: Basis | None = None,
     is_reversed: bool = False,
 ) -> Plaquette:
+    """Create a spatial cube arm memory plaquette oriented along ``direction``.
+
+    The four orientations (UP/DOWN/LEFT/RIGHT) share the same GHZ schedule
+    logic and differ only in their qubit layout and in the phase of the
+    schedule: UP and LEFT use the base phase (the RX-first GHZ sequence is
+    emitted for ``is_reversed=False``) while DOWN and RIGHT use the
+    phase-shifted variant (the same sequence is emitted for
+    ``is_reversed=True``).
+    """
+    # DOWN and RIGHT emit the RX-first GHZ sequence when ``is_reversed`` is
+    # True, i.e. exactly when ``is_reversed == reversed_phase``.
+    reversed_phase = direction in (
+        ExtendedPlaquettePosition.DOWN,
+        ExtendedPlaquettePosition.RIGHT,
+    )
     # Checking the validity of the provided schedules
-    first_available_schedule = 2 if not is_reversed else 3
-    last_available_schedule = 4 if not is_reversed else 5
+    first_available_schedule = 2 + (reversed_phase != is_reversed)
+    last_available_schedule = first_available_schedule + 2
     _check_schedules(
-        [left_qubit.n, right_qubit.n], first_available_schedule, last_available_schedule
+        [first_qubit.n, second_qubit.n], first_available_schedule, last_available_schedule
     )
-    # dl ---- dr
-    # |        |
-    # |   s1   |
-    # |        |
-    # s2 ---- s2
-    qubits = PlaquetteQubits(
-        [GridQubit(-1, -1), GridQubit(1, -1)],
-        [GridQubit(0, 0), GridQubit(1 if is_reversed else -1, 1)],
-    )
-    dl, dr = tuple(qubits.data_qubits_indices)
-    s1, s2 = tuple(qubits.syndrome_qubits_indices)
-    # Define the base moments, only containing the reset on s2 as that is the
-    # only operation that does not depend on the parameters of this function.
-    base_moments = [
-        Moment(stim.Circuit(f"RZ {s2}")),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-    ]
-    # Add the GHZ state creation and measurement.
-    if not is_reversed:
-        base_moments[0].append("RX", [s1], [])
-        base_moments[1].append("CX", [s1, s2], [])
-        base_moments[5].append("CX", [s2, s1], [])
-    else:
-        base_moments[1].append("RZ", [s1], [])
-        base_moments[2].append("CX", [s2, s1], [])
-        base_moments[6].append("CX", [s1, s2], [])
-        base_moments[7].append("MX", [s1], [])
-    # Add controlled gates
-    if left_qubit.p is not None and left_qubit.n is not None:
-        base_moments[left_qubit.n].append(f"C{left_qubit.p.name.upper()}", [s1, dl], [])
-    if right_qubit.p is not None and right_qubit.n is not None:
-        base_moments[right_qubit.n].append(f"C{right_qubit.p.name.upper()}", [s1, dr], [])
-    # Add data-qubit reset/measurement if needed
-    # Note about resets: data-qubits (i.e., the 4 corners) are already in a
-    # correct state and we should not reset them. Internal qubits are also
-    # already reset individually by the circuit constructed above. That means
-    # that we should NOT reset anything here. Nevertheless, the reset argument
-    # is kept because the plaquette naming should be adapted.
-    if measurement:
-        # Add ancilla measurements if data-qubits are measured.
-        base_moments[-1].append("M", [s2] if is_reversed else [s1, s2], [])
-    # Finally, return the plaquette
-    return Plaquette(
-        _get_spatial_cube_arm_name(
-            left_qubit.p, right_qubit.p, "UP", reset, measurement, is_reversed
+    # Qubit layout per direction. Data qubits are listed as (dl, dr); the
+    # second syndrome qubit sits at ``s2_base`` for the non-reversed schedule
+    # and at ``s2_reversed`` otherwise.
+    data_qubits, s2_base, s2_reversed = {
+        ExtendedPlaquettePosition.UP: (
+            (GridQubit(-1, -1), GridQubit(1, -1)),
+            GridQubit(-1, 1),
+            GridQubit(1, 1),
         ),
-        qubits,
-        ScheduledCircuit(base_moments, 0, qubits.qubit_map),
-        MEASUREMENT_INSTRUCTION_NAMES | RESET_INSTRUCTION_NAMES,
-    )
-
-
-def _make_spatial_cube_arm_memory_plaquette_down(
-    left_qubit: RPNG,
-    right_qubit: RPNG,
-    reset: Basis | None = None,
-    measurement: Basis | None = None,
-    is_reversed: bool = False,
-) -> Plaquette:
-    # Checking the validity of the provided schedules
-    first_available_schedule = 3 if not is_reversed else 2
-    last_available_schedule = 5 if not is_reversed else 4
-    _check_schedules(
-        [left_qubit.n, right_qubit.n], first_available_schedule, last_available_schedule
-    )
-    # s2 ---- s2
-    # |        |
-    # |   s1   |
-    # |        |
-    # dl ---- dr
-    qubits = PlaquetteQubits(
-        [GridQubit(-1, 1), GridQubit(1, 1)],
-        [GridQubit(0, 0), GridQubit(1 if is_reversed else -1, -1)],
-    )
-    dl, dr = tuple(qubits.data_qubits_indices)
-    s1, s2 = tuple(qubits.syndrome_qubits_indices)
-    # Define the base moments, only containing the reset on s2 as that is the
-    # only operation that does not depend on the parameters of this function.
-    base_moments = [
-        Moment(stim.Circuit(f"RZ {s2}")),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-    ]
-    # Add the GHZ state creation and measurement.
-    if is_reversed:
-        base_moments[0].append("RX", [s1], [])
-        base_moments[1].append("CX", [s1, s2], [])
-        base_moments[5].append("CX", [s2, s1], [])
-    else:
-        base_moments[1].append("RZ", [s1], [])
-        base_moments[2].append("CX", [s2, s1], [])
-        base_moments[6].append("CX", [s1, s2], [])
-        base_moments[7].append("MX", [s1], [])
-    # Add controlled gates
-    if left_qubit.p is not None and left_qubit.n is not None:
-        base_moments[left_qubit.n].append(f"C{left_qubit.p.name.upper()}", [s1, dl], [])
-    if right_qubit.p is not None and right_qubit.n is not None:
-        base_moments[right_qubit.n].append(f"C{right_qubit.p.name.upper()}", [s1, dr], [])
-    # Add data-qubit reset/measurement if needed
-    # Note about resets: data-qubits (i.e., the 4 corners) are already in a
-    # correct state and we should not reset them. Internal qubits are also
-    # already reset individually by the circuit constructed above. That means
-    # that we should NOT reset anything here. Nevertheless, the reset argument
-    # is kept because the plaquette naming should be adapted.
-    if measurement:
-        # Add ancilla measurements if data-qubits are measured.
-        base_moments[-1].append("M", [s1, s2] if is_reversed else [s2], [])
-    # Finally, return the plaquette
-    return Plaquette(
-        _get_spatial_cube_arm_name(
-            left_qubit.p, right_qubit.p, "DOWN", reset, measurement, is_reversed
+        ExtendedPlaquettePosition.DOWN: (
+            (GridQubit(-1, 1), GridQubit(1, 1)),
+            GridQubit(-1, -1),
+            GridQubit(1, -1),
         ),
-        qubits,
-        ScheduledCircuit(base_moments, 0, qubits.qubit_map),
-        MEASUREMENT_INSTRUCTION_NAMES | RESET_INSTRUCTION_NAMES,
-    )
-
-
-def _make_spatial_cube_arm_memory_plaquette_left(
-    top_qubit: RPNG,
-    bottom_qubit: RPNG,
-    reset: Basis | None = None,
-    measurement: Basis | None = None,
-    is_reversed: bool = False,
-) -> Plaquette:
-    # Checking the validity of the provided schedules
-    first_available_schedule = 2 if not is_reversed else 3
-    last_available_schedule = 4 if not is_reversed else 5
-    _check_schedules(
-        [top_qubit.n, bottom_qubit.n], first_available_schedule, last_available_schedule
-    )
-    # dl ---- s2
-    # |        |
-    # |   s1   |
-    # |        |
-    # dr ---- s2
-    qubits = PlaquetteQubits(
-        [GridQubit(-1, -1), GridQubit(-1, 1)],
-        [GridQubit(0, 0), GridQubit(1, -1 if not is_reversed else 1)],
-    )
-    dl, dr = tuple(qubits.data_qubits_indices)
-    s1, s2 = tuple(qubits.syndrome_qubits_indices)
-    # Define the base moments, only containing the reset on s2 as that is the
-    # only operation that does not depend on the parameters of this function.
-    base_moments = [
-        Moment(stim.Circuit(f"RZ {s2}")),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-        Moment(stim.Circuit()),
-    ]
-    # Add the GHZ state creation and measurement.
-    if not is_reversed:
-        base_moments[0].append("RX", [s1], [])
-        base_moments[1].append("CX", [s1, s2], [])
-        base_moments[5].append("CX", [s2, s1], [])
-    else:
-        base_moments[1].append("RZ", [s1], [])
-        base_moments[2].append("CX", [s2, s1], [])
-        base_moments[6].append("CX", [s1, s2], [])
-        base_moments[7].append("MX", [s1], [])
-    # Add controlled gates
-    if top_qubit.p is not None and top_qubit.n is not None:
-        base_moments[top_qubit.n].append(f"C{top_qubit.p.name.upper()}", [s1, dl], [])
-    if bottom_qubit.p is not None and bottom_qubit.n is not None:
-        base_moments[bottom_qubit.n].append(f"C{bottom_qubit.p.name.upper()}", [s1, dr], [])
-    # Add data-qubit reset/measurement if needed
-    # Note about resets: data-qubits (i.e., the 4 corners) are already in a
-    # correct state and we should not reset them. Internal qubits are also
-    # already reset individually by the circuit constructed above. That means
-    # that we should NOT reset anything here. Nevertheless, the reset argument
-    # is kept because the plaquette naming should be adapted.
-    if measurement:
-        # Add ancilla measurements if data-qubits are measured.
-        base_moments[-1].append("M", [s2] if is_reversed else [s1, s2], [])
-    # Finally, return the plaquette
-    return Plaquette(
-        _get_spatial_cube_arm_name(
-            top_qubit.p, bottom_qubit.p, "LEFT", reset, measurement, is_reversed
+        ExtendedPlaquettePosition.LEFT: (
+            (GridQubit(-1, -1), GridQubit(-1, 1)),
+            GridQubit(1, -1),
+            GridQubit(1, 1),
         ),
-        qubits,
-        ScheduledCircuit(base_moments, 0, qubits.qubit_map),
-        MEASUREMENT_INSTRUCTION_NAMES | RESET_INSTRUCTION_NAMES,
-    )
-
-
-def _make_spatial_cube_arm_memory_plaquette_right(
-    top_qubit: RPNG,
-    bottom_qubit: RPNG,
-    reset: Basis | None = None,
-    measurement: Basis | None = None,
-    is_reversed: bool = False,
-) -> Plaquette:
-    # Checking the validity of the provided schedules
-    first_available_schedule = 3 if not is_reversed else 2
-    last_available_schedule = 5 if not is_reversed else 4
-    _check_schedules(
-        [top_qubit.n, bottom_qubit.n], first_available_schedule, last_available_schedule
-    )
-    # s2 ---- dl
-    # |        |
-    # |   s1   |
-    # |        |
-    # s2 ---- dr
+        ExtendedPlaquettePosition.RIGHT: (
+            (GridQubit(1, -1), GridQubit(1, 1)),
+            GridQubit(-1, -1),
+            GridQubit(-1, 1),
+        ),
+    }[direction]
     qubits = PlaquetteQubits(
-        [GridQubit(1, -1), GridQubit(1, 1)],
-        [GridQubit(0, 0), GridQubit(-1, -1 if not is_reversed else 1)],
+        list(data_qubits),
+        [GridQubit(0, 0), s2_reversed if is_reversed else s2_base],
     )
     dl, dr = tuple(qubits.data_qubits_indices)
     s1, s2 = tuple(qubits.syndrome_qubits_indices)
@@ -314,7 +137,7 @@ def _make_spatial_cube_arm_memory_plaquette_right(
         Moment(stim.Circuit()),
     ]
     # Add the GHZ state creation and measurement.
-    if is_reversed:
+    if is_reversed == reversed_phase:
         base_moments[0].append("RX", [s1], [])
         base_moments[1].append("CX", [s1, s2], [])
         base_moments[5].append("CX", [s2, s1], [])
@@ -324,10 +147,10 @@ def _make_spatial_cube_arm_memory_plaquette_right(
         base_moments[6].append("CX", [s1, s2], [])
         base_moments[7].append("MX", [s1], [])
     # Add controlled gates
-    if top_qubit.p is not None and top_qubit.n is not None:
-        base_moments[top_qubit.n].append(f"C{top_qubit.p.name.upper()}", [s1, dl], [])
-    if bottom_qubit.p is not None and bottom_qubit.n is not None:
-        base_moments[bottom_qubit.n].append(f"C{bottom_qubit.p.name.upper()}", [s1, dr], [])
+    if first_qubit.p is not None and first_qubit.n is not None:
+        base_moments[first_qubit.n].append(f"C{first_qubit.p.name.upper()}", [s1, dl], [])
+    if second_qubit.p is not None and second_qubit.n is not None:
+        base_moments[second_qubit.n].append(f"C{second_qubit.p.name.upper()}", [s1, dr], [])
     # Add data-qubit reset/measurement if needed
     # Note about resets: data-qubits (i.e., the 4 corners) are already in a
     # correct state and we should not reset them. Internal qubits are also
@@ -336,11 +159,18 @@ def _make_spatial_cube_arm_memory_plaquette_right(
     # is kept because the plaquette naming should be adapted.
     if measurement:
         # Add ancilla measurements if data-qubits are measured.
-        base_moments[-1].append("M", [s1, s2] if is_reversed else [s2], [])
+        base_moments[-1].append(
+            "M", [s1, s2] if is_reversed == reversed_phase else [s2], []
+        )
     # Finally, return the plaquette
     return Plaquette(
         _get_spatial_cube_arm_name(
-            top_qubit.p, bottom_qubit.p, "RIGHT", reset, measurement, is_reversed
+            first_qubit.p,
+            second_qubit.p,
+            cast(Literal["UP", "DOWN", "LEFT", "RIGHT"], direction.value),
+            reset,
+            measurement,
+            is_reversed,
         ),
         qubits,
         ScheduledCircuit(base_moments, 0, qubits.qubit_map),
@@ -373,8 +203,12 @@ def get_extended_plaquette(
     """
     tl, tr, bl, br = rpng.corners
     return (
-        _make_spatial_cube_arm_memory_plaquette_up(tl, tr, reset, measurement, is_reversed),
-        _make_spatial_cube_arm_memory_plaquette_down(bl, br, reset, measurement, is_reversed),
+        _make_spatial_cube_arm_memory_plaquette(
+            ExtendedPlaquettePosition.UP, tl, tr, reset, measurement, is_reversed
+        ),
+        _make_spatial_cube_arm_memory_plaquette(
+            ExtendedPlaquettePosition.DOWN, bl, br, reset, measurement, is_reversed
+        ),
     )
 
 
@@ -403,11 +237,11 @@ def get_horizontal_extended_plaquette(
     """
     tl, tr, bl, br = rpng.corners
     return (
-        _make_spatial_cube_arm_memory_plaquette_left(
-            tl, bl, reset, measurement, is_reversed
+        _make_spatial_cube_arm_memory_plaquette(
+            ExtendedPlaquettePosition.LEFT, tl, bl, reset, measurement, is_reversed
         ),
-        _make_spatial_cube_arm_memory_plaquette_right(
-            tr, br, reset, measurement, is_reversed
+        _make_spatial_cube_arm_memory_plaquette(
+            ExtendedPlaquettePosition.RIGHT, tr, br, reset, measurement, is_reversed
         ),
     )
 
@@ -515,7 +349,7 @@ class ExtendedPlaquetteCollection:
         reset: Basis | None,
         measurement: Basis | None,
         is_reversed: bool,
-        orientation: Literal["UP_DOWN", "LEFT_RIGHT"] = "UP_DOWN",
+        orientation: Orientation = Orientation.VERTICAL,
     ) -> ExtendedPlaquetteCollection:
         """Build an instance from the provided ``RPNGDescription``.
 
@@ -528,17 +362,17 @@ class ExtendedPlaquetteCollection:
                 (used as syndrome qubits). Defaults to ``None`` that translates to no measurement
                 being applied on data-qubits.
             is_reversed: flag indicating if the plaquette schedule should be reversed or not.
-            orientation: orientation of the extended stabilisers. ``"UP_DOWN"`` (the default)
-                builds vertical extended stabilisers with a long direction along the y axis,
-                ``"LEFT_RIGHT"`` builds horizontal extended stabilisers with a long direction
-                along the x axis.
+            orientation: orientation of the extended stabilisers. ``Orientation.VERTICAL``
+                (the default) builds vertical extended stabilisers with a long direction along
+                the y axis, ``Orientation.HORIZONTAL`` builds horizontal extended stabilisers
+                with a long direction along the x axis.
 
         Returns:
             a collection of extended plaquettes in the requested orientation.
 
         """
         _raise_if_undefined_corners(description)
-        if orientation == "LEFT_RIGHT":
+        if orientation == Orientation.HORIZONTAL:
             first, second = get_horizontal_extended_plaquette(
                 description, reset, measurement, is_reversed
             )
@@ -649,7 +483,7 @@ class ExtendedPlaquetteCollection:
         measurement: Basis | None,
         is_reversed: bool,
         schedule: Sequence[int] | Schedule | None = None,
-        orientation: Literal["UP_DOWN", "LEFT_RIGHT"] = "UP_DOWN",
+        orientation: Orientation = Orientation.VERTICAL,
     ) -> ExtendedPlaquetteCollection:
         """Create an instance from a basis and a schedule.
 
@@ -674,9 +508,10 @@ class ExtendedPlaquetteCollection:
                 this schedule (no matter the provided value of ``is_reversed``, it is up to the
                 caller to ensure the provided value is valid). If not provided, a default schedule
                 that depends on ``is_reversed`` is used. Needs to contain exactly 4 integer entries.
-            orientation: orientation of the pair of returned extended plaquettes. ``"UP_DOWN"``
-                returns the standard vertical extended plaquettes, while ``"LEFT_RIGHT"`` returns
-                the horizontal ones, with data-qubits on the left/right columns.
+            orientation: orientation of the pair of returned extended plaquettes.
+                ``Orientation.VERTICAL`` returns the standard vertical extended plaquettes, while
+                ``Orientation.HORIZONTAL`` returns the horizontal ones, with data-qubits on the
+                left/right columns.
 
         Returns:
             a collection of extended plaquettes measuring the provided basis on data-qubits in the

--- a/src/tqec/visualisation/computation/plaquette/extended.py
+++ b/src/tqec/visualisation/computation/plaquette/extended.py
@@ -21,6 +21,8 @@ from tqec.visualisation.exception import TQECDrawingError
 class ExtendedPlaquettePosition(Enum):
     UP = "UP"
     DOWN = "DOWN"
+    LEFT = "LEFT"
+    RIGHT = "RIGHT"
 
     def flip(self) -> ExtendedPlaquettePosition:
         """Return the opposite direction."""
@@ -29,6 +31,10 @@ class ExtendedPlaquettePosition(Enum):
                 return ExtendedPlaquettePosition.DOWN
             case ExtendedPlaquettePosition.DOWN:
                 return ExtendedPlaquettePosition.UP
+            case ExtendedPlaquettePosition.LEFT:
+                return ExtendedPlaquettePosition.RIGHT
+            case ExtendedPlaquettePosition.RIGHT:
+                return ExtendedPlaquettePosition.LEFT
             # wildcard entry added as it was flagged by ty
             case _:
                 raise ValueError("Unexpected input provided.")
@@ -60,10 +66,38 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
         self._position = position
         self._basis = basis
         self._schedule = (
-            schedule[0:2] if position == ExtendedPlaquettePosition.UP else schedule[2:4]
+            schedule[0:2]
+            if position
+            in (ExtendedPlaquettePosition.UP, ExtendedPlaquettePosition.LEFT)
+            else schedule[2:4]
         )
         self._reset = reset
         self._measurement = measurement
+
+    @staticmethod
+    def _is_first(position: ExtendedPlaquettePosition) -> bool:
+        """Whether the position is the first of a (UP, DOWN) or (LEFT, RIGHT) pair."""
+        return position in (
+            ExtendedPlaquettePosition.UP,
+            ExtendedPlaquettePosition.LEFT,
+        )
+
+    @staticmethod
+    def _transform_point(
+        position: ExtendedPlaquettePosition, point: complex
+    ) -> complex:
+        """Transpose a point for horizontal (LEFT/RIGHT) positions.
+
+        Horizontal extended plaquettes are drawn by transposing the vertical
+        layout inside the same drawing domain: the top edge becomes the left
+        edge and the bottom edge becomes the right edge.
+        """
+        if position in (
+            ExtendedPlaquettePosition.LEFT,
+            ExtendedPlaquettePosition.RIGHT,
+        ):
+            return complex(point.imag / 2, 2 * point.real)
+        return point
 
     @override
     def draw(
@@ -100,6 +134,16 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
         configuration: DrawerConfiguration = DrawerConfiguration(),
     ) -> svg.G:
         tl, tr, bl, br = SVGPlaquetteDrawer._CORNERS
+        if position in (
+            ExtendedPlaquettePosition.LEFT,
+            ExtendedPlaquettePosition.RIGHT,
+        ):
+            tl, tr, bl, br = (
+                ExtendedPlaquetteDrawer._transform_point(position, tl),
+                ExtendedPlaquetteDrawer._transform_point(position, tr),
+                ExtendedPlaquetteDrawer._transform_point(position, bl),
+                ExtendedPlaquetteDrawer._transform_point(position, br),
+            )
         if plaquette_type == ExtendedPlaquetteType.RIGHT_HALF_RECTANGLE:
             tl, bl = (tl + tr) / 2, (bl + br) / 2
         elif plaquette_type == ExtendedPlaquetteType.LEFT_HALF_RECTANGLE:
@@ -109,7 +153,10 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
             configuration.stroke_color,
             configuration.thin_stroke_color,
         )
-        if position == ExtendedPlaquettePosition.DOWN:
+        if position in (
+            ExtendedPlaquettePosition.DOWN,
+            ExtendedPlaquettePosition.RIGHT,
+        ):
             up_stroke_color, down_stroke_color = down_stroke_color, up_stroke_color
         return svg.G(
             elements=[
@@ -167,7 +214,10 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
         fill: str = "none",
         configuration: DrawerConfiguration = DrawerConfiguration(),
     ) -> svg.Element:
-        if position == ExtendedPlaquettePosition.DOWN:
+        if position in (
+            ExtendedPlaquettePosition.DOWN,
+            ExtendedPlaquettePosition.RIGHT,
+        ):
             return svg.G()
         _, tr, bl, br = SVGPlaquetteDrawer._CORNERS
         bl += 1j
@@ -187,6 +237,8 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
                 vs = [complex(1 - v.real, v.imag) for v in (2 * center - v for v in vs)]
             case _:
                 raise ValueError("Unsupported triangle plaquette type provided.")
+        if position == ExtendedPlaquettePosition.LEFT:
+            vs = [ExtendedPlaquetteDrawer._transform_point(position, v) for v in vs]
         return svg_path_enclosing_points(vs, fill, configuration)
 
     def get_plaquette_shape_path(
@@ -246,32 +298,68 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
         """
         interaction_order_texts: list[svg.Text] = []
         tl, tr, bl, br = SVGPlaquetteDrawer._CORNERS
+        if self._position in (
+            ExtendedPlaquettePosition.LEFT,
+            ExtendedPlaquettePosition.RIGHT,
+        ):
+            tl, tr, bl, br = (
+                ExtendedPlaquetteDrawer._transform_point(self._position, tl),
+                ExtendedPlaquetteDrawer._transform_point(self._position, tr),
+                ExtendedPlaquetteDrawer._transform_point(self._position, bl),
+                ExtendedPlaquetteDrawer._transform_point(self._position, br),
+            )
         s1, s2 = self._schedule
         data_corners: list[complex]
         schedules: list[int]
         match self._plaquette_type:
             case ExtendedPlaquetteType.BULK:
                 data_corners = (
-                    [tl, tr] if self._position == ExtendedPlaquettePosition.UP else [bl, br]
+                    [tl, tr]
+                    if ExtendedPlaquetteDrawer._is_first(self._position)
+                    else [bl, br]
                 )
                 schedules = [s1, s2]
             case ExtendedPlaquetteType.BOTTOM_RIGHT_TRIANGLE:
-                data_corners = [tr] if self._position == ExtendedPlaquettePosition.UP else [bl, br]
-                schedules = [s2] if self._position == ExtendedPlaquettePosition.UP else [s1, s2]
+                data_corners = (
+                    [tr] if ExtendedPlaquetteDrawer._is_first(self._position) else [bl, br]
+                )
+                schedules = (
+                    [s2] if ExtendedPlaquetteDrawer._is_first(self._position) else [s1, s2]
+                )
             case ExtendedPlaquetteType.TOP_LEFT_TRIANGLE:
-                data_corners = [tl, tr] if self._position == ExtendedPlaquettePosition.UP else [bl]
-                schedules = [s1, s2] if self._position == ExtendedPlaquettePosition.UP else [s1]
+                data_corners = (
+                    [tl, tr] if ExtendedPlaquetteDrawer._is_first(self._position) else [bl]
+                )
+                schedules = (
+                    [s1, s2]
+                    if ExtendedPlaquetteDrawer._is_first(self._position)
+                    else [s1]
+                )
             case ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE:
-                data_corners = [tl] if self._position == ExtendedPlaquettePosition.UP else [bl, br]
-                schedules = [s1] if self._position == ExtendedPlaquettePosition.UP else [s1, s2]
+                data_corners = (
+                    [tl] if ExtendedPlaquetteDrawer._is_first(self._position) else [bl, br]
+                )
+                schedules = (
+                    [s1] if ExtendedPlaquetteDrawer._is_first(self._position) else [s1, s2]
+                )
             case ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE:
-                data_corners = [tl, tr] if self._position == ExtendedPlaquettePosition.UP else [br]
-                schedules = [s1, s2] if self._position == ExtendedPlaquettePosition.UP else [s2]
+                data_corners = (
+                    [tl, tr] if ExtendedPlaquetteDrawer._is_first(self._position) else [br]
+                )
+                schedules = (
+                    [s1, s2]
+                    if ExtendedPlaquetteDrawer._is_first(self._position)
+                    else [s2]
+                )
             case ExtendedPlaquetteType.RIGHT_HALF_RECTANGLE:
-                data_corners = [tr] if self._position == ExtendedPlaquettePosition.UP else [br]
+                data_corners = (
+                    [tr] if ExtendedPlaquetteDrawer._is_first(self._position) else [br]
+                )
                 schedules = [s2]
             case ExtendedPlaquetteType.LEFT_HALF_RECTANGLE:
-                data_corners = [tl] if self._position == ExtendedPlaquettePosition.UP else [bl]
+                data_corners = (
+                    [tl] if ExtendedPlaquetteDrawer._is_first(self._position) else [bl]
+                )
                 schedules = [s1]
 
         for corner, schedule in zip(data_corners, schedules):
@@ -316,31 +404,45 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
         if (
             (
                 self._plaquette_type == ExtendedPlaquetteType.BOTTOM_RIGHT_TRIANGLE
-                and self._position == ExtendedPlaquettePosition.UP
+                and ExtendedPlaquetteDrawer._is_first(self._position)
             )
             or (
                 self._plaquette_type == ExtendedPlaquetteType.TOP_LEFT_TRIANGLE
-                and self._position == ExtendedPlaquettePosition.DOWN
+                and not ExtendedPlaquetteDrawer._is_first(self._position)
             )
             or (
                 self._plaquette_type == ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE
-                and self._position == ExtendedPlaquettePosition.UP
+                and ExtendedPlaquetteDrawer._is_first(self._position)
             )
             or (
                 self._plaquette_type == ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE
-                and self._position == ExtendedPlaquettePosition.DOWN
+                and not ExtendedPlaquetteDrawer._is_first(self._position)
             )
         ):
             return None
 
         if (
             self._plaquette_type == ExtendedPlaquetteType.BULK
-            and self._position == ExtendedPlaquettePosition.UP
+            and ExtendedPlaquetteDrawer._is_first(self._position)
         ):
             return None
 
         tl, tr, bl, br = SVGPlaquetteDrawer._CORNERS
-        c1, c2 = (tl, tr) if self._position == ExtendedPlaquettePosition.UP else (bl, br)
+        if self._position in (
+            ExtendedPlaquettePosition.LEFT,
+            ExtendedPlaquettePosition.RIGHT,
+        ):
+            tl, tr, bl, br = (
+                ExtendedPlaquetteDrawer._transform_point(self._position, tl),
+                ExtendedPlaquetteDrawer._transform_point(self._position, tr),
+                ExtendedPlaquetteDrawer._transform_point(self._position, bl),
+                ExtendedPlaquetteDrawer._transform_point(self._position, br),
+            )
+        c1, c2 = (
+            (tl, tr)
+            if ExtendedPlaquetteDrawer._is_first(self._position)
+            else (bl, br)
+        )
         f = configuration.hook_error_line_lerp_coefficient
         a = lerp(SVGPlaquetteDrawer._CENTER_COORDINATE, c1, f)
         b = lerp(SVGPlaquetteDrawer._CENTER_COORDINATE, c2, f)
@@ -377,48 +479,55 @@ class ExtendedPlaquetteDrawer(SVGPlaquetteDrawer):
             case ExtendedPlaquetteType.BULK:
                 places = (
                     [PlaquetteCorner.TOP_LEFT, PlaquetteCorner.TOP_RIGHT]
-                    if self._position == ExtendedPlaquettePosition.UP
+                    if ExtendedPlaquetteDrawer._is_first(self._position)
                     else [PlaquetteCorner.BOTTOM_LEFT, PlaquetteCorner.BOTTOM_RIGHT]
                 )
             case ExtendedPlaquetteType.BOTTOM_RIGHT_TRIANGLE:
                 places = (
                     [PlaquetteCorner.TOP_RIGHT]
-                    if self._position == ExtendedPlaquettePosition.UP
+                    if ExtendedPlaquetteDrawer._is_first(self._position)
                     else [PlaquetteCorner.BOTTOM_LEFT, PlaquetteCorner.BOTTOM_RIGHT]
                 )
             case ExtendedPlaquetteType.TOP_LEFT_TRIANGLE:
                 places = (
                     [PlaquetteCorner.TOP_LEFT, PlaquetteCorner.TOP_RIGHT]
-                    if self._position == ExtendedPlaquettePosition.UP
+                    if ExtendedPlaquetteDrawer._is_first(self._position)
                     else [PlaquetteCorner.BOTTOM_LEFT]
                 )
             case ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE:
                 places = (
                     [PlaquetteCorner.TOP_LEFT]
-                    if self._position == ExtendedPlaquettePosition.UP
+                    if ExtendedPlaquetteDrawer._is_first(self._position)
                     else [PlaquetteCorner.BOTTOM_LEFT, PlaquetteCorner.BOTTOM_RIGHT]
                 )
             case ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE:
                 places = (
                     [PlaquetteCorner.TOP_LEFT, PlaquetteCorner.TOP_RIGHT]
-                    if self._position == ExtendedPlaquettePosition.UP
+                    if ExtendedPlaquetteDrawer._is_first(self._position)
                     else [PlaquetteCorner.BOTTOM_RIGHT]
                 )
             case ExtendedPlaquetteType.RIGHT_HALF_RECTANGLE:
                 places = (
                     [PlaquetteCorner.TOP_RIGHT]
-                    if self._position == ExtendedPlaquettePosition.UP
+                    if ExtendedPlaquetteDrawer._is_first(self._position)
                     else [PlaquetteCorner.BOTTOM_RIGHT]
                 )
             case ExtendedPlaquetteType.LEFT_HALF_RECTANGLE:
                 places = (
                     [PlaquetteCorner.TOP_LEFT]
-                    if self._position == ExtendedPlaquettePosition.UP
+                    if ExtendedPlaquetteDrawer._is_first(self._position)
                     else [PlaquetteCorner.BOTTOM_LEFT]
                 )
         reset_measurement_svgs: list[svg.Element] = []
         for place in places:
             corner_coords = self.get_corner_coordinates(place)
+            if self._position in (
+                ExtendedPlaquettePosition.LEFT,
+                ExtendedPlaquettePosition.RIGHT,
+            ):
+                corner_coords = ExtendedPlaquetteDrawer._transform_point(
+                    self._position, corner_coords
+                )
             reset_measurement_svgs.append(
                 svg.G(
                     elements=[

--- a/tests/compile/specs/library/generators/extended_stabilizers_test.py
+++ b/tests/compile/specs/library/generators/extended_stabilizers_test.py
@@ -16,7 +16,7 @@ from tqec.compile.specs.library.generators.extended_stabilizers import (
 from tqec.plaquette.debug import DrawPolygon, PlaquetteDebugInformation
 from tqec.plaquette.plaquette import Plaquettes
 from tqec.plaquette.rpng.rpng import PauliBasis, RPNGDescription
-from tqec.utils.enums import Basis
+from tqec.utils.enums import Basis, Orientation
 from tqec.utils.exceptions import TQECError
 from tqec.utils.frozendefaultdict import FrozenDefaultDict
 from tqec.utils.position import Shift2D
@@ -243,7 +243,7 @@ def test_horizontal_extended_plaquette_collection_positions(
         reset=None,
         measurement=None,
         is_reversed=is_reversed,
-        orientation="LEFT_RIGHT",
+        orientation=Orientation.HORIZONTAL,
     )
     for name in [
         "bulk",

--- a/tests/compile/specs/library/generators/extended_stabilizers_test.py
+++ b/tests/compile/specs/library/generators/extended_stabilizers_test.py
@@ -3,6 +3,7 @@ import pytest
 import stim
 import svg
 
+from tqec.circuit.qubit import GridQubit
 from tqec.compile.generation import generate_circuit_from_instantiation
 from tqec.compile.specs.library.generators.constants import EXTENDED_PLAQUETTE_SCHEDULES
 from tqec.compile.specs.library.generators.extended_stabilizers import (
@@ -10,6 +11,7 @@ from tqec.compile.specs.library.generators.extended_stabilizers import (
     ExtendedPlaquetteCollection,
     _with_extended_plaquette_drawer,
     get_extended_plaquette,
+    get_horizontal_extended_plaquette,
 )
 from tqec.plaquette.debug import DrawPolygon, PlaquetteDebugInformation
 from tqec.plaquette.plaquette import Plaquettes
@@ -171,3 +173,164 @@ def test_extended_plaquettes_have_svg_drawers(
         assert drawer._plaquette_type is expected_type
         assert drawer._position is position
         assert drawer.draw("extended-plaquette")
+
+
+def _shape_lines(
+    shape: svg.G,
+) -> set[tuple[float, float, float, float]]:
+    lines: set[tuple[float, float, float, float]] = set()
+    for element in shape.elements:
+        if isinstance(element, svg.Line):
+            lines.add(
+                (
+                    round(float(element.x1), 10),
+                    round(float(element.y1), 10),
+                    round(float(element.x2), 10),
+                    round(float(element.y2), 10),
+                )
+            )
+    return lines
+
+
+@pytest.mark.parametrize(
+    "basis,is_reversed",
+    [(Basis.X, False), (Basis.Z, False), (Basis.X, True), (Basis.Z, True)],
+)
+def test_horizontal_extended_plaquette(basis: Basis, is_reversed: bool) -> None:
+    left, right = get_horizontal_extended_plaquette(
+        RPNGDescription.from_basis_and_schedule(basis, EXTENDED_PLAQUETTE_SCHEDULES[is_reversed]),
+        is_reversed=is_reversed,
+    )
+    # Horizontal plaquettes must be laid out along the x axis so that the
+    # data qubits of the two plaquettes do not overlap.
+    scheduled_circuit = generate_circuit_from_instantiation(
+        numpy.array([[1, 2]]),
+        Plaquettes(FrozenDefaultDict({1: left, 2: right})),
+        increments=Shift2D(2, 2),
+    )
+    circuit = scheduled_circuit.get_circuit()
+    b = basis.value.upper() if basis is not None else "_"
+    # Horizontal layouts give qubits 0, 1 (data, LEFT), 2 (syndrome, LEFT),
+    # 3 (shared syndrome), 4 (syndrome, RIGHT), 5, 6 (data, RIGHT). The
+    # stabilizer flow is the joint product of the four data qubits, and is
+    # independent of the reversal of the schedules.
+    assert circuit.has_flow(stim.Flow(f"1 -> {b}{b}___{b}{b} xor rec[0]"))
+    assert circuit.has_flow(stim.Flow(f"{b}{b}___{b}{b} -> rec[0]"))
+
+
+def test_horizontal_plaquette_qubit_layouts() -> None:
+    description = RPNGDescription.from_basis_and_schedule(
+        Basis.X, EXTENDED_PLAQUETTE_SCHEDULES[False]
+    )
+    left, right = get_horizontal_extended_plaquette(description, is_reversed=False)
+
+    def data_coordinates(plaquette) -> set[GridQubit]:
+        index_to_qubit = {i: q for q, i in plaquette.qubits.qubit_map.q2i.items()}
+        return {index_to_qubit[i] for i in tuple(plaquette.qubits.data_qubits_indices)}
+
+    assert data_coordinates(left) == {GridQubit(-1, -1), GridQubit(-1, 1)}
+    assert data_coordinates(right) == {GridQubit(1, -1), GridQubit(1, 1)}
+    assert GridQubit(0, 0) in left.qubits.qubit_map.q2i
+    assert GridQubit(0, 0) in right.qubits.qubit_map.q2i
+
+
+@pytest.mark.parametrize("is_reversed", [False, True])
+def test_horizontal_extended_plaquette_collection_positions(
+    is_reversed: bool,
+) -> None:
+    collection = ExtendedPlaquetteCollection.from_basis(
+        Basis.X,
+        reset=None,
+        measurement=None,
+        is_reversed=is_reversed,
+        orientation="LEFT_RIGHT",
+    )
+    for name in [
+        "bulk",
+        "bottom_right_triangle",
+        "right_half_rectangle",
+        "top_left_triangle",
+        "left_half_rectangle",
+        "bottom_left_triangle",
+        "top_right_triangle",
+    ]:
+        plaquette = getattr(collection, name)
+        assert (
+            plaquette.top.debug_information.drawer._position
+            is ExtendedPlaquettePosition.LEFT
+        )
+        assert (
+            plaquette.bottom.debug_information.drawer._position
+            is ExtendedPlaquettePosition.RIGHT
+        )
+        # Drawing must not raise for horizontal positions.
+        plaquette.top.debug_information.drawer.draw("extended-plaquette")
+        plaquette.bottom.debug_information.drawer.draw("extended-plaquette")
+
+
+@pytest.mark.parametrize(
+    "plaquette_type",
+    [
+        ExtendedPlaquetteType.BULK,
+        ExtendedPlaquetteType.RIGHT_HALF_RECTANGLE,
+        ExtendedPlaquetteType.LEFT_HALF_RECTANGLE,
+    ],
+)
+def test_horizontal_square_shapes_are_transposed_vertical_ones(
+    plaquette_type: ExtendedPlaquetteType,
+) -> None:
+    up = ExtendedPlaquetteDrawer._get_extended_plaquette_square_shape(
+        ExtendedPlaquettePosition.UP, plaquette_type
+    )
+    down = ExtendedPlaquetteDrawer._get_extended_plaquette_square_shape(
+        ExtendedPlaquettePosition.DOWN, plaquette_type
+    )
+    left = ExtendedPlaquetteDrawer._get_extended_plaquette_square_shape(
+        ExtendedPlaquettePosition.LEFT, plaquette_type
+    )
+    right = ExtendedPlaquetteDrawer._get_extended_plaquette_square_shape(
+        ExtendedPlaquettePosition.RIGHT, plaquette_type
+    )
+
+    # Transposition T(x, y) = (y / 2, 2x) maps the vertical layout onto the
+    # horizontal one, keeping the drawing domain unchanged.
+    def transpose(
+        lines: set[tuple[float, float, float, float]],
+    ) -> set[tuple[float, float, float, float]]:
+        return {(y1 / 2, 2 * x1, y2 / 2, 2 * x2) for x1, y1, x2, y2 in lines}
+
+    assert _shape_lines(left) == transpose(_shape_lines(up))
+    assert _shape_lines(right) == transpose(_shape_lines(down))
+
+
+@pytest.mark.parametrize(
+    "plaquette_type",
+    [
+        ExtendedPlaquetteType.BOTTOM_RIGHT_TRIANGLE,
+        ExtendedPlaquetteType.BOTTOM_LEFT_TRIANGLE,
+        ExtendedPlaquetteType.TOP_LEFT_TRIANGLE,
+        ExtendedPlaquetteType.TOP_RIGHT_TRIANGLE,
+    ],
+)
+def test_horizontal_weight_three_shapes_are_transposed_vertical_ones(
+    plaquette_type: ExtendedPlaquetteType,
+) -> None:
+    up = ExtendedPlaquetteDrawer._get_weight_three_extended_plaquette_shape(
+        ExtendedPlaquettePosition.UP, plaquette_type
+    )
+    left = ExtendedPlaquetteDrawer._get_weight_three_extended_plaquette_shape(
+        ExtendedPlaquettePosition.LEFT, plaquette_type
+    )
+    # UP and LEFT share the same "first" slot: the triangle is only drawn on
+    # the data-qubit side, and the LEFT version is the transposed UP one.
+    assert _path_points(left) == {
+        (y / 2, 2 * x) for x, y in _path_points(up)
+    }
+
+
+def test_horizontal_weight_three_shape_empty_on_right() -> None:
+    shape = ExtendedPlaquetteDrawer._get_weight_three_extended_plaquette_shape(
+        ExtendedPlaquettePosition.RIGHT, ExtendedPlaquetteType.BOTTOM_RIGHT_TRIANGLE
+    )
+    assert isinstance(shape, svg.G)
+    assert not shape.elements


### PR DESCRIPTION
> **Re-submitted.** This supersedes #1029, which GitHub permanently closed when its source fork was deleted — a pull request cannot be reopened once its head repository is gone.
> Branch and commit are identical to the original.

## Summary

Implements **horizontal extended stabilisers** (LEFT/RIGHT), completing the existing vertical UP/DOWN support. This is the primitive needed for the x-direction spatial Hadamard gates in #838, as discussed in #839.

## Changes

- `ExtendedPlaquettePosition` gains `LEFT` / `RIGHT` (with `flip()` support)
- `ExtendedPlaquetteDrawer` transposes the vertical geometry inside the drawing domain (T(x, y) = (y/2, 2x)) for horizontal positions: square shapes, weight-three triangles, interaction-order texts, hook-error lines, reset/measurement layers
- `get_horizontal_extended_plaquette` builds the (LEFT, RIGHT) pair from the left/right columns of the RPNG description
- `ExtendedPlaquetteCollection.from_description` / `from_basis` accept `orientation="UP_DOWN" | "LEFT_RIGHT"` (default unchanged, backward compatible)
- 15 new tests — 47 total, all green

## Layout

```
UP (vertical, data on top)         LEFT (horizontal, data on left)
  dl ---- dr                         dl ---- s2
  |        |                         |        |
  |   s1   |                         |   s1   |
  |        |                         |        |
  s2 ---- s2                         dr ---- s2

DOWN (vertical, data on bottom)    RIGHT (horizontal, data on right)
  s2 ---- s2                         s2 ---- dl
  |        |                         |        |
  |   s1   |                         |   s1   |
  |        |                         |        |
  dl ---- dr                         s2 ---- dr
```

## Notable property

The horizontal stabilizer flow is **independent of `is_reversed`**: both directions yield `1 -> XX___XX xor rec[0]` (the 4 data-qubit X product), because the LEFT/RIGHT data-qubit groups each stay within their own column under the schedule flip. The vertical UP/DOWN flow, in contrast, permutes which syndrome qubit is measured. This makes x-direction scheduling structurally simpler than y-direction scheduling.

## Testing

- Stabilizer flows: X/Z bases x reversed/non-reversed x both flow directions (8 assertions)
- Qubit layouts: data-qubits on the left/right columns, shared s2 ancilla
- Drawer positions for all 7 plaquette types; drawing does not raise
- Transposed-geometry checks for square and weight-three shapes
- `ruff check` clean
